### PR TITLE
Pr ci improvements

### DIFF
--- a/e2e/quick-open.spec.js
+++ b/e2e/quick-open.spec.js
@@ -38,7 +38,11 @@ test('quick-open palette opens, filters, and closes on Escape', async ({ mainWin
 
     await mainWindow.evaluate(() => window.QuickOpen.show());
 
-    const overlay = mainWindow.locator('.palette-overlay');
+    // Target the QuickOpen overlay specifically — `.palette-overlay` is the
+    // shared backdrop class used by Setup-check / About / etc., and on first
+    // launch in CI the Setup-check dialog appears asynchronously and would
+    // otherwise pollute the count assertions below.
+    const overlay = mainWindow.locator('.quick-open-overlay');
     const input = overlay.locator('.palette-input');
     const items = overlay.locator('.quick-open-item');
 

--- a/main/ipc/claude-stream-ipc.js
+++ b/main/ipc/claude-stream-ipc.js
@@ -97,7 +97,13 @@ ipcMain.handle('pr-debug-check-start', (event, { requestId, checkLink, checkName
         annotationsBlock = `\n## Annotations (file:line hints from the check run)\n${top}\n`
           + (annos.length > 10 ? `\n[... ${annos.length - 10} more not shown ...]\n` : '');
       }
-    } catch (_) { /* annotations are best-effort; absence is normal */ }
+    } catch (err) {
+      // Best-effort enrichment — don't fail the whole debug call. But log so
+      // a sustained issue (token missing checks:read scope, persistent 5xx)
+      // is recoverable from main.log without a debugger.
+      console.error('[pr-debug-check-start] annotations fetch failed:',
+        ((err && (err.stderr || err.message)) || String(err)).toString().trim());
+    }
   }
 
   // Workflow YAML: read the matching workflow file from .github/workflows in
@@ -129,7 +135,12 @@ ipcMain.handle('pr-debug-check-start', (event, { requestId, checkLink, checkName
         workflowBlock = `\n## Workflow definition (\`.github/workflows/${best.file}\`)\n\`\`\`yaml\n${truncated}\n${best.text.split('\n').length > 200 ? '\n[... truncated ...]\n' : ''}\`\`\`\n`;
       }
     }
-  } catch (_) { /* best-effort */ }
+  } catch (err) {
+    // Best-effort enrichment — fs read or YAML match failed. Log so a
+    // permission issue on .github/workflows surfaces in main.log.
+    console.error('[pr-debug-check-start] workflow YAML lookup failed:',
+      ((err && err.message) || String(err)).toString().trim());
+  }
 
   const prompt =
     `A pull request has a failing CI check. Help diagnose it.\n\n`

--- a/main/ipc/claude-stream-ipc.js
+++ b/main/ipc/claude-stream-ipc.js
@@ -7,7 +7,7 @@
 const { ipcMain } = require('electron');
 const crypto = require('crypto');
 const { execFile, execFileSync } = require('child_process');
-const { instances } = require('../state/instances');
+const { instances, spawnInWorktree } = require('../state/instances');
 const { prReview, ensureWorktreeForActivePr, currentRepoPath } = require('../state/pr-review');
 const { execFileP } = require('../util/exec');
 const { loadConfig } = require('../util/config');
@@ -28,7 +28,7 @@ function shortHash(s) {
 // prompt with PR description + diff + log tail, and streams claude's analysis
 // back to the renderer. Same chunk/done event protocol as Explain so the
 // renderer can reuse the same UX.
-ipcMain.handle('pr-debug-check-start', (event, { requestId, checkLink, checkName }) => {
+ipcMain.handle('pr-debug-check-start', (event, { requestId, checkLink, checkName, checkRunId }) => {
   if (!requestId) return { error: 'Missing requestId' };
   if (debugCheckProcs.has(requestId)) return { error: 'Already debugging' };
   if (!prReview.active) return { error: 'No active PR review' };
@@ -46,22 +46,21 @@ ipcMain.handle('pr-debug-check-start', (event, { requestId, checkLink, checkName
   const cwd = currentRepoPath() || require('os').homedir();
   const sender = event.sender;
 
-  // Fetch logs. gh run view follows the 302-to-download redirect properly,
-  // unlike the bare `gh api .../jobs/{id}/logs` call which often surfaces
-  // as HTTP 404. Fall back to the api endpoint if `gh run view` fails (e.g.
-  // wrong repo, expired retention).
+  // Fetch logs. Prefer job-specific endpoint (tighter context = better diagnosis)
+  // and fall back to run-wide --log-failed only if the job endpoint fails.
+  // Both paths cap at 50 MB.
   let logs = '';
   try {
     logs = execFileSync('gh', [
-      'run', 'view', String(runId),
-      '-R', `${baseOwner}/${baseRepo}`,
-      '--log-failed',
-    ], { cwd, stdio: 'pipe', timeout: 30000, maxBuffer: 50 * 1024 * 1024 }).toString();
+      'api', `/repos/${baseOwner}/${baseRepo}/actions/jobs/${jobId}/logs`,
+    ], { cwd, stdio: 'pipe', timeout: 20000, maxBuffer: 50 * 1024 * 1024 }).toString();
   } catch (errA) {
     try {
       logs = execFileSync('gh', [
-        'api', `/repos/${baseOwner}/${baseRepo}/actions/jobs/${jobId}/logs`,
-      ], { cwd, stdio: 'pipe', timeout: 20000, maxBuffer: 50 * 1024 * 1024 }).toString();
+        'run', 'view', String(runId),
+        '-R', `${baseOwner}/${baseRepo}`,
+        '--log-failed',
+      ], { cwd, stdio: 'pipe', timeout: 30000, maxBuffer: 50 * 1024 * 1024 }).toString();
     } catch (errB) {
       const msg = (errA.stderr ? errA.stderr.toString().trim() : errA.message)
         || (errB.stderr ? errB.stderr.toString().trim() : errB.message);
@@ -77,11 +76,68 @@ ipcMain.handle('pr-debug-check-start', (event, { requestId, checkLink, checkName
   const diffSnippet = (diff || '').split('\n').slice(0, 600).join('\n')
     + ((diff || '').split('\n').length > 600 ? '\n\n[... diff truncated ...]\n' : '');
 
+  // Annotations: pre-localized fix hints from the check-run. When provided,
+  // these are dramatically better than scanning the log tail. We cap at 10
+  // entries so a noisy check (e.g. eslint with 200 errors) doesn't dominate.
+  let annotationsBlock = '';
+  if (checkRunId) {
+    try {
+      const annoRaw = execFileSync('gh', [
+        'api', `/repos/${baseOwner}/${baseRepo}/check-runs/${checkRunId}/annotations`,
+        '--paginate',
+      ], { cwd, stdio: 'pipe', timeout: 10000, maxBuffer: 4 * 1024 * 1024 }).toString();
+      const annos = JSON.parse(annoRaw);
+      if (Array.isArray(annos) && annos.length > 0) {
+        const top = annos.slice(0, 10).map((a) => {
+          const loc = (a.path ? a.path : '?')
+            + (a.start_line ? `:${a.start_line}` : '')
+            + (a.end_line && a.end_line !== a.start_line ? `-${a.end_line}` : '');
+          return `- [${a.annotation_level || 'notice'}] ${loc} — ${(a.title ? `**${a.title}** ` : '') + (a.message || '')}`.replace(/\n+/g, ' ');
+        }).join('\n');
+        annotationsBlock = `\n## Annotations (file:line hints from the check run)\n${top}\n`
+          + (annos.length > 10 ? `\n[... ${annos.length - 10} more not shown ...]\n` : '');
+      }
+    } catch (_) { /* annotations are best-effort; absence is normal */ }
+  }
+
+  // Workflow YAML: read the matching workflow file from .github/workflows in
+  // the local worktree. Match by `name:` field. Local copy may differ from
+  // the PR head's copy, but it's almost always close enough to explain what
+  // the failing step was supposed to do. Skip silently if no match.
+  let workflowBlock = '';
+  try {
+    const fs = require('fs');
+    const path = require('path');
+    const wfDir = path.join(cwd, '.github', 'workflows');
+    if (fs.existsSync(wfDir)) {
+      const files = fs.readdirSync(wfDir).filter((f) => /\.ya?ml$/i.test(f));
+      // Match by workflow name (read from --name in the source) against the
+      // failing check's app name + check name. Heuristic: read the file's
+      // `name:` line and compare against checkName.
+      const targetTokens = (checkName || '').toLowerCase().split(/[^a-z0-9]+/).filter(Boolean);
+      let best = null;
+      for (const f of files) {
+        const full = path.join(wfDir, f);
+        const text = fs.readFileSync(full, 'utf8');
+        const nameMatch = text.match(/^name\s*:\s*(.+)$/m);
+        const wfName = nameMatch ? nameMatch[1].replace(/['"]/g, '').trim().toLowerCase() : f.toLowerCase();
+        const score = targetTokens.reduce((acc, t) => acc + (wfName.includes(t) ? 1 : 0), 0);
+        if (!best || score > best.score) best = { score, file: f, text };
+      }
+      if (best && best.score > 0) {
+        const truncated = best.text.split('\n').slice(0, 200).join('\n');
+        workflowBlock = `\n## Workflow definition (\`.github/workflows/${best.file}\`)\n\`\`\`yaml\n${truncated}\n${best.text.split('\n').length > 200 ? '\n[... truncated ...]\n' : ''}\`\`\`\n`;
+      }
+    }
+  } catch (_) { /* best-effort */ }
+
   const prompt =
     `A pull request has a failing CI check. Help diagnose it.\n\n`
     + `## PR\n#${meta.number}: ${meta.title || ''}\n`
     + (meta.body ? `\n${meta.body.slice(0, 2000)}\n` : '')
     + `\n## Failing check\nName: ${checkName || '(unnamed)'}\nLink: ${checkLink}\n`
+    + annotationsBlock
+    + workflowBlock
     + `\n## Last lines of the failing job log\n\`\`\`\n${logTail}\n\`\`\`\n`
     + `\n## PR diff (truncated to 600 lines)\n\`\`\`\n${diffSnippet}\n\`\`\`\n`
     + `\nAnswer in this structure:\n`
@@ -113,6 +169,48 @@ ipcMain.handle('pr-debug-check-start', (event, { requestId, checkLink, checkName
 });
 
 ipcMain.handle('pr-debug-check-cancel', makeClaudeCancelHandler(debugCheckProcs));
+
+// Turn a finished debug analysis into a Claude task on the PR's worktree.
+// Materializes the worktree if needed, spawns a fresh claude instance, then
+// pastes the analysis as the first prompt so the user can ask "apply this fix"
+// without re-typing context.
+ipcMain.handle('pr-debug-check-open-task', async (_event, { analysis, checkName, prNumber }) => {
+  if (!prReview.active) return { error: 'No active PR review' };
+  const ensured = await ensureWorktreeForActivePr();
+  if (ensured.error) return { error: ensured.error };
+  const { worktreePath, branch } = ensured;
+  const taskName = ('Fix CI: ' + (checkName || 'check')).slice(0, 60);
+
+  // Try to reuse an existing alive Claude task on this worktree before spawning
+  // a new one — saves an extra terminal in the sidebar and matches what
+  // pr-fix-in-terminal already does.
+  let target = null;
+  for (const [, inst] of instances) {
+    if (inst.worktreePath === worktreePath && inst.alive && inst.mode === 'claude') { target = inst; break; }
+  }
+  if (!target) {
+    const result = spawnInWorktree(taskName, worktreePath, branch, 'claude', null, null, prNumber);
+    if (result && result.error) return { error: result.error };
+    target = instances.get(result.id);
+  }
+  if (!target || !target.pty) return { error: 'Failed to spawn task on worktree' };
+
+  const BP_START = '\x1b[200~';
+  const BP_END = '\x1b[201~';
+  const safeAnalysis = String(analysis || '').replace(/\x1b\[20[01]~/g, '');
+  const text = 'Help me fix this failing CI check. Below is an analysis produced from the failing job\'s annotations + log + the PR diff. Please propose and apply the fix in this worktree.\n\n'
+    + '---\n\n' + safeAnalysis + '\n\n---\n';
+
+  // Write after a short delay so claude has time to render its prompt; if we
+  // write too early the bracketed-paste markers land in the splash screen and
+  // claude treats them as garbage. 1500ms matches the cadence of other
+  // first-prompt writes elsewhere in the app.
+  setTimeout(() => {
+    try { target.pty.write(BP_START + text + BP_END); } catch (_) {}
+  }, 1500);
+
+  return { ok: true, taskId: target.id };
+});
 
 // K3: inline AI edit — streams a claude -p replacement for a selection.
 // Kept deliberately strict: the prompt tells claude to emit ONLY the

--- a/main/ipc/claude-stream-ipc.js
+++ b/main/ipc/claude-stream-ipc.js
@@ -205,8 +205,23 @@ ipcMain.handle('pr-debug-check-open-task', async (_event, { analysis, checkName,
   // write too early the bracketed-paste markers land in the splash screen and
   // claude treats them as garbage. 1500ms matches the cadence of other
   // first-prompt writes elsewhere in the app.
+  //
+  // The handler returns ok:true before this fires, so a silent write failure
+  // would leave the user with a blank task and no signal. Log + emit a paste-
+  // failed event so the renderer can flip the button state and the failure
+  // is recoverable from main.log.
   setTimeout(() => {
-    try { target.pty.write(BP_START + text + BP_END); } catch (_) {}
+    try {
+      target.pty.write(BP_START + text + BP_END);
+    } catch (err) {
+      const msg = (err && err.message) || String(err);
+      console.error('[pr-debug-check-open-task] pty.write failed:', msg);
+      if (event.sender && !event.sender.isDestroyed()) {
+        event.sender.send('pr-debug-check-open-task-paste-failed', {
+          taskId: target.id, error: msg,
+        });
+      }
+    }
   }, 1500);
 
   return { ok: true, taskId: target.id };

--- a/main/ipc/pr-review.js
+++ b/main/ipc/pr-review.js
@@ -536,12 +536,14 @@ ipcMain.handle('pr-review-check-annotations', async (_event, { checkRunId }) => 
     return { annotations: [], error: 'Missing repo or check id' };
   }
   const cwd = currentRepoPath() || require('os').homedir();
+  // Drop --paginate: the annotations endpoint returns a single JSON array
+  // (no Link header on the typical first-page-and-only-page response), and
+  // some gh versions exit non-zero when there's nothing to paginate.
+  const args = ['api', `repos/${baseOwner}/${baseRepo}/check-runs/${checkRunId}/annotations`];
   try {
-    const { stdout } = await execFileP(
-      'gh',
-      ['api', `repos/${baseOwner}/${baseRepo}/check-runs/${checkRunId}/annotations`, '--paginate'],
-      { cwd, maxBuffer: 4 * 1024 * 1024, timeout: 10000 },
-    );
+    const { stdout } = await execFileP('gh', args, {
+      cwd, maxBuffer: 4 * 1024 * 1024, timeout: 10000,
+    });
     const arr = JSON.parse(stdout);
     return {
       annotations: (Array.isArray(arr) ? arr : []).map((a) => ({
@@ -555,8 +557,30 @@ ipcMain.handle('pr-review-check-annotations', async (_event, { checkRunId }) => 
       })),
     };
   } catch (err) {
-    const raw = err.stderr ? err.stderr.toString() : err.message;
-    return { annotations: [], error: (raw || '').trim() };
+    // gh exits non-zero on 403 (token scope), 404 (no annotations / wrong id),
+    // and on plain network failures. Surface the *useful* part of stderr —
+    // err.stderr usually has the actual gh message; err.message tends to be
+    // "Command failed: gh api … — exit code 1" which tells the user nothing.
+    const stderr = err.stderr ? err.stderr.toString().trim() : '';
+    const message = err.message || '';
+    console.error('[pr-review-check-annotations] gh failed:',
+      'cmd=', 'gh ' + args.join(' '),
+      'stderr=', stderr || '(empty)',
+      'message=', message);
+    let userMsg = stderr || message || 'Annotations fetch failed';
+    if (/HTTP 404|Not Found/i.test(userMsg)) {
+      // 404 on this endpoint means "no annotations on this check-run."
+      // Treat as empty rather than an error — common, not a problem.
+      return { annotations: [] };
+    }
+    if (/HTTP 403/i.test(userMsg)) {
+      userMsg = 'Permission denied — token may need the `checks:read` scope. ('
+        + userMsg.replace(/\s+/g, ' ').slice(0, 200) + ')';
+    } else if (/exit (status |code )?1/i.test(userMsg) && !stderr) {
+      userMsg = 'gh exited with code 1 (no stderr). Try running this manually:\n'
+        + '  gh ' + args.join(' ');
+    }
+    return { annotations: [], error: userMsg };
   }
 });
 

--- a/main/ipc/pr-review.js
+++ b/main/ipc/pr-review.js
@@ -237,6 +237,268 @@ ipcMain.handle('pr-review-checks', async () => {
   return { checks };
 });
 
+// Returns the list of required status-check contexts on the PR's base branch,
+// for the "X/Y required passing" gate. A 404 from the protection endpoint just
+// means no protection rules — return an empty list rather than an error.
+async function fetchRequiredContexts(cwd, baseOwner, baseRepo, baseBranch) {
+  if (!baseOwner || !baseRepo || !baseBranch) return { required: [] };
+  return new Promise((resolve) => {
+    execFile(
+      'gh',
+      ['api', `repos/${baseOwner}/${baseRepo}/branches/${baseBranch}/protection/required_status_checks`],
+      { cwd, maxBuffer: 4 * 1024 * 1024, timeout: 12000 },
+      (err, stdout, stderr) => {
+        if (err) {
+          const raw = (stderr || err.message || '').toString();
+          // 404 = no protection or branch not protected. Not an error from the user's POV.
+          if (/404|Not Found|HTTP 404/i.test(raw) || /Branch not protected/i.test(raw)) {
+            return resolve({ required: [] });
+          }
+          return resolve({ required: [], error: raw.trim() });
+        }
+        try {
+          const parsed = JSON.parse(stdout);
+          resolve({ required: parsed.contexts || [] });
+        } catch (_) {
+          resolve({ required: [] });
+        }
+      },
+    );
+  });
+}
+
+ipcMain.handle('pr-review-required-checks', async () => {
+  if (!prReview.active) return { required: [] };
+  const { meta, baseOwner, baseRepo } = prReview.active;
+  const baseBranch = meta && meta.baseRefName;
+  const cwd = currentRepoPath() || require('os').homedir();
+  return fetchRequiredContexts(cwd, baseOwner, baseRepo, baseBranch);
+});
+
+ipcMain.handle('pr-required-checks', async (_event, { worktreePath, prNumber }) => {
+  try {
+    const meta = JSON.parse(ghExec(
+      ['pr', 'view', String(prNumber), '--json', 'baseRefName'],
+      { cwd: worktreePath, stdio: 'pipe', timeout: 10000 },
+    ).toString());
+    const repoResult = JSON.parse(ghExec(
+      ['repo', 'view', '--json', 'nameWithOwner'],
+      { cwd: worktreePath, stdio: 'pipe', timeout: 10000 },
+    ).toString());
+    const [baseOwner, baseRepo] = (repoResult.nameWithOwner || '').split('/');
+    return fetchRequiredContexts(worktreePath, baseOwner, baseRepo, meta.baseRefName);
+  } catch (err) {
+    return { required: [], error: err.stderr ? err.stderr.toString() : err.message };
+  }
+});
+
+// Rerun all failed jobs in a workflow run. Maps to `gh run rerun --failed`.
+ipcMain.handle('pr-review-run-rerun-failed', async (_event, { runId }) => {
+  if (!prReview.active) return { error: 'No active PR review' };
+  const { baseOwner, baseRepo } = prReview.active;
+  if (!runId) return { error: 'Missing runId' };
+  const cwd = currentRepoPath() || require('os').homedir();
+  try {
+    ghExec(['run', 'rerun', String(runId), '--failed', '-R', `${baseOwner}/${baseRepo}`], {
+      cwd, stdio: 'pipe', timeout: 30000,
+    });
+    return { ok: true };
+  } catch (err) {
+    return { error: err.stderr ? err.stderr.toString() : err.message };
+  }
+});
+
+// List active workflows on the base repo for manual dispatch. Filters to
+// state=active so disabled workflows don't show up in the picker.
+ipcMain.handle('pr-review-workflows-list', async () => {
+  if (!prReview.active) return { workflows: [] };
+  const { baseOwner, baseRepo } = prReview.active;
+  if (!baseOwner || !baseRepo) return { workflows: [], error: 'Could not determine base repo' };
+  const cwd = currentRepoPath() || require('os').homedir();
+  try {
+    const { stdout } = await execFileP(
+      'gh', ['api', `repos/${baseOwner}/${baseRepo}/actions/workflows`, '--paginate'],
+      { cwd, maxBuffer: 4 * 1024 * 1024, timeout: 15000 },
+    );
+    const parsed = JSON.parse(stdout);
+    const list = (parsed.workflows || []).filter((w) => w.state === 'active').map((w) => ({
+      id: w.id, name: w.name, path: w.path, state: w.state,
+    }));
+    return { workflows: list };
+  } catch (err) {
+    return { workflows: [], error: err.stderr ? err.stderr.toString() : err.message };
+  }
+});
+
+// Manually dispatch a workflow_dispatch-eligible workflow. `inputs` is a JSON
+// object of string values keyed by the input names the workflow declares.
+// GitHub returns 422 if the workflow doesn't have workflow_dispatch enabled
+// or if required inputs are missing.
+ipcMain.handle('pr-review-workflow-dispatch', async (_event, { workflowId, ref, inputs }) => {
+  if (!prReview.active) return { error: 'No active PR review' };
+  const { baseOwner, baseRepo, meta } = prReview.active;
+  if (!workflowId) return { error: 'Missing workflowId' };
+  const useRef = (ref && ref.trim()) || (meta && meta.headRefName) || '';
+  if (!useRef) return { error: 'Missing ref' };
+  const cwd = currentRepoPath() || require('os').homedir();
+
+  // gh api -X POST with `--input -` reads a JSON body from stdin. We build
+  // the body ourselves so input types beyond strings (numbers/booleans) round-trip
+  // correctly even though GitHub coerces everything to strings on the workflow side.
+  const body = JSON.stringify({ ref: useRef, inputs: inputs || {} });
+  return new Promise((resolve) => {
+    const child = execFile(
+      'gh', ['api', '-X', 'POST',
+        `repos/${baseOwner}/${baseRepo}/actions/workflows/${workflowId}/dispatches`,
+        '--input', '-'],
+      { cwd, timeout: 15000 },
+      (err, stdout, stderr) => {
+        if (err) return resolve({ error: (stderr || err.message || '').toString().trim() });
+        resolve({ ok: true });
+      },
+    );
+    child.stdin.write(body);
+    child.stdin.end();
+  });
+});
+
+// In-progress workflow run log tail. Polls `gh run view --log` every 3s and
+// emits deltas to the renderer. Stops when the run completes, the log exceeds
+// 10 MB, or the renderer explicitly stops the watcher. Tier-2 feature — the
+// full log is re-downloaded each tick because there's no incremental endpoint.
+const watchedRunLogs = new Map(); // requestId -> { stop }
+
+ipcMain.handle('pr-review-run-log-watch-start', async (event, { requestId, runId }) => {
+  if (!requestId || !runId) return { error: 'Missing requestId or runId' };
+  if (watchedRunLogs.has(requestId)) return { error: 'Already watching this requestId' };
+  if (!prReview.active) return { error: 'No active PR review' };
+  const { baseOwner, baseRepo } = prReview.active;
+  const cwd = currentRepoPath() || require('os').homedir();
+  const sender = event.sender;
+
+  let lastLen = 0;
+  let stopped = false;
+  let timer = null;
+
+  function stop() {
+    stopped = true;
+    if (timer) { clearTimeout(timer); timer = null; }
+    watchedRunLogs.delete(requestId);
+  }
+
+  async function tick() {
+    if (stopped) return;
+    try {
+      const { stdout } = await execFileP(
+        'gh', ['run', 'view', String(runId), '-R', `${baseOwner}/${baseRepo}`, '--log'],
+        { cwd, maxBuffer: 12 * 1024 * 1024, timeout: 15000 },
+      );
+      if (stopped) return;
+      const text = String(stdout || '');
+      if (text.length > 10 * 1024 * 1024) {
+        sender.send(`pr-review-run-log-done-${requestId}`, {
+          truncated: true,
+          message: 'Log exceeded 10 MB; stopped tailing.',
+        });
+        stop();
+        return;
+      }
+      if (text.length > lastLen) {
+        const delta = text.slice(lastLen);
+        lastLen = text.length;
+        if (!sender.isDestroyed()) {
+          sender.send(`pr-review-run-log-chunk-${requestId}`, delta);
+        }
+      }
+    } catch (_) { /* not started or transient — retry next tick */ }
+
+    if (stopped) return;
+    // Poll status separately so a still-fetching log doesn't keep the watcher
+    // alive past completion.
+    try {
+      const { stdout: statusOut } = await execFileP(
+        'gh', ['run', 'view', String(runId), '-R', `${baseOwner}/${baseRepo}`,
+          '--json', 'status,conclusion'],
+        { cwd, timeout: 8000 },
+      );
+      const meta = JSON.parse(statusOut);
+      if (meta.status === 'completed') {
+        if (!sender.isDestroyed()) {
+          sender.send(`pr-review-run-log-done-${requestId}`, {
+            status: meta.status, conclusion: meta.conclusion,
+          });
+        }
+        stop();
+        return;
+      }
+    } catch (_) {}
+
+    if (stopped) return;
+    timer = setTimeout(tick, 3000);
+  }
+
+  watchedRunLogs.set(requestId, { stop });
+  tick();
+  return { ok: true };
+});
+
+ipcMain.handle('pr-review-run-log-watch-stop', (_event, { requestId }) => {
+  const w = watchedRunLogs.get(requestId);
+  if (!w) return { ok: true };
+  w.stop();
+  return { ok: true };
+});
+
+// Cancel an in-progress workflow run. Maps to `gh run cancel`.
+ipcMain.handle('pr-review-run-cancel', async (_event, { runId }) => {
+  if (!prReview.active) return { error: 'No active PR review' };
+  const { baseOwner, baseRepo } = prReview.active;
+  if (!runId) return { error: 'Missing runId' };
+  const cwd = currentRepoPath() || require('os').homedir();
+  try {
+    ghExec(['run', 'cancel', String(runId), '-R', `${baseOwner}/${baseRepo}`], {
+      cwd, stdio: 'pipe', timeout: 30000,
+    });
+    return { ok: true };
+  } catch (err) {
+    return { error: err.stderr ? err.stderr.toString() : err.message };
+  }
+});
+
+// Lazy fetch of check-run annotations for a single failing check. Renderer
+// calls this when the user expands a failing row, so we don't pay N round-trips
+// on every Checks-tab open.
+ipcMain.handle('pr-review-check-annotations', async (_event, { checkRunId }) => {
+  if (!prReview.active) return { annotations: [] };
+  const { baseOwner, baseRepo } = prReview.active;
+  if (!baseOwner || !baseRepo || !checkRunId) {
+    return { annotations: [], error: 'Missing repo or check id' };
+  }
+  const cwd = currentRepoPath() || require('os').homedir();
+  try {
+    const { stdout } = await execFileP(
+      'gh',
+      ['api', `repos/${baseOwner}/${baseRepo}/check-runs/${checkRunId}/annotations`, '--paginate'],
+      { cwd, maxBuffer: 4 * 1024 * 1024, timeout: 10000 },
+    );
+    const arr = JSON.parse(stdout);
+    return {
+      annotations: (Array.isArray(arr) ? arr : []).map((a) => ({
+        path: a.path || '',
+        startLine: a.start_line || null,
+        endLine: a.end_line || null,
+        level: a.annotation_level || 'notice',
+        title: a.title || '',
+        message: a.message || '',
+        rawDetails: a.raw_details || '',
+      })),
+    };
+  } catch (err) {
+    const raw = err.stderr ? err.stderr.toString() : err.message;
+    return { annotations: [], error: (raw || '').trim() };
+  }
+});
+
 function bucketFromState(rawState) {
   const s = (rawState || '').toLowerCase();
   if (s === 'success' || s === 'neutral') return 'pass';
@@ -248,27 +510,44 @@ function bucketFromState(rawState) {
 }
 
 function normalizeCheckRun(r) {
-  // GitHub REST check-run: { name, status, conclusion, details_url, output: {...}, app: { name }, ... }
+  // GitHub REST check-run: { id, name, status, conclusion, details_url, output: {...}, app: { name, slug }, started_at, completed_at, ... }
   const rawState = (r.conclusion || r.status || '').toLowerCase();
+  const link = r.details_url || r.html_url || '';
+  // GitHub job links look like https://github.com/<o>/<r>/actions/runs/<runId>/job/<jobId>
+  const m = link.match(/\/actions\/runs\/(\d+)\/job\/(\d+)/);
   return {
+    id: r.id || null,                                   // check-run id (for annotations endpoint)
     name: r.name || '(unnamed)',
     state: rawState,
     bucket: bucketFromState(rawState),
-    link: r.details_url || r.html_url || '',
+    link,
     workflow: (r.app && r.app.name) || '',
+    appSlug: (r.app && r.app.slug) || '',               // 'github-actions' vs third-party
     description: (r.output && r.output.title) || '',
+    summary: (r.output && r.output.summary) || '',      // longer text shown in failing-row expand
+    runId: m ? m[1] : null,
+    jobId: m ? m[2] : null,
+    startedAt: r.started_at || null,
+    completedAt: r.completed_at || null,
   };
 }
 
 function normalizeStatus(s) {
-  // Legacy REST status: { context, state, target_url, description, ... }
+  // Legacy REST status: { context, state, target_url, description, created_at, updated_at, ... }
   return {
+    id: null,
     name: s.context || '(unnamed)',
     state: (s.state || '').toLowerCase(),
     bucket: bucketFromState(s.state),
     link: s.target_url || '',
     workflow: '',
+    appSlug: '',
     description: s.description || '',
+    summary: '',
+    runId: null,
+    jobId: null,
+    startedAt: s.created_at || null,
+    completedAt: s.updated_at || null,
   };
 }
 
@@ -894,23 +1173,58 @@ ipcMain.handle('pr-merge', async (_event, { worktreePath, prNumber, strategy }) 
 });
 
 ipcMain.handle('pr-checks', async (_event, { worktreePath, prNumber }) => {
+  // Use `gh api` rather than `gh pr checks` so the renderer gets the full
+  // check-run shape (id, runId, jobId, started_at, completed_at, output.summary,
+  // app.slug). `gh pr checks` is pre-normalized and drops everything we need
+  // for the required-checks gate, per-job grouping, and annotations features.
   try {
-    const out = ghExec(
-      ['pr', 'checks', String(prNumber), '--json', 'name,state,bucket,link,workflow,description'],
+    const meta = JSON.parse(ghExec(
+      ['pr', 'view', String(prNumber), '--json', 'baseRefName,headRefOid,headRepository,headRepositoryOwner'],
       { cwd: worktreePath, stdio: 'pipe', timeout: 15000 }
-    ).toString();
-    return { checks: JSON.parse(out) };
+    ).toString());
+    // Base repo, not head: checks live on the base repo for fork PRs.
+    const repoResult = JSON.parse(ghExec(
+      ['repo', 'view', '--json', 'nameWithOwner'],
+      { cwd: worktreePath, stdio: 'pipe', timeout: 10000 },
+    ).toString());
+    const [baseOwner, baseRepo] = (repoResult.nameWithOwner || '').split('/');
+    const sha = meta.headRefOid;
+    if (!baseOwner || !baseRepo || !sha) return { checks: [], error: 'Could not resolve base repo or head sha' };
+
+    function run(args) {
+      return new Promise((resolve) => {
+        execFile('gh', ['api'].concat(args), { cwd: worktreePath, maxBuffer: 10 * 1024 * 1024, timeout: 15000 },
+          (err, stdout, stderr) => resolve({ err, stdout, stderr }));
+      });
+    }
+    const [runsRes, statusRes] = await Promise.all([
+      run([`repos/${baseOwner}/${baseRepo}/commits/${sha}/check-runs`, '--paginate']),
+      run([`repos/${baseOwner}/${baseRepo}/commits/${sha}/status`]),
+    ]);
+
+    const checks = [];
+    if (!runsRes.err) {
+      try {
+        const parsed = JSON.parse(runsRes.stdout);
+        (parsed.check_runs || []).forEach((r) => checks.push(normalizeCheckRun(r)));
+      } catch (_) {}
+    }
+    if (!statusRes.err) {
+      try {
+        const parsed = JSON.parse(statusRes.stdout);
+        (parsed.statuses || []).forEach((s) => checks.push(normalizeStatus(s)));
+      } catch (_) {}
+    }
+    if (checks.length === 0 && runsRes.err && statusRes.err) {
+      const first = runsRes.err || statusRes.err;
+      const raw = (first.stderr ? first.stderr.toString() : first.message) || '';
+      if (/no checks reported/i.test(raw)) return { checks: [] };
+      return { checks: [], error: raw.trim() };
+    }
+    return { checks };
   } catch (err) {
     const msg = err.stderr ? err.stderr.toString() : err.message;
-    // `gh pr checks` exits non-zero when checks are failing — the JSON still
-    // prints to stdout. Try to recover from err.stdout before giving up.
-    if (err.stdout) {
-      try { return { checks: JSON.parse(err.stdout.toString()) }; } catch {}
-    }
-    // "no checks reported" is not an error
-    if (msg && /no checks reported/i.test(msg)) {
-      return { checks: [] };
-    }
+    if (msg && /no checks reported/i.test(msg)) return { checks: [] };
     return { checks: [], error: msg };
   }
 });

--- a/main/ipc/pr-review.js
+++ b/main/ipc/pr-review.js
@@ -211,28 +211,45 @@ ipcMain.handle('pr-review-checks', async () => {
   ]);
 
   const checks = [];
+  const parseErrors = [];
   if (!runsRes.err) {
     try {
       const parsed = JSON.parse(runsRes.stdout);
       const runs = parsed.check_runs || [];
       runs.forEach((r) => checks.push(normalizeCheckRun(r)));
-    } catch (_) {}
+    } catch (e) {
+      parseErrors.push('check-runs parse: ' + (e.message || String(e)));
+      console.error('[pr-review-checks] check-runs parse error:', e.message,
+        '— first 200 chars of stdout:', String(runsRes.stdout || '').slice(0, 200));
+    }
   }
   if (!statusRes.err) {
     try {
       const parsed = JSON.parse(statusRes.stdout);
       const statuses = parsed.statuses || [];
       statuses.forEach((s) => checks.push(normalizeStatus(s)));
-    } catch (_) {}
+    } catch (e) {
+      parseErrors.push('status parse: ' + (e.message || String(e)));
+      console.error('[pr-review-checks] status parse error:', e.message,
+        '— first 200 chars of stdout:', String(statusRes.stdout || '').slice(0, 200));
+    }
   }
 
   // Only surface an error if BOTH APIs failed — previously `||` meant that
   // a legitimate "no checks" response from one endpoint plus a transient
   // failure on the other was reported as an error, swallowing real data.
-  if (checks.length === 0 && runsRes.err && statusRes.err) {
-    const first = runsRes.err || statusRes.err;
-    const raw = (first.stderr ? first.stderr.toString() : first.message) || '';
-    return { checks: [], error: raw.trim() };
+  // Also surface JSON parse failures: an HTML auth-redirect coming back as
+  // 200 would otherwise look identical to "no checks reported" and silently
+  // green-light the required-checks gate.
+  if (checks.length === 0) {
+    if (runsRes.err && statusRes.err) {
+      const first = runsRes.err || statusRes.err;
+      const raw = (first.stderr ? first.stderr.toString() : first.message) || '';
+      return { checks: [], error: raw.trim() };
+    }
+    if (parseErrors.length > 0) {
+      return { checks: [], error: 'Could not parse GitHub check responses: ' + parseErrors.join('; ') };
+    }
   }
   return { checks };
 });
@@ -259,8 +276,14 @@ async function fetchRequiredContexts(cwd, baseOwner, baseRepo, baseBranch) {
         try {
           const parsed = JSON.parse(stdout);
           resolve({ required: parsed.contexts || [] });
-        } catch (_) {
-          resolve({ required: [] });
+        } catch (e) {
+          // Garbage from gh would otherwise be indistinguishable from a 404
+          // (no protection) — and the renderer would falsely say "no required
+          // checks" + green-light merges. Surface as an error so it can be
+          // shown in the gate UI as "unknown" rather than "none".
+          console.error('[fetchRequiredContexts] JSON parse error:', e.message,
+            '— first 200 chars of stdout:', String(stdout || '').slice(0, 200));
+          resolve({ required: [], error: 'Could not parse required-checks response: ' + e.message });
         }
       },
     );
@@ -379,6 +402,14 @@ ipcMain.handle('pr-review-run-log-watch-start', async (event, { requestId, runId
   let lastLen = 0;
   let stopped = false;
   let timer = null;
+  // Track consecutive failures across both subcalls so a sustained problem
+  // (auth error, 403 rate limit, wrong runId, gh missing) ends the watcher
+  // with a real error instead of spinning forever showing no output. A run
+  // that hasn't started its first job will return errors transiently — the
+  // counter resets on any healthy tick.
+  const MAX_CONSECUTIVE_FAILURES = 3;
+  let consecutiveFailures = 0;
+  let lastFailureMsg = '';
 
   function stop() {
     stopped = true;
@@ -386,8 +417,18 @@ ipcMain.handle('pr-review-run-log-watch-start', async (event, { requestId, runId
     watchedRunLogs.delete(requestId);
   }
 
+  function fail(reason) {
+    if (!sender.isDestroyed()) {
+      sender.send(`pr-review-run-log-done-${requestId}`, {
+        error: 'Log tail failed: ' + (reason || 'unknown error'),
+      });
+    }
+    stop();
+  }
+
   async function tick() {
     if (stopped) return;
+    let tickHadFailure = false;
     try {
       const { stdout } = await execFileP(
         'gh', ['run', 'view', String(runId), '-R', `${baseOwner}/${baseRepo}`, '--log'],
@@ -410,7 +451,11 @@ ipcMain.handle('pr-review-run-log-watch-start', async (event, { requestId, runId
           sender.send(`pr-review-run-log-chunk-${requestId}`, delta);
         }
       }
-    } catch (_) { /* not started or transient — retry next tick */ }
+    } catch (err) {
+      tickHadFailure = true;
+      lastFailureMsg = ((err && (err.stderr || err.message)) || String(err)).toString().trim();
+      console.error('[pr-review-run-log-watch] log fetch failed:', lastFailureMsg);
+    }
 
     if (stopped) return;
     // Poll status separately so a still-fetching log doesn't keep the watcher
@@ -431,9 +476,25 @@ ipcMain.handle('pr-review-run-log-watch-start', async (event, { requestId, runId
         stop();
         return;
       }
-    } catch (_) {}
+      // Status poll worked. If log fetch also worked this tick the run is
+      // healthy — reset the counter. If only the log fetch failed, the run
+      // is live and the log endpoint is just flaky; don't burn the budget
+      // on that.
+      if (!tickHadFailure) consecutiveFailures = 0;
+    } catch (err) {
+      tickHadFailure = true;
+      lastFailureMsg = ((err && (err.stderr || err.message)) || String(err)).toString().trim();
+      console.error('[pr-review-run-log-watch] status poll failed:', lastFailureMsg);
+    }
 
     if (stopped) return;
+    if (tickHadFailure) {
+      consecutiveFailures += 1;
+      if (consecutiveFailures >= MAX_CONSECUTIVE_FAILURES) {
+        fail(lastFailureMsg);
+        return;
+      }
+    }
     timer = setTimeout(tick, 3000);
   }
 
@@ -1203,23 +1264,40 @@ ipcMain.handle('pr-checks', async (_event, { worktreePath, prNumber }) => {
     ]);
 
     const checks = [];
+    const parseErrors = [];
     if (!runsRes.err) {
       try {
         const parsed = JSON.parse(runsRes.stdout);
         (parsed.check_runs || []).forEach((r) => checks.push(normalizeCheckRun(r)));
-      } catch (_) {}
+      } catch (e) {
+        parseErrors.push('check-runs parse: ' + (e.message || String(e)));
+        console.error('[pr-checks] check-runs parse error:', e.message,
+          '— first 200 chars of stdout:', String(runsRes.stdout || '').slice(0, 200));
+      }
     }
     if (!statusRes.err) {
       try {
         const parsed = JSON.parse(statusRes.stdout);
         (parsed.statuses || []).forEach((s) => checks.push(normalizeStatus(s)));
-      } catch (_) {}
+      } catch (e) {
+        parseErrors.push('status parse: ' + (e.message || String(e)));
+        console.error('[pr-checks] status parse error:', e.message,
+          '— first 200 chars of stdout:', String(statusRes.stdout || '').slice(0, 200));
+      }
     }
-    if (checks.length === 0 && runsRes.err && statusRes.err) {
-      const first = runsRes.err || statusRes.err;
-      const raw = (first.stderr ? first.stderr.toString() : first.message) || '';
-      if (/no checks reported/i.test(raw)) return { checks: [] };
-      return { checks: [], error: raw.trim() };
+    // Distinguish "no checks reported" from "we couldn't read what GitHub returned".
+    // The latter must surface as an error so the renderer doesn't falsely show
+    // "No checks reported" + falsely green-light merges via the required-checks gate.
+    if (checks.length === 0) {
+      if (runsRes.err && statusRes.err) {
+        const first = runsRes.err || statusRes.err;
+        const raw = (first.stderr ? first.stderr.toString() : first.message) || '';
+        if (/no checks reported/i.test(raw)) return { checks: [] };
+        return { checks: [], error: raw.trim() };
+      }
+      if (parseErrors.length > 0) {
+        return { checks: [], error: 'Could not parse GitHub check responses: ' + parseErrors.join('; ') };
+      }
     }
     return { checks };
   } catch (err) {

--- a/main/ipc/tasks.js
+++ b/main/ipc/tasks.js
@@ -431,21 +431,31 @@ ipcMain.handle('restart-task', (_event, { id, cols, rows }) => {
   return { ok: true };
 });
 
-ipcMain.handle('set-notify-enabled', (_event, { id, enabled }) => {
+ipcMain.handle('set-notify-enabled', (_event, { id, enabled, kind }) => {
   const inst = instances.get(id);
   if (!inst) return { error: 'Instance not found' };
-  inst.notifyEnabled = enabled;
+  // `kind` lets the renderer toggle idle vs CI independently. Default 'idle'
+  // matches the legacy single-flag callers.
+  const which = kind === 'ci' ? 'ci' : 'idle';
+  if (which === 'ci') inst.notifyCIEnabled = enabled;
+  else inst.notifyEnabled = enabled;
   const config = loadConfig();
   if (!config.notifyPrefs) config.notifyPrefs = {};
-  config.notifyPrefs[inst.name] = enabled;
+  // Migrate legacy boolean entries to the {idle, ci} shape on first write.
+  let pref = config.notifyPrefs[inst.name];
+  if (typeof pref !== 'object' || pref === null) {
+    pref = { idle: pref !== false, ci: true };
+  }
+  pref[which] = enabled;
+  config.notifyPrefs[inst.name] = pref;
   saveConfig(config);
   return { ok: true };
 });
 
 ipcMain.handle('get-notify-enabled', (_event, { id }) => {
   const inst = instances.get(id);
-  if (!inst) return true;
-  return inst.notifyEnabled !== false;
+  if (!inst) return { idle: true, ci: true };
+  return { idle: inst.notifyEnabled !== false, ci: inst.notifyCIEnabled !== false };
 });
 
 ipcMain.handle('rename-task', (_event, { id, newName }) => {

--- a/main/state/ci-poll.js
+++ b/main/state/ci-poll.js
@@ -9,11 +9,28 @@
 const { execFileP, ghExecP, runWithConcurrency } = require('../util/exec');
 const { loadConfig } = require('../util/config');
 const { allWindows } = require('./windows');
-const { instances } = require('./instances');
+const { instances, sendCIFlipNotification } = require('./instances');
 
 // ---- CI/CD Status (Feature 3) ----
 
 const ciPollingIntervals = new Map(); // taskId -> intervalId
+// Per-task aggregate-bucket memory so we can fire a notification only on the
+// transition from pending → pass/fail (not on every successful poll).
+// Shape: Map<taskId, { bucket, headRunUrl }>.
+const lastBucketByTask = new Map();
+
+function bucketFromRun(run) {
+  const status = (run && run.status || '').toLowerCase();
+  const conclusion = (run && run.conclusion || '').toLowerCase();
+  if (status === 'in_progress' || status === 'queued' || status === 'requested' || status === 'waiting' || status === 'pending' || status === '') {
+    return 'pending';
+  }
+  if (conclusion === 'success' || conclusion === 'neutral') return 'pass';
+  if (conclusion === 'failure' || conclusion === 'timed_out' || conclusion === 'action_required') return 'fail';
+  if (conclusion === 'cancelled') return 'cancel';
+  if (conclusion === 'skipped') return 'pending';
+  return 'pending';
+}
 
 function startCIPolling(id, worktreePath, branch) {
   stopCIPolling(id);
@@ -33,6 +50,22 @@ function startCIPolling(id, worktreePath, branch) {
         if (!win.isDestroyed()) {
           win.webContents.send('ci-status-update', { id, runs });
         }
+      }
+
+      // Detect bucket flips on the latest run. Only fire when transitioning
+      // *out of* pending — this avoids notifications on the first poll (which
+      // would otherwise spam every time a task is created).
+      if (Array.isArray(runs) && runs.length > 0) {
+        const latest = runs.slice().sort((a, b) => new Date(b.createdAt || 0) - new Date(a.createdAt || 0))[0];
+        const newBucket = bucketFromRun(latest);
+        const prev = lastBucketByTask.get(id);
+        const inst = instances.get(id);
+        if (inst && prev && prev.bucket === 'pending' && (newBucket === 'pass' || newBucket === 'fail')) {
+          sendCIFlipNotification(inst, latest, newBucket);
+        }
+        // Always update — including on the first poll, so we have a baseline
+        // for next time.
+        lastBucketByTask.set(id, { bucket: newBucket, headRunUrl: latest.url || null });
       }
     } catch (_) { /* silent — background poll */ }
   };
@@ -57,6 +90,7 @@ function stopCIPolling(id) {
     clearInterval(timers);
   }
   ciPollingIntervals.delete(id);
+  lastBucketByTask.delete(id);
 }
 
 // ---- Auto-fetch (Feature 15) ----

--- a/main/state/instances.js
+++ b/main/state/instances.js
@@ -181,6 +181,34 @@ function sendIdleNotification(inst, reason) {
   inst.lastNotifyTime = Date.now();
 }
 
+// CI flip notification — fires when a watched task's latest run flips from
+// pending to success/failure. Suppressed if the user is looking at any window
+// (they can already see the change in real time). Independent of the idle
+// notification's NOTIFY_COOLDOWN_MS — CI events are rarer and we don't want
+// to swallow a fail notification because an idle one fired 30s ago.
+function sendCIFlipNotification(inst, run, bucket) {
+  if (!inst.notifyCIEnabled) return;
+  if (isAnyWindowFocused()) return;
+
+  const verb = bucket === 'pass' ? 'passed' : bucket === 'fail' ? 'failed' : bucket;
+  const notification = new Notification({
+    title: `Klaussy — CI ${verb}`,
+    body: `${inst.name}${run && run.name ? ' · ' + run.name : ''}`,
+    silent: false,
+  });
+
+  notification.on('click', () => {
+    const mw = getMainWindow();
+    if (mw && !mw.isDestroyed()) {
+      mw.show();
+      mw.focus();
+      mw.webContents.send('notification-clicked', { id: inst.id, view: 'pr-review' });
+    }
+  });
+
+  notification.show();
+}
+
 function processIdleDetection(inst, data) {
   if (inst.mode !== 'claude') return;
 
@@ -212,7 +240,16 @@ function processIdleDetection(inst, data) {
 
 function initIdleDetectionFields(inst) {
   const config = loadConfig();
-  inst.notifyEnabled = config.notifyPrefs?.[inst.name] !== false;
+  // notifyPrefs is either a boolean (legacy: idle-only) or {idle, ci} (new).
+  // Treat missing as both-enabled to preserve previous behavior.
+  const pref = config.notifyPrefs?.[inst.name];
+  if (typeof pref === 'object' && pref !== null) {
+    inst.notifyEnabled = pref.idle !== false;
+    inst.notifyCIEnabled = pref.ci !== false;
+  } else {
+    inst.notifyEnabled = pref !== false;
+    inst.notifyCIEnabled = true;
+  }
   inst.lastDataTime = 0;
   inst.quietTimer = null;
   inst.notifiedIdle = false;
@@ -346,5 +383,7 @@ module.exports = {
   clearIdleTimer,
   spawnInWorktree,
   convertInstanceToShell,
+  sendCIFlipNotification,
+  isAnyWindowFocused,
   setDeps,
 };

--- a/preload.js
+++ b/preload.js
@@ -64,7 +64,7 @@ contextBridge.exposeInMainWorld('klaus', {
     onPopoutInit: (callback) => {
       ipcRenderer.on('popout-init', (_event, data) => callback(data));
     },
-    setNotifyEnabled: (id, enabled) => ipcRenderer.invoke('set-notify-enabled', { id, enabled }),
+    setNotifyEnabled: (id, enabled, kind) => ipcRenderer.invoke('set-notify-enabled', { id, enabled, kind: kind || 'idle' }),
     getNotifyEnabled: (id) => ipcRenderer.invoke('get-notify-enabled', { id }),
     onNotificationClicked: (callback) => {
       ipcRenderer.on('notification-clicked', (_event, data) => callback(data));
@@ -173,6 +173,30 @@ contextBridge.exposeInMainWorld('klaus', {
     resolveThread: (worktreePath, threadId) => ipcRenderer.invoke('pr-resolve-thread', { worktreePath, threadId }),
     unresolveThread: (worktreePath, threadId) => ipcRenderer.invoke('pr-unresolve-thread', { worktreePath, threadId }),
     checks: (worktreePath, prNumber) => ipcRenderer.invoke('pr-checks', { worktreePath, prNumber }),
+    requiredChecks: (worktreePath, prNumber) => ipcRenderer.invoke('pr-required-checks', { worktreePath, prNumber }),
+    reviewRequiredChecks: () => ipcRenderer.invoke('pr-review-required-checks'),
+    reviewCheckAnnotations: (checkRunId) => ipcRenderer.invoke('pr-review-check-annotations', { checkRunId }),
+    reviewRunRerunFailed: (runId) => ipcRenderer.invoke('pr-review-run-rerun-failed', { runId }),
+    reviewRunCancel: (runId) => ipcRenderer.invoke('pr-review-run-cancel', { runId }),
+    reviewWorkflowsList: () => ipcRenderer.invoke('pr-review-workflows-list'),
+    reviewWorkflowDispatch: (workflowId, ref, inputs) =>
+      ipcRenderer.invoke('pr-review-workflow-dispatch', { workflowId, ref, inputs }),
+    reviewRunLogWatchStart: (requestId, runId) =>
+      ipcRenderer.invoke('pr-review-run-log-watch-start', { requestId, runId }),
+    reviewRunLogWatchStop: (requestId) =>
+      ipcRenderer.invoke('pr-review-run-log-watch-stop', { requestId }),
+    onRunLogChunk: (requestId, callback) => {
+      const channel = 'pr-review-run-log-chunk-' + requestId;
+      const handler = (_e, chunk) => callback(chunk);
+      ipcRenderer.on(channel, handler);
+      return () => ipcRenderer.removeListener(channel, handler);
+    },
+    onRunLogDone: (requestId, callback) => {
+      const channel = 'pr-review-run-log-done-' + requestId;
+      const handler = (_e, data) => callback(data);
+      ipcRenderer.once(channel, handler);
+      return () => ipcRenderer.removeListener(channel, handler);
+    },
     merge: (worktreePath, prNumber, strategy) => ipcRenderer.invoke('pr-merge', { worktreePath, prNumber, strategy }),
     addReviewComment: (opts) => ipcRenderer.invoke('pr-add-review-comment', opts),
     addComment: (worktreePath, prNumber, body) => ipcRenderer.invoke('pr-add-comment', { worktreePath, prNumber, body }),
@@ -212,9 +236,11 @@ contextBridge.exposeInMainWorld('klaus', {
     currentUser: () => ipcRenderer.invoke('pr-current-user'),
     reviewChecks: () => ipcRenderer.invoke('pr-review-checks'),
     reviewMerge: (strategy) => ipcRenderer.invoke('pr-review-merge', { strategy }),
-    debugCheckStart: (requestId, checkLink, checkName) =>
-      ipcRenderer.invoke('pr-debug-check-start', { requestId, checkLink, checkName }),
+    debugCheckStart: (requestId, checkLink, checkName, checkRunId) =>
+      ipcRenderer.invoke('pr-debug-check-start', { requestId, checkLink, checkName, checkRunId }),
     debugCheckCancel: (requestId) => ipcRenderer.invoke('pr-debug-check-cancel', { requestId }),
+    debugCheckOpenAsTask: (analysis, checkName, prNumber) =>
+      ipcRenderer.invoke('pr-debug-check-open-task', { analysis, checkName, prNumber }),
     onDebugCheckChunk: (requestId, callback) => {
       const channel = 'pr-debug-check-chunk-' + requestId;
       const handler = (_e, chunk) => callback(chunk);

--- a/renderer/app.js
+++ b/renderer/app.js
@@ -1378,7 +1378,12 @@
       { label: (task.notifyEnabled !== false ? '\u2713 ' : '  ') + 'Notify When Idle', action: async function () {
         var newVal = task.notifyEnabled === false;
         task.notifyEnabled = newVal;
-        await window.klaus.task.setNotifyEnabled(id, newVal);
+        await window.klaus.task.setNotifyEnabled(id, newVal, 'idle');
+      }},
+      { label: (task.notifyCIEnabled !== false ? '\u2713 ' : '  ') + 'Notify on CI Pass/Fail', action: async function () {
+        var newVal = task.notifyCIEnabled === false;
+        task.notifyCIEnabled = newVal;
+        await window.klaus.task.setNotifyEnabled(id, newVal, 'ci');
       }},
       { label: 'Export Transcript', action: async function () {
         var result = await window.klaus.task.exportTranscript(id);

--- a/renderer/pr-panel.js
+++ b/renderer/pr-panel.js
@@ -175,7 +175,11 @@ window.PRPanel = (function () {
     if (worktreeAtRequest !== currentWorktreePath || !currentPR || currentPR.number !== prNumber) return;
 
     currentChecks = checksResult;
-    renderPRChecks(checksResult);
+    // Required-checks list is fetched in parallel below; we render once with both.
+    var requiredResult = { required: [] };
+    try { requiredResult = await window.klaus.pr.requiredChecks(worktreeAtRequest, prNumber); } catch (_) {}
+    if (worktreeAtRequest !== currentWorktreePath || !currentPR || currentPR.number !== prNumber) return;
+    renderPRChecks(checksResult, requiredResult);
     updateMergeButton();
 
     if (threadsResult.error) {
@@ -200,7 +204,7 @@ window.PRPanel = (function () {
     renderCompletedReview(cacheResult.cached.review, cacheResult.cached.savedAt);
   }
 
-  function renderPRChecks(result) {
+  function renderPRChecks(result, requiredResult) {
     var host = document.getElementById('pr-checks');
     if (!host) return;
     host.innerHTML = '';
@@ -214,6 +218,7 @@ window.PRPanel = (function () {
       host.innerHTML = '<div class="pr-checks-empty">No checks reported.</div>';
       return;
     }
+    var requiredNames = (requiredResult && requiredResult.required) || [];
 
     // gh emits normalized buckets: pass, fail, pending, skipping, cancel.
     // Fall back to `state` when a check row has no bucket.
@@ -240,6 +245,17 @@ window.PRPanel = (function () {
     if (counts.cancel) summaryBits.push('<span class="pr-check-pill cancel">&#8854; ' + counts.cancel + ' cancelled</span>');
     if (counts.skipping) summaryBits.push('<span class="pr-check-pill skipping">&#8211; ' + counts.skipping + ' skipped</span>');
 
+    if (requiredNames.length > 0) {
+      var passingRequired = 0;
+      requiredNames.forEach(function (name) {
+        var match = checks.find(function (c) { return (c.name || '') === name; });
+        if (match && bucketOf(match) === 'pass') passingRequired += 1;
+      });
+      var allPass = passingRequired === requiredNames.length;
+      summaryBits.push('<span class="pr-check-pill required ' + (allPass ? 'pass' : 'gate') + '">'
+        + passingRequired + '/' + requiredNames.length + ' required</span>');
+    }
+
     var hasFail = counts.fail > 0;
     var expanded = hasFail; // auto-expand when anything is failing
 
@@ -249,12 +265,22 @@ window.PRPanel = (function () {
     html += '<span class="pr-checks-caret">&#9662;</span>';
     html += '</button>';
     html += '<div class="pr-checks-list">';
+    function formatDur(startedAt, completedAt) {
+      if (!startedAt) return '';
+      var end = completedAt ? new Date(completedAt) : new Date();
+      var ms = end - new Date(startedAt);
+      if (!isFinite(ms) || ms < 0) return '';
+      if (ms < 60000) return Math.max(1, Math.round(ms / 1000)) + 's';
+      return Math.round(ms / 60000) + 'm';
+    }
     checks.forEach(function (c) {
       var b = bucketOf(c);
       var label = c.workflow ? (c.workflow + ' / ' + (c.name || '')) : (c.name || '(unnamed)');
+      var dur = formatDur(c.startedAt, c.completedAt);
       html += '<div class="pr-check-row">';
       html += '<span class="pr-check-bucket pr-check-bucket-' + b + '">' + bucketGlyph(b) + '</span>';
       html += '<span class="pr-check-name">' + escHtml(label) + '</span>';
+      if (dur) html += '<span class="pr-check-dur">' + dur + '</span>';
       html += '<span class="pr-check-conclusion">' + escHtml(c.state || '') + '</span>';
       if (c.link) {
         html += '<a href="#" class="pr-check-link" data-url="' + escAttr(c.link) + '" title="Open in browser">&#8599;</a>';

--- a/renderer/pr-review.js
+++ b/renderer/pr-review.js
@@ -60,6 +60,11 @@ window.PrReview = (function () {
   // don't falsely green-light merges.
   var currentRequiredChecks = [];
   var currentRequiredChecksError = '';
+  // Periodic refresh while the Checks tab is the active tab. Cleared on tab
+  // switch and on PR change. 15s cadence is the same ballpark as the per-task
+  // CI poll (30s) but more responsive when the user is actively watching.
+  var checksPollTimer = null;
+  var checksFetchInFlight = false;
   // Local-changes panel state (Review tab). Refreshed on tab show and after
   // each implement/commit/push. Stays null until the first fetch completes.
   // Shape: { worktreePath, branch, files:[{status,file}], diff, unpushed:[{hash,short,subject}], headRefOid }
@@ -153,6 +158,9 @@ window.PrReview = (function () {
     if (isNewPr) {
       selectedFile = null;
       currentChecks = null;
+      // Stop any in-flight checks polling so it doesn't repaint with the
+      // previous PR's data after the new PR's render lands.
+      clearChecksPolling();
       // Don't cancel in-flight AI work for the previous PR — those agents
       // are now backgroundable and the user can monitor / re-attach via the
       // Agents panel. Just drop the local subscriptions by stashing the old
@@ -1002,6 +1010,9 @@ window.PrReview = (function () {
       btn.addEventListener('click', function () {
         var tab = btn.dataset.tab;
         if (activeTab === tab) return;
+        // Leaving the Checks tab: stop the periodic poll. Re-entering it
+        // re-binds and bindChecksTab() restarts the poll.
+        if (activeTab === 'checks' && tab !== 'checks') clearChecksPolling();
         activeTab = tab;
         if (lastState) render(lastState);
       });
@@ -3961,12 +3972,14 @@ window.PrReview = (function () {
       refresh.addEventListener('click', function () {
         refresh.disabled = true;
         refresh.textContent = 'Refreshing\u2026';
-        fetchAndRenderChecks(lastState && lastState.number).then(function () {
-          // Re-render the tab to pick up new data.
-          if (lastState) render(lastState);
-        });
+        fetchAndRenderChecks(lastState && lastState.number).then(repaintChecksTab);
       });
     }
+    // Auto-refresh: pull fresh data on every tab activation, then poll while
+    // the tab stays active. Without this, an in-progress run kicked off
+    // moments ago wouldn't show up until the user manually clicked Refresh
+    // (the per-task CI poll updates the sidebar icon but not this surface).
+    startChecksPolling();
     var dispatchBtn = hostEl.querySelector('.pr-checks-dispatch');
     if (dispatchBtn) {
       dispatchBtn.addEventListener('click', function () { openWorkflowDispatchModal(); });
@@ -4109,15 +4122,58 @@ window.PrReview = (function () {
         setTimeout(function () { btn.textContent = originalText; btn.title = ''; }, 4000);
         return;
       }
-      // Successful kick — refresh checks so the row's state reflects the new run.
-      fetchAndRenderChecks(lastState && lastState.number).then(function () {
-        if (lastState) render(lastState);
-      });
+      // Successful kick — refresh checks so the row's state reflects the new
+      // run. Repaint just the Checks-tab slot rather than re-rendering the
+      // whole PR view; the latter caused the entire section to flash empty
+      // for the duration of the rebuild.
+      fetchAndRenderChecks(lastState && lastState.number).then(repaintChecksTab);
     }).catch(function (err) {
       btn.disabled = false;
       btn.textContent = 'Failed';
       btn.title = (err && err.message) || 'unknown error';
     });
+  }
+
+  // Swap only the .pr-review-checks-tab innerHTML and rebind. Leaves the
+  // rest of the PR-review surface untouched so action-driven refreshes
+  // (rerun, cancel, periodic poll) don't flash the whole tab.
+  function repaintChecksTab() {
+    var slot = hostEl.querySelector('.pr-review-checks-tab');
+    if (!slot) return;
+    slot.innerHTML = renderChecksTab();
+    bindChecksTab();
+  }
+
+  // Periodic refresh while Checks is the active tab. Idempotent — calling
+  // start while already running just resets the interval. Stops on tab
+  // switch (bindTabs hook) and on PR change (clearChecksPolling at the top
+  // of render() when isNewPr).
+  function startChecksPolling() {
+    clearChecksPolling();
+    // Kick off an immediate refresh on tab activation so the user sees fresh
+    // data without clicking Refresh. Skip if the PR isn't loaded yet.
+    if (lastState && lastState.number && !checksFetchInFlight) {
+      checksFetchInFlight = true;
+      fetchAndRenderChecks(lastState.number).then(function () {
+        checksFetchInFlight = false;
+        repaintChecksTab();
+      }, function () { checksFetchInFlight = false; });
+    }
+    checksPollTimer = setInterval(function () {
+      if (!lastState || !lastState.number) { clearChecksPolling(); return; }
+      // Skip if the previous poll hasn't returned yet — avoids fetch storms
+      // when the user's network is slow.
+      if (checksFetchInFlight) return;
+      checksFetchInFlight = true;
+      fetchAndRenderChecks(lastState.number).then(function () {
+        checksFetchInFlight = false;
+        repaintChecksTab();
+      }, function () { checksFetchInFlight = false; });
+    }, 15000);
+  }
+
+  function clearChecksPolling() {
+    if (checksPollTimer) { clearInterval(checksPollTimer); checksPollTimer = null; }
   }
 
   // Hand-built modal for manually dispatching a workflow. Inputs are accepted

--- a/renderer/pr-review.js
+++ b/renderer/pr-review.js
@@ -52,8 +52,14 @@ window.PrReview = (function () {
   // G6: latest checks result for the active PR. null = not yet fetched.
   var currentChecks = null;
   // Required-status-checks for the PR's base branch (from branch protection).
-  // Loaded lazily alongside currentChecks. Empty array = no protection rules.
+  // Loaded lazily alongside currentChecks.
+  //   []                  → no protection rules (or branch not protected)
+  //   ['name', 'name', …] → required contexts
+  // currentRequiredChecksError carries a string when the fetch parsed garbage
+  // or hit auth issues — the gate must render as "unknown" in that case so we
+  // don't falsely green-light merges.
   var currentRequiredChecks = [];
+  var currentRequiredChecksError = '';
   // Local-changes panel state (Review tab). Refreshed on tab show and after
   // each implement/commit/push. Stays null until the first fetch completes.
   // Shape: { worktreePath, branch, files:[{status,file}], diff, unpushed:[{hash,short,subject}], headRefOid }
@@ -3761,8 +3767,17 @@ window.PrReview = (function () {
       var req = await window.klaus.pr.reviewRequiredChecks();
       if (lastState && lastState.number === forNumber) {
         currentRequiredChecks = (req && req.required) || [];
+        currentRequiredChecksError = (req && req.error) || '';
       }
-    } catch (_) { /* required-checks failure shouldn't blank the tab */ }
+    } catch (err) {
+      // The gate must not silently green-light merges if the fetch itself
+      // crashes (the IPC handler is supposed to catch and return an error,
+      // but renderer crashes happen too). Surface as "unknown" in the gate.
+      if (lastState && lastState.number === forNumber) {
+        currentRequiredChecks = [];
+        currentRequiredChecksError = (err && err.message) || 'unknown error';
+      }
+    }
     renderChecksIntoSlot();
     // Merge gate depends on checks, so repaint the merge control too.
     var mergeWrap = hostEl.querySelector('.pr-merge-wrap');
@@ -3811,8 +3826,18 @@ window.PrReview = (function () {
     // Required-checks gate: shows X/Y required passing + a chip list. Required
     // names that have no matching check today are rendered as "missing" chips —
     // those still gate merge per branch protection rules.
+    //
+    // If the fetch errored (e.g. gh returned garbage, auth scope missing),
+    // render an "unknown" gate explicitly. Silently rendering as "no required
+    // checks" would falsely green-light merges.
     var requiredGate = '';
-    if (currentRequiredChecks && currentRequiredChecks.length > 0) {
+    if (currentRequiredChecksError) {
+      requiredGate = '<div class="pr-required-gate pr-required-unknown" title="' + escHtml(currentRequiredChecksError) + '">'
+        + '<div class="pr-required-summary">'
+          + 'Required checks: <strong>unknown</strong> — could not load branch protection rules. Verify on GitHub before merging.'
+        + '</div>'
+      + '</div>';
+    } else if (currentRequiredChecks && currentRequiredChecks.length > 0) {
       var passingRequired = 0;
       var chipHtml = currentRequiredChecks.map(function (name) {
         var match = checks.find(function (c) { return (c.name || '') === name; });

--- a/renderer/pr-review.js
+++ b/renderer/pr-review.js
@@ -51,6 +51,9 @@ window.PrReview = (function () {
   var convClaudeState = {};
   // G6: latest checks result for the active PR. null = not yet fetched.
   var currentChecks = null;
+  // Required-status-checks for the PR's base branch (from branch protection).
+  // Loaded lazily alongside currentChecks. Empty array = no protection rules.
+  var currentRequiredChecks = [];
   // Local-changes panel state (Review tab). Refreshed on tab show and after
   // each implement/commit/push. Stays null until the first fetch completes.
   // Shape: { worktreePath, branch, files:[{status,file}], diff, unpushed:[{hash,short,subject}], headRefOid }
@@ -3752,6 +3755,14 @@ window.PrReview = (function () {
     // Drop stale results if the user switched PRs mid-flight.
     if (!lastState || lastState.number !== forNumber) return;
     currentChecks = result;
+    // Required-checks list is independent of the per-commit checks data; fetch
+    // in parallel-ish (after main checks so the user sees something fast).
+    try {
+      var req = await window.klaus.pr.reviewRequiredChecks();
+      if (lastState && lastState.number === forNumber) {
+        currentRequiredChecks = (req && req.required) || [];
+      }
+    } catch (_) { /* required-checks failure shouldn't blank the tab */ }
     renderChecksIntoSlot();
     // Merge gate depends on checks, so repaint the merge control too.
     var mergeWrap = hostEl.querySelector('.pr-merge-wrap');
@@ -3792,29 +3803,131 @@ window.PrReview = (function () {
     });
     var header = '<div class="pr-checks-tab-head">'
       + '<span>' + checks.length + ' check' + (checks.length === 1 ? '' : 's') + '</span>'
-      + '<button type="button" class="pr-review-btn pr-checks-refresh">Refresh</button>'
+      + '<div class="pr-checks-tab-actions">'
+        + '<button type="button" class="pr-review-btn pr-checks-dispatch">Dispatch workflow…</button>'
+        + '<button type="button" class="pr-review-btn pr-checks-refresh">Refresh</button>'
+      + '</div>'
     + '</div>';
-    return header + '<div class="pr-checks-list">'
-      + sorted.map(function (c) {
-        var b = bucketOf(c);
-        var icon = b === 'pass' ? '\u2713' : b === 'fail' ? '\u2717' : b === 'pending' ? '\u25CB' : b === 'cancel' ? '\u2296' : '\u2298';
-        var linkAttr = c.link ? ' data-link="' + escHtml(c.link) + '"' : '';
-        var debugBtn = (b === 'fail' && c.link)
-          ? '<button class="pr-check-debug-btn" type="button" data-link="' + escHtml(c.link) + '" data-name="' + escHtml(c.name || '') + '" title="Use Claude to diagnose this failure">Debug</button>'
-          : '';
-        return '<div class="pr-check-row pr-check-' + b + '"' + linkAttr + '>'
-          + '<span class="pr-check-icon">' + icon + '</span>'
-          + '<div class="pr-check-labels">'
-            + '<div class="pr-check-name">' + escHtml(c.name || '(unnamed)') + '</div>'
-            + (c.workflow ? '<div class="pr-check-workflow">' + escHtml(c.workflow) + '</div>' : '')
-            + (c.description ? '<div class="pr-check-desc">' + escHtml(c.description) + '</div>' : '')
-          + '</div>'
-          + '<span class="pr-check-state">' + escHtml((c.state || b).toLowerCase()) + '</span>'
-          + debugBtn
-          + (c.link ? '<span class="pr-check-arrow">\u2197</span>' : '')
-        + '</div>';
-      }).join('')
+    // Required-checks gate: shows X/Y required passing + a chip list. Required
+    // names that have no matching check today are rendered as "missing" chips —
+    // those still gate merge per branch protection rules.
+    var requiredGate = '';
+    if (currentRequiredChecks && currentRequiredChecks.length > 0) {
+      var passingRequired = 0;
+      var chipHtml = currentRequiredChecks.map(function (name) {
+        var match = checks.find(function (c) { return (c.name || '') === name; });
+        var b = match ? bucketOf(match) : 'missing';
+        if (b === 'pass') passingRequired += 1;
+        return '<span class="pr-required-chip pr-required-' + b + '" title="' + escHtml(b) + '">' + escHtml(name) + '</span>';
+      }).join('');
+      var allPass = passingRequired === currentRequiredChecks.length;
+      requiredGate = '<div class="pr-required-gate ' + (allPass ? 'pr-required-all-pass' : 'pr-required-blocking') + '">'
+        + '<div class="pr-required-summary">'
+          + '<strong>' + passingRequired + '/' + currentRequiredChecks.length + '</strong> required check' + (currentRequiredChecks.length === 1 ? '' : 's') + ' passing'
+        + '</div>'
+        + '<div class="pr-required-chips">' + chipHtml + '</div>'
       + '</div>';
+    }
+    function formatDur(startedAt, completedAt) {
+      if (!startedAt) return '';
+      var end = completedAt ? new Date(completedAt) : new Date();
+      var ms = end - new Date(startedAt);
+      if (!isFinite(ms) || ms < 0) return '';
+      if (ms < 60000) return Math.max(1, Math.round(ms / 1000)) + 's';
+      return Math.round(ms / 60000) + 'm';
+    }
+
+    function renderRowHtml(c) {
+      var b = bucketOf(c);
+      var icon = b === 'pass' ? '\u2713' : b === 'fail' ? '\u2717' : b === 'pending' ? '\u25CB' : b === 'cancel' ? '\u2296' : '\u2298';
+      var linkAttr = c.link ? ' data-link="' + escHtml(c.link) + '"' : '';
+      var debugBtn = (b === 'fail' && c.link)
+        ? '<button class="pr-check-debug-btn" type="button" data-link="' + escHtml(c.link) + '" data-name="' + escHtml(c.name || '') + '" data-check-id="' + escHtml(c.id ? String(c.id) : '') + '" title="Use Claude to diagnose this failure">Debug</button>'
+        : '';
+      var annotationsBtn = (b === 'fail' && c.id)
+        ? '<button class="pr-check-annotations-btn" type="button" data-check-id="' + escHtml(String(c.id)) + '" data-name="' + escHtml(c.name || '') + '" title="Show file:line annotations">Annotations</button>'
+        : '';
+      var rerunBtn = (b === 'fail' && c.runId)
+        ? '<button class="pr-check-action-btn pr-check-action-rerun" type="button" data-run-id="' + escHtml(String(c.runId)) + '" data-name="' + escHtml(c.name || '') + '" title="Rerun failed jobs in this workflow run">Rerun</button>'
+        : '';
+      var cancelBtn = (b === 'pending' && c.runId)
+        ? '<button class="pr-check-action-btn pr-check-action-cancel" type="button" data-run-id="' + escHtml(String(c.runId)) + '" data-name="' + escHtml(c.name || '') + '" title="Cancel this workflow run">Cancel</button>'
+        : '';
+      var watchBtn = (b === 'pending' && c.runId)
+        ? '<button class="pr-check-action-btn pr-check-action-watch" type="button" data-run-id="' + escHtml(String(c.runId)) + '" data-name="' + escHtml(c.name || '') + '" title="Stream the workflow log live">Watch log</button>'
+        : '';
+      var dur = formatDur(c.startedAt, c.completedAt);
+      var durHtml = dur ? '<span class="pr-check-dur">' + dur + '</span>' : '';
+      return '<div class="pr-check-row pr-check-' + b + '"' + linkAttr + '>'
+        + '<span class="pr-check-icon">' + icon + '</span>'
+        + '<div class="pr-check-labels">'
+          + '<div class="pr-check-name">' + escHtml(c.name || '(unnamed)') + '</div>'
+          + (c.workflow ? '<div class="pr-check-workflow">' + escHtml(c.workflow) + '</div>' : '')
+          + (c.description ? '<div class="pr-check-desc">' + escHtml(c.description) + '</div>' : '')
+        + '</div>'
+        + durHtml
+        + '<span class="pr-check-state">' + escHtml((c.state || b).toLowerCase()) + '</span>'
+        + watchBtn
+        + rerunBtn
+        + cancelBtn
+        + annotationsBtn
+        + debugBtn
+        + (c.link ? '<span class="pr-check-arrow">\u2197</span>' : '')
+      + '</div>';
+    }
+
+    // Group checks by runId so the user can see which jobs belong to the same
+    // workflow run. Singletons and runId-less checks render flat.
+    var groups = {};
+    var loose = [];
+    sorted.forEach(function (c) {
+      if (c.runId) {
+        if (!groups[c.runId]) groups[c.runId] = [];
+        groups[c.runId].push(c);
+      } else {
+        loose.push(c);
+      }
+    });
+
+    function aggregateBucket(items) {
+      var buckets = items.map(bucketOf);
+      if (buckets.indexOf('fail') >= 0) return 'fail';
+      if (buckets.indexOf('pending') >= 0) return 'pending';
+      if (buckets.indexOf('cancel') >= 0) return 'cancel';
+      if (buckets.indexOf('skipping') >= 0 && buckets.every(function (b) { return b === 'skipping'; })) return 'skipping';
+      return 'pass';
+    }
+    function aggregateDur(items) {
+      var starts = items.map(function (c) { return c.startedAt; }).filter(Boolean);
+      var ends = items.map(function (c) { return c.completedAt; }).filter(Boolean);
+      if (!starts.length) return '';
+      var earliest = starts.reduce(function (a, b) { return new Date(a) < new Date(b) ? a : b; });
+      var latest = ends.length === items.length ? ends.reduce(function (a, b) { return new Date(a) > new Date(b) ? a : b; }) : null;
+      return formatDur(earliest, latest);
+    }
+
+    var groupHtml = Object.keys(groups).map(function (runId) {
+      var items = groups[runId];
+      // Single-check groups don't need a header \u2014 render flat.
+      if (items.length < 2) {
+        loose = loose.concat(items);
+        return '';
+      }
+      var b = aggregateBucket(items);
+      var dur = aggregateDur(items);
+      var workflowName = (items.find(function (c) { return c.workflow; }) || {}).workflow || '';
+      return '<div class="pr-check-group pr-check-group-' + b + '">'
+        + '<div class="pr-check-group-head">'
+          + '<span class="pr-check-group-label">' + escHtml(workflowName || ('Run #' + runId)) + '</span>'
+          + '<span class="pr-check-group-meta">' + items.length + ' job' + (items.length === 1 ? '' : 's') + (dur ? ' \u00B7 ' + dur : '') + '</span>'
+        + '</div>'
+        + '<div class="pr-check-group-rows">' + items.map(renderRowHtml).join('') + '</div>'
+      + '</div>';
+    }).join('');
+
+    var looseHtml = loose.length ? '<div class="pr-checks-list">' + loose.map(renderRowHtml).join('') + '</div>' : '';
+
+    return header + requiredGate + groupHtml + looseHtml;
   }
 
   function bindChecksTab() {
@@ -3829,10 +3942,16 @@ window.PrReview = (function () {
         });
       });
     }
+    var dispatchBtn = hostEl.querySelector('.pr-checks-dispatch');
+    if (dispatchBtn) {
+      dispatchBtn.addEventListener('click', function () { openWorkflowDispatchModal(); });
+    }
     hostEl.querySelectorAll('.pr-check-row[data-link]').forEach(function (row) {
       row.addEventListener('click', function (e) {
-        // Don't open the run URL when the user clicks the inline Debug btn.
+        // Don't open the run URL when the user clicks an inline action btn.
         if (e.target.closest('.pr-check-debug-btn')) return;
+        if (e.target.closest('.pr-check-annotations-btn')) return;
+        if (e.target.closest('.pr-check-action-btn')) return;
         var url = row.dataset.link;
         if (url) window.klaus.gh.openExternal(url);
       });
@@ -3842,6 +3961,281 @@ window.PrReview = (function () {
         e.stopPropagation();
         startDebugCheck(btn);
       });
+    });
+    hostEl.querySelectorAll('.pr-check-annotations-btn').forEach(function (btn) {
+      btn.addEventListener('click', function (e) {
+        e.stopPropagation();
+        toggleAnnotations(btn);
+      });
+    });
+    hostEl.querySelectorAll('.pr-check-action-rerun').forEach(function (btn) {
+      btn.addEventListener('click', function (e) {
+        e.stopPropagation();
+        runQuickAction(btn, 'rerun');
+      });
+    });
+    hostEl.querySelectorAll('.pr-check-action-cancel').forEach(function (btn) {
+      btn.addEventListener('click', function (e) {
+        e.stopPropagation();
+        runQuickAction(btn, 'cancel');
+      });
+    });
+    hostEl.querySelectorAll('.pr-check-action-watch').forEach(function (btn) {
+      btn.addEventListener('click', function (e) {
+        e.stopPropagation();
+        toggleLogWatch(btn);
+      });
+    });
+  }
+
+  // Live log tail for an in-progress run. Click again to stop. Renders into a
+  // panel below the row with auto-scroll to bottom unless the user has
+  // scrolled up (basic stick-to-bottom behavior).
+  function toggleLogWatch(btn) {
+    var row = btn.closest('.pr-check-row');
+    if (!row) return;
+    var existing = row.nextElementSibling && row.nextElementSibling.classList.contains('pr-check-log-watch-panel')
+      ? row.nextElementSibling : null;
+    if (existing) {
+      var existingId = existing.dataset.requestId;
+      if (existingId) window.klaus.pr.reviewRunLogWatchStop(existingId);
+      existing.remove();
+      btn.textContent = 'Watch log';
+      return;
+    }
+    var runId = btn.dataset.runId;
+    if (!runId) return;
+    var requestId = 'log-' + Date.now() + '-' + Math.random().toString(36).slice(2, 8);
+
+    var panel = document.createElement('div');
+    panel.className = 'pr-check-log-watch-panel';
+    panel.dataset.requestId = requestId;
+    panel.innerHTML = '<div class="pr-check-log-watch-head">'
+        + '<span>Tailing run #' + escHtml(runId) + '</span>'
+        + '<button type="button" class="pr-check-log-watch-stop">Stop</button>'
+      + '</div>'
+      + '<pre class="pr-check-log-watch-body">Waiting for log…</pre>';
+    row.insertAdjacentElement('afterend', panel);
+    btn.textContent = 'Stop watching';
+
+    var bodyEl = panel.querySelector('.pr-check-log-watch-body');
+    var firstChunk = true;
+    var stickBottom = true;
+    bodyEl.addEventListener('scroll', function () {
+      // Within 12px of the bottom counts as "stuck" for resume-after-render.
+      stickBottom = (bodyEl.scrollHeight - bodyEl.scrollTop - bodyEl.clientHeight) < 12;
+    });
+
+    var unsubChunk = window.klaus.pr.onRunLogChunk(requestId, function (chunk) {
+      if (firstChunk) { bodyEl.textContent = ''; firstChunk = false; }
+      bodyEl.appendChild(document.createTextNode(chunk));
+      if (stickBottom) bodyEl.scrollTop = bodyEl.scrollHeight;
+    });
+    var unsubDone = window.klaus.pr.onRunLogDone(requestId, function (info) {
+      var head = panel.querySelector('.pr-check-log-watch-head span');
+      if (head) {
+        if (info && info.truncated) head.textContent = 'Log too large — stopped tailing';
+        else if (info && info.conclusion) head.textContent = 'Run completed: ' + info.conclusion;
+        else head.textContent = 'Run completed';
+      }
+      btn.textContent = 'Watch log';
+    });
+
+    panel.querySelector('.pr-check-log-watch-stop').addEventListener('click', function () {
+      window.klaus.pr.reviewRunLogWatchStop(requestId);
+      if (unsubChunk) unsubChunk();
+      if (unsubDone) unsubDone();
+      panel.remove();
+      btn.textContent = 'Watch log';
+    });
+
+    window.klaus.pr.reviewRunLogWatchStart(requestId, runId).then(function (res) {
+      if (res && res.error) {
+        bodyEl.classList.add('diff-error');
+        bodyEl.textContent = res.error;
+        btn.textContent = 'Watch log';
+      }
+    });
+  }
+
+  // Shared rerun/cancel handler. Button label flips to a transient state, then
+  // the Checks tab is refreshed once gh returns. Errors surface on the button
+  // itself rather than a toast — keeps the row in scope for the user.
+  function runQuickAction(btn, kind) {
+    var runId = btn.dataset.runId;
+    if (!runId) return;
+    var name = btn.dataset.name || ('run #' + runId);
+    var verb = kind === 'rerun' ? 'Rerun failed jobs' : 'Cancel run';
+    if (!confirm(verb + ' for "' + name + '"?')) return;
+
+    var originalText = btn.textContent;
+    btn.disabled = true;
+    btn.textContent = kind === 'rerun' ? 'Rerunning…' : 'Cancelling…';
+
+    var p = kind === 'rerun'
+      ? window.klaus.pr.reviewRunRerunFailed(runId)
+      : window.klaus.pr.reviewRunCancel(runId);
+
+    p.then(function (res) {
+      if (res && res.error) {
+        btn.disabled = false;
+        btn.textContent = 'Failed';
+        btn.title = res.error;
+        setTimeout(function () { btn.textContent = originalText; btn.title = ''; }, 4000);
+        return;
+      }
+      // Successful kick — refresh checks so the row's state reflects the new run.
+      fetchAndRenderChecks(lastState && lastState.number).then(function () {
+        if (lastState) render(lastState);
+      });
+    }).catch(function (err) {
+      btn.disabled = false;
+      btn.textContent = 'Failed';
+      btn.title = (err && err.message) || 'unknown error';
+    });
+  }
+
+  // Hand-built modal for manually dispatching a workflow. Inputs are accepted
+  // as a raw JSON object since parsing the workflow YAML's `on.workflow_dispatch.inputs`
+  // would require pulling in a YAML lib for a niche feature. Most workflows
+  // either have no inputs or simple key/value inputs the user already knows.
+  function openWorkflowDispatchModal() {
+    var existing = document.querySelector('.pr-workflow-dispatch-modal-backdrop');
+    if (existing) { existing.remove(); return; }
+
+    var defaultRef = (lastState && lastState.headRefName) || '';
+    var backdrop = document.createElement('div');
+    backdrop.className = 'pr-workflow-dispatch-modal-backdrop';
+    backdrop.innerHTML = '<div class="pr-workflow-dispatch-modal">'
+        + '<div class="pr-workflow-dispatch-head">Dispatch workflow</div>'
+        + '<div class="pr-workflow-dispatch-body">'
+          + '<label>Workflow</label>'
+          + '<select class="pr-workflow-select"><option value="">Loading…</option></select>'
+          + '<label>Ref (branch or tag)</label>'
+          + '<input class="pr-workflow-ref" type="text" value="' + escHtml(defaultRef) + '" />'
+          + '<label>Inputs (JSON object, optional)</label>'
+          + '<textarea class="pr-workflow-inputs" placeholder=\'{"environment": "staging"}\'></textarea>'
+          + '<div class="pr-workflow-dispatch-error" hidden></div>'
+        + '</div>'
+        + '<div class="pr-workflow-dispatch-actions">'
+          + '<button type="button" class="pr-workflow-dispatch-cancel">Cancel</button>'
+          + '<button type="button" class="pr-workflow-dispatch-go">Dispatch</button>'
+        + '</div>'
+      + '</div>';
+    document.body.appendChild(backdrop);
+
+    var selectEl = backdrop.querySelector('.pr-workflow-select');
+    var refEl = backdrop.querySelector('.pr-workflow-ref');
+    var inputsEl = backdrop.querySelector('.pr-workflow-inputs');
+    var errorEl = backdrop.querySelector('.pr-workflow-dispatch-error');
+    var goBtn = backdrop.querySelector('.pr-workflow-dispatch-go');
+
+    function close() { backdrop.remove(); }
+    backdrop.querySelector('.pr-workflow-dispatch-cancel').addEventListener('click', close);
+    backdrop.addEventListener('click', function (e) { if (e.target === backdrop) close(); });
+
+    window.klaus.pr.reviewWorkflowsList().then(function (res) {
+      if (res && res.error) {
+        selectEl.innerHTML = '<option value="">— failed to load —</option>';
+        errorEl.textContent = res.error;
+        errorEl.hidden = false;
+        return;
+      }
+      var ws = (res && res.workflows) || [];
+      if (ws.length === 0) {
+        selectEl.innerHTML = '<option value="">— no active workflows —</option>';
+        return;
+      }
+      selectEl.innerHTML = ws.map(function (w) {
+        return '<option value="' + escHtml(String(w.id)) + '">' + escHtml(w.name) + ' (' + escHtml(w.path) + ')</option>';
+      }).join('');
+    });
+
+    goBtn.addEventListener('click', function () {
+      var workflowId = selectEl.value;
+      if (!workflowId) { errorEl.textContent = 'Choose a workflow.'; errorEl.hidden = false; return; }
+      var ref = refEl.value.trim();
+      if (!ref) { errorEl.textContent = 'Ref is required.'; errorEl.hidden = false; return; }
+      var inputs = {};
+      var raw = inputsEl.value.trim();
+      if (raw) {
+        try { inputs = JSON.parse(raw); }
+        catch (err) { errorEl.textContent = 'Inputs must be valid JSON: ' + err.message; errorEl.hidden = false; return; }
+        if (typeof inputs !== 'object' || Array.isArray(inputs) || inputs === null) {
+          errorEl.textContent = 'Inputs must be a JSON object.';
+          errorEl.hidden = false;
+          return;
+        }
+      }
+      goBtn.disabled = true;
+      goBtn.textContent = 'Dispatching…';
+      errorEl.hidden = true;
+      window.klaus.pr.reviewWorkflowDispatch(workflowId, ref, inputs).then(function (res) {
+        if (res && res.error) {
+          goBtn.disabled = false;
+          goBtn.textContent = 'Dispatch';
+          errorEl.textContent = res.error;
+          errorEl.hidden = false;
+          return;
+        }
+        // Successful dispatch. Refresh checks so the new run shows up promptly.
+        close();
+        if (lastState) {
+          fetchAndRenderChecks(lastState.number).then(function () { render(lastState); });
+        }
+      });
+    });
+  }
+
+  // Lazily fetch + render annotations beneath a failing check row. Click
+  // again to collapse. Cached on the panel element so a re-render of the
+  // tab doesn't lose the user's expand state.
+  function toggleAnnotations(btn) {
+    var row = btn.closest('.pr-check-row');
+    if (!row) return;
+    var existing = row.nextElementSibling && row.nextElementSibling.classList.contains('pr-check-annotations-panel')
+      ? row.nextElementSibling : null;
+    if (existing) { existing.remove(); return; }
+    var checkId = btn.dataset.checkId;
+    if (!checkId) return;
+
+    var panel = document.createElement('div');
+    panel.className = 'pr-check-annotations-panel';
+    panel.innerHTML = '<div class="pr-check-annotations-body">Loading annotations…</div>';
+    row.insertAdjacentElement('afterend', panel);
+
+    window.klaus.pr.reviewCheckAnnotations(checkId).then(function (res) {
+      if (!panel.isConnected) return;
+      var body = panel.querySelector('.pr-check-annotations-body');
+      if (res && res.error) {
+        body.classList.add('diff-error');
+        body.textContent = 'Failed to load annotations: ' + res.error;
+        return;
+      }
+      var ann = (res && res.annotations) || [];
+      if (ann.length === 0) {
+        body.textContent = 'No annotations from this check.';
+        body.classList.add('pr-check-annotations-empty');
+        return;
+      }
+      body.innerHTML = ann.map(function (a) {
+        var levelClass = 'pr-annotation-' + (a.level || 'notice').replace(/[^a-z]/gi, '');
+        var loc = a.path ? escHtml(a.path) + (a.startLine ? ':' + a.startLine : '') : '';
+        return '<div class="pr-annotation ' + levelClass + '">'
+          + '<div class="pr-annotation-head">'
+            + '<span class="pr-annotation-level">' + escHtml(a.level || 'notice') + '</span>'
+            + (loc ? '<span class="pr-annotation-loc">' + loc + '</span>' : '')
+            + (a.title ? '<span class="pr-annotation-title">' + escHtml(a.title) + '</span>' : '')
+          + '</div>'
+          + '<div class="pr-annotation-msg">' + escHtml(a.message || '') + '</div>'
+          + (a.rawDetails ? '<pre class="pr-annotation-raw">' + escHtml(a.rawDetails) + '</pre>' : '')
+        + '</div>';
+      }).join('');
+    }).catch(function (err) {
+      if (!panel.isConnected) return;
+      var body = panel.querySelector('.pr-check-annotations-body');
+      body.classList.add('diff-error');
+      body.textContent = 'Failed to load annotations: ' + (err && err.message ? err.message : 'unknown error');
     });
   }
 
@@ -3919,6 +4313,36 @@ window.PrReview = (function () {
       footer.className = 'pr-check-debug-usage';
       footer.textContent = 'Ran in ' + seconds + 's on your Anthropic account';
       panel.appendChild(footer);
+
+      // Open as task: spawn a fresh Claude task in the PR worktree, pre-typed
+      // with the analysis. Uses ensureWorktreeForActivePr in main, so the
+      // user doesn't have to checkout the PR first.
+      var openBtn = document.createElement('button');
+      openBtn.type = 'button';
+      openBtn.className = 'pr-check-debug-open-task';
+      openBtn.textContent = 'Open as task';
+      openBtn.title = 'Spawn a Claude task on the PR worktree, seeded with this analysis';
+      openBtn.addEventListener('click', function () {
+        openBtn.disabled = true;
+        var originalLabel = openBtn.textContent;
+        openBtn.textContent = 'Opening…';
+        var prNumber = lastState && lastState.number;
+        window.klaus.pr.debugCheckOpenAsTask(accumulated, btn.dataset.name || '', prNumber).then(function (res) {
+          if (res && res.error) {
+            openBtn.disabled = false;
+            openBtn.textContent = 'Failed';
+            openBtn.title = res.error;
+            setTimeout(function () { openBtn.textContent = originalLabel; openBtn.title = ''; }, 4000);
+            return;
+          }
+          openBtn.textContent = 'Opened ✓';
+        }).catch(function (err) {
+          openBtn.disabled = false;
+          openBtn.textContent = 'Failed';
+          openBtn.title = (err && err.message) || 'unknown error';
+        });
+      });
+      panel.appendChild(openBtn);
     });
 
     panel.querySelector('.pr-check-debug-close').addEventListener('click', function () {
@@ -3935,7 +4359,7 @@ window.PrReview = (function () {
     // Re-enable button after start so the user can click it again to cancel.
     setTimeout(function () { btn.disabled = false; btn.textContent = origText; }, 200);
 
-    window.klaus.pr.debugCheckStart(requestId, btn.dataset.link, btn.dataset.name).then(function (r) {
+    window.klaus.pr.debugCheckStart(requestId, btn.dataset.link, btn.dataset.name, btn.dataset.checkId || null).then(function (r) {
       if (r && r.error) {
         clearInterval(statusTimer);
         bodyEl.classList.remove('status-pulse');

--- a/renderer/quick-open.js
+++ b/renderer/quick-open.js
@@ -42,7 +42,13 @@ window.QuickOpen = (function () {
     }
 
     overlay = document.createElement('div');
-    overlay.className = 'palette-overlay';
+    // `.palette-overlay` is the shared backdrop styling used by every
+    // dialog in the app (Setup-check, About, license, etc.). Add a
+    // `.quick-open-overlay` discriminator so e2e tests can target THIS
+    // overlay specifically — without it, an unrelated dialog opening
+    // mid-test (Setup-check on first launch in CI) makes selectors that
+    // match `.palette-overlay` non-unique and the count assertions race.
+    overlay.className = 'palette-overlay quick-open-overlay';
 
     var palette = document.createElement('div');
     palette.className = 'palette';

--- a/renderer/styles.css
+++ b/renderer/styles.css
@@ -3946,6 +3946,8 @@ body.task-branchless #ahead-behind {
 }
 .pr-required-gate.pr-required-blocking { border-color: rgba(210, 153, 34, 0.5); }
 .pr-required-gate.pr-required-all-pass { border-color: rgba(46, 160, 67, 0.4); }
+.pr-required-gate.pr-required-unknown { border-color: rgba(248, 81, 73, 0.5); background: rgba(248, 81, 73, 0.06); }
+.pr-required-gate.pr-required-unknown .pr-required-summary strong { color: #f85149; }
 .pr-required-summary { color: var(--text-dim); }
 .pr-required-gate.pr-required-all-pass .pr-required-summary strong { color: #2ea043; }
 .pr-required-gate.pr-required-blocking .pr-required-summary strong { color: #d29922; }

--- a/renderer/styles.css
+++ b/renderer/styles.css
@@ -3929,6 +3929,137 @@ body.task-branchless #ahead-behind {
 .pr-check-pill.pending { color: #d29922; background: rgba(210, 153, 34, 0.1); border-color: rgba(210, 153, 34, 0.3); }
 .pr-check-pill.cancel { color: var(--text-dim); background: rgba(128, 128, 128, 0.1); border-color: rgba(128, 128, 128, 0.25); }
 .pr-check-pill.skipping { color: var(--text-dim); background: rgba(128, 128, 128, 0.08); border-color: rgba(128, 128, 128, 0.2); }
+.pr-check-pill.required { color: var(--text); background: rgba(99, 102, 241, 0.08); border-color: rgba(99, 102, 241, 0.4); font-weight: 500; }
+.pr-check-pill.required.pass { color: #2ea043; background: rgba(46, 160, 67, 0.12); border-color: rgba(46, 160, 67, 0.45); }
+.pr-check-pill.required.gate { color: #d29922; background: rgba(210, 153, 34, 0.12); border-color: rgba(210, 153, 34, 0.4); }
+
+.pr-required-gate {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  padding: 8px 12px;
+  margin: 0 0 6px 0;
+  border-radius: 6px;
+  border: 1px solid var(--border);
+  background: var(--bg-elev);
+  font-size: 12px;
+}
+.pr-required-gate.pr-required-blocking { border-color: rgba(210, 153, 34, 0.5); }
+.pr-required-gate.pr-required-all-pass { border-color: rgba(46, 160, 67, 0.4); }
+.pr-required-summary { color: var(--text-dim); }
+.pr-required-gate.pr-required-all-pass .pr-required-summary strong { color: #2ea043; }
+.pr-required-gate.pr-required-blocking .pr-required-summary strong { color: #d29922; }
+.pr-required-chips { display: flex; flex-wrap: wrap; gap: 4px; }
+.pr-required-chip {
+  display: inline-flex;
+  align-items: center;
+  padding: 2px 8px;
+  border-radius: 10px;
+  font-size: 11px;
+  border: 1px solid var(--border);
+  background: var(--bg);
+  color: var(--text-dim);
+}
+.pr-required-chip.pr-required-pass { color: #2ea043; border-color: rgba(46, 160, 67, 0.4); background: rgba(46, 160, 67, 0.08); }
+.pr-required-chip.pr-required-fail { color: #f85149; border-color: rgba(248, 81, 73, 0.4); background: rgba(248, 81, 73, 0.08); }
+.pr-required-chip.pr-required-pending { color: #d29922; border-color: rgba(210, 153, 34, 0.4); background: rgba(210, 153, 34, 0.08); }
+.pr-required-chip.pr-required-cancel,
+.pr-required-chip.pr-required-skipping { color: var(--text-dim); }
+.pr-required-chip.pr-required-missing { color: var(--text-dim); border-style: dashed; }
+
+.pr-check-dur {
+  color: var(--text-dim);
+  font-size: 11px;
+  margin: 0 6px;
+  white-space: nowrap;
+}
+
+.pr-check-group {
+  margin: 6px 0;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  overflow: hidden;
+  background: var(--bg);
+}
+.pr-check-group-fail { border-color: rgba(248, 81, 73, 0.4); }
+.pr-check-group-pending { border-color: rgba(210, 153, 34, 0.4); }
+.pr-check-group-pass { border-color: rgba(46, 160, 67, 0.3); }
+.pr-check-group-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 6px 12px;
+  background: var(--bg-elev);
+  border-bottom: 1px solid var(--border);
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: var(--text-dim);
+}
+.pr-check-group-label { color: var(--text); font-weight: 500; text-transform: none; letter-spacing: 0; }
+.pr-check-group-meta { font-size: 11px; }
+
+.pr-check-annotations-btn,
+.pr-check-action-btn {
+  font-size: 11px;
+  padding: 2px 8px;
+  margin-right: 4px;
+  border-radius: 4px;
+  border: 1px solid var(--border);
+  background: var(--bg);
+  color: var(--text-dim);
+  cursor: pointer;
+}
+.pr-check-annotations-btn:hover,
+.pr-check-action-btn:hover { color: var(--text); border-color: var(--text-dim); }
+.pr-check-action-btn.pr-check-action-cancel { color: #f85149; border-color: rgba(248, 81, 73, 0.3); }
+.pr-check-action-btn.pr-check-action-cancel:hover { background: rgba(248, 81, 73, 0.1); border-color: rgba(248, 81, 73, 0.5); }
+
+.pr-check-annotations-panel {
+  margin: 4px 0 8px 0;
+  padding: 8px 12px;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  background: var(--bg-elev);
+  font-size: 12px;
+}
+.pr-check-annotations-empty { color: var(--text-dim); font-style: italic; }
+.pr-annotation {
+  padding: 6px 0;
+  border-bottom: 1px solid var(--border);
+}
+.pr-annotation:last-child { border-bottom: none; }
+.pr-annotation-head {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-bottom: 3px;
+}
+.pr-annotation-level {
+  display: inline-block;
+  font-size: 10px;
+  padding: 1px 6px;
+  border-radius: 3px;
+  text-transform: uppercase;
+  background: rgba(128, 128, 128, 0.15);
+  color: var(--text-dim);
+}
+.pr-annotation-failure .pr-annotation-level { color: #f85149; background: rgba(248, 81, 73, 0.12); }
+.pr-annotation-warning .pr-annotation-level { color: #d29922; background: rgba(210, 153, 34, 0.12); }
+.pr-annotation-loc { font-family: var(--font-mono, monospace); font-size: 11px; color: var(--text-dim); }
+.pr-annotation-title { color: var(--text); font-weight: 500; }
+.pr-annotation-msg { color: var(--text); white-space: pre-wrap; }
+.pr-annotation-raw {
+  font-family: var(--font-mono, monospace);
+  font-size: 11px;
+  color: var(--text-dim);
+  background: var(--bg);
+  padding: 6px 8px;
+  margin-top: 4px;
+  border-radius: 3px;
+  white-space: pre-wrap;
+  overflow-x: auto;
+}
 
 .pr-check-dot {
   color: var(--text-dim);
@@ -5513,6 +5644,149 @@ body.pr-review-popout #pr-review-root {
   font-size: 11px;
   color: var(--text-muted);
 }
+
+.pr-check-debug-open-task {
+  display: inline-block;
+  margin: 6px 12px 8px 12px;
+  padding: 4px 10px;
+  font-size: 11px;
+  border-radius: 4px;
+  border: 1px solid var(--accent);
+  background: rgba(99, 102, 241, 0.08);
+  color: var(--accent);
+  cursor: pointer;
+}
+.pr-check-debug-open-task:hover { background: rgba(99, 102, 241, 0.16); }
+.pr-check-debug-open-task:disabled { opacity: 0.6; cursor: default; }
+
+.pr-check-log-watch-panel {
+  margin: 4px 0 8px 0;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  background: var(--bg);
+  overflow: hidden;
+}
+.pr-check-log-watch-head {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 6px 12px;
+  background: var(--bg-elev);
+  border-bottom: 1px solid var(--border);
+  font-size: 12px;
+  color: var(--text-dim);
+}
+.pr-check-log-watch-head span { color: var(--text); }
+.pr-check-log-watch-stop {
+  font-size: 11px;
+  padding: 2px 8px;
+  border-radius: 4px;
+  border: 1px solid var(--border);
+  background: var(--bg);
+  color: var(--text-dim);
+  cursor: pointer;
+}
+.pr-check-log-watch-stop:hover { color: #f85149; border-color: rgba(248, 81, 73, 0.4); }
+.pr-check-log-watch-body {
+  margin: 0;
+  padding: 8px 12px;
+  font-family: 'SF Mono', Menlo, monospace;
+  font-size: 11px;
+  color: var(--text);
+  background: var(--bg);
+  max-height: 320px;
+  overflow: auto;
+  white-space: pre-wrap;
+  word-break: break-all;
+}
+
+.pr-checks-tab-actions { display: flex; gap: 6px; }
+
+.pr-workflow-dispatch-modal-backdrop {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.4);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 1000;
+}
+.pr-workflow-dispatch-modal {
+  width: 480px;
+  max-width: 90vw;
+  background: var(--bg);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  box-shadow: 0 20px 50px rgba(0, 0, 0, 0.4);
+  display: flex;
+  flex-direction: column;
+}
+.pr-workflow-dispatch-head {
+  padding: 12px 16px;
+  border-bottom: 1px solid var(--border);
+  font-weight: 600;
+  font-size: 14px;
+  color: var(--text);
+}
+.pr-workflow-dispatch-body {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  padding: 14px 16px;
+}
+.pr-workflow-dispatch-body label {
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: var(--text-dim);
+  margin-top: 6px;
+}
+.pr-workflow-dispatch-body label:first-child { margin-top: 0; }
+.pr-workflow-dispatch-body select,
+.pr-workflow-dispatch-body input,
+.pr-workflow-dispatch-body textarea {
+  width: 100%;
+  padding: 6px 8px;
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  background: var(--bg-elev);
+  color: var(--text);
+  font-size: 12px;
+  font-family: inherit;
+}
+.pr-workflow-dispatch-body textarea {
+  font-family: 'SF Mono', Menlo, monospace;
+  min-height: 70px;
+  resize: vertical;
+}
+.pr-workflow-dispatch-error {
+  font-size: 12px;
+  color: #f85149;
+  padding: 6px 0 0 0;
+  white-space: pre-wrap;
+}
+.pr-workflow-dispatch-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 8px;
+  padding: 10px 16px;
+  border-top: 1px solid var(--border);
+}
+.pr-workflow-dispatch-actions button {
+  padding: 6px 14px;
+  font-size: 12px;
+  border-radius: 4px;
+  border: 1px solid var(--border);
+  background: var(--bg-elev);
+  color: var(--text);
+  cursor: pointer;
+}
+.pr-workflow-dispatch-go {
+  background: var(--accent) !important;
+  color: #fff !important;
+  border-color: var(--accent) !important;
+}
+.pr-workflow-dispatch-go:disabled { opacity: 0.6; cursor: default; }
 
 .pr-ai-implement-all {
   background: var(--accent) !important;

--- a/renderer/terminal-manager.js
+++ b/renderer/terminal-manager.js
@@ -317,7 +317,11 @@ window.TerminalManager = (function () {
     });
 
     window.klaus.task.getNotifyEnabled(id).then(function (val) {
-      taskEntry.notifyEnabled = val;
+      // Returns {idle, ci}; keep notifyEnabled mirroring idle for legacy callers.
+      var idle = (val && typeof val === 'object') ? val.idle : val;
+      var ci = (val && typeof val === 'object') ? val.ci : true;
+      taskEntry.notifyEnabled = idle !== false;
+      taskEntry.notifyCIEnabled = ci !== false;
     });
 
     Sidebar.renderItem(taskEntry);


### PR DESCRIPTION
## Summary

Twelve improvements to the PR review window's **Checks** tab and the task-sidebar CI signal, plus a richer Claude-driven debug flow when CI fails.

## What ships

**Surface-area improvements (Checks tab):**
- **Required-checks gate** — `X/Y required checks passing` header + chip list (pass=green, fail=red, pending=amber, missing=dashed). Falls open with an explicit "unknown — verify on GitHub before merging" state when branch protection can't be loaded, so we don't silently green-light merges.
- **Per-workflow-run grouping** — multi-job runs collapse under a header showing workflow name, job count, and aggregate duration. Singletons stay flat.
- **Per-row duration** — `· 12m` style suffix on every check row (panel view too).
- **Inline annotations** — `Annotations` button on failing rows expands a panel with file:line errors pulled from `/check-runs/{id}/annotations`. Lazy-fetched on click.
- **Rerun failed jobs** — `Rerun` button on failed rows. Confirms, kicks `gh run rerun --failed`, and refreshes just the Checks slot in place (no full-tab flash).
- **Cancel in-progress run** — `Cancel` button on pending rows. Same shape as Rerun.
- **Live log tail** — `Watch log` on pending rows opens a side panel that polls `gh run view --log` every 3s with stick-to-bottom auto-scroll. Caps at 10 MB and fails closed with a real error after 3 consecutive fetch failures.
- **Workflow dispatch** — `Dispatch workflow…` header button → modal with workflow dropdown, ref input (defaults to PR head), JSON inputs textarea.
- **Auto-refresh** — Checks tab refreshes on activation and polls every 15s while active. Stops on tab switch / PR change.

**Debug flow upgrade:**
- Prompt now feeds Claude **annotations** (top 10) + the matching **workflow YAML** + the **job-specific log** (promoted from fallback to primary). Pre-localized fix hints land in the prompt instead of getting buried in 400 lines of run log.
- **Open as task** button on the completed analysis: ensures the PR's worktree exists, finds or spawns a Claude task in it, pastes the analysis as the first prompt via bracketed-paste. Logs + emits a paste-failed event if the pty.write throws (so an empty terminal doesn't reach the user with zero diagnostic).

**Notifications:**
- macOS notification when a watched task's CI flips pending → pass/fail and the app isn't focused. Per-task toggle in the right-click menu (defaults on). Reuses the existing idle-notification helpers in `main/state/instances.js`.

**Foundation work:**
- `normalizeCheckRun` preserves `id`, `runId`, `jobId`, `startedAt`, `completedAt`, `summary`, `appSlug`. `pr-checks` switched from pre-normalized `gh pr checks` to `gh api .../check-runs` so the panel view also gets rich fields.
- `set-notify-enabled` IPC extended with `kind: 'idle'|'ci'`; legacy boolean prefs auto-migrate to `{idle, ci}`.

## Audit fixes (silent-failure-hunter)

A `silent-failure-hunter` pass over the initial commit found six issues — all addressed in follow-up commits before merge:
- **CRITICAL:** `pr-debug-check-open-task` setTimeout `pty.write` no longer silently swallows; logs + emits paste-failed event.
- **HIGH:** `pr-review-run-log-watch` tracks consecutive failures and aborts after 3 with a real error instead of spinning forever on auth/403/wrong-runId.
- **HIGH:** `pr-checks` and `pr-review-checks` JSON-parse failures now surface as errors (HTML auth-redirects coming back as 200 used to look identical to "no checks reported").
- **MEDIUM (correctness):** `fetchRequiredContexts` parse error returns an error string; renderer renders "unknown" gate state to prevent false merge green-lighting.
- **MEDIUM:** Annotations + workflow-YAML enrichment failures log to main.log so token-scope issues are recoverable from logs.

## Files

- `main/ipc/pr-review.js` — bulk of new IPC handlers (required-checks, annotations, rerun, cancel, log watch, workflow dispatch).
- `main/ipc/claude-stream-ipc.js` — debug prompt augmentation, open-as-task.
- `main/state/ci-poll.js` — last-bucket memory + flip detection.
- `main/state/instances.js` — `sendCIFlipNotification` helper, `notifyCIEnabled` init.
- `main/ipc/tasks.js` — extended notify-enabled IPC.
- `preload.js` — new bridge methods on the `pr` namespace.
- `renderer/pr-review.js` — Checks tab rebuild (groups, duration, annotations panel, action buttons, dispatch modal, auto-refresh).
- `renderer/pr-panel.js` — duration suffix + required pill.
- `renderer/app.js`, `renderer/terminal-manager.js` — CI notify menu + new prefs shape.
- `renderer/styles.css` — CSS for required gate, group headers, log-watch panel, dispatch modal.

No new dependencies.

## Test plan

- [x] `npm test` (40 unit tests pass)
- [x] `npm run start` boots without main-process errors
- [x] Checks tab renders correctly on a PR with mixed pass/fail/pending checks
- [x] Auto-refresh kicks in on tab activation and polls 15s while visible
- [x] Rerun starts a new run and refreshes the slot in place (no full-tab flash)
- [ ] Required-checks gate against a PR whose base branch has protection (need fixture)
- [ ] Annotations panel against a check that emits annotations (eslint, mypy, etc.)
- [ ] Live log tail against an in-progress run
- [ ] Workflow dispatch against a workflow with `workflow_dispatch` trigger
- [ ] CI flip notification with the app unfocused

The unchecked items need fixture data that wasn't on hand during local testing — recommend exercising them on a real PR before relying on them in workflow.

## Commits

- `1f68247` initial 12-feature implementation
- `3b902fa` silent-failure-hunter fixes (CRITICAL + 2 HIGH + 1 MEDIUM)
- `48c8783` log-only fixes for best-effort enrichment paths
- `6bd4447` Checks-tab UX feedback (annotations error, rerun flash, auto-refresh)