### PR TITLE
Searchable dropdowns for repo/session filters, resume picker, and PR list

### DIFF
--- a/e2e/create-task.spec.js
+++ b/e2e/create-task.spec.js
@@ -69,3 +69,39 @@ test('create-task spawns a worktree on a new branch', async ({ mainWindow }) => 
     fs.rmSync(sessionDir, { recursive: true, force: true });
   }
 });
+
+test('create-task preserves the session name casing in the branch', async ({ mainWindow }) => {
+  await mainWindow.waitForLoadState('networkidle');
+
+  const repo = buildBaseRepo();
+  // Mixed-case name: the branch (and session folder) must keep the exact
+  // casing the user typed — "FEAT-Bar", never lowercased to "feat-bar".
+  const repoBasename = path.basename(repo);
+  const taskName = 'FEAT-Bar';
+  const sessionDir = path.join(os.homedir(), 'klaussy', 'sessions', taskName);
+  const expectedWorktree = path.join(sessionDir, repoBasename);
+
+  let taskId = null;
+  try {
+    const result = await mainWindow.evaluate(
+      ({ name, repoPath }) => window.klaus.task.create(name, repoPath, 'shell'),
+      { name: taskName, repoPath: repo },
+    );
+
+    expect(result.error, `create-task error: ${result.error}`).toBeFalsy();
+    expect(result.branch).toBe(taskName);
+    expect(result.worktreePath).toBe(expectedWorktree);
+    taskId = result.id;
+
+    // Real git branch keeps the casing too (not just the returned value).
+    expect(gitOut(expectedWorktree, 'rev-parse', '--abbrev-ref', 'HEAD')).toBe(taskName);
+  } finally {
+    if (taskId != null) {
+      await mainWindow.evaluate((id) => window.klaus.task.kill(id), taskId).catch(() => {});
+    }
+    try { execFileSync('git', ['worktree', 'remove', '--force', expectedWorktree], { cwd: repo, stdio: 'pipe' }); } catch {}
+    try { execFileSync('git', ['branch', '-D', taskName], { cwd: repo, stdio: 'pipe' }); } catch {}
+    fs.rmSync(repo, { recursive: true, force: true });
+    fs.rmSync(sessionDir, { recursive: true, force: true });
+  }
+});

--- a/main/ipc/tasks.js
+++ b/main/ipc/tasks.js
@@ -256,7 +256,9 @@ ipcMain.handle('create-task', async (_event, { name, repoPath, mode, basePath, e
     return { error: 'Active project is not a git repository. Remove and re-add the project to initialize git.' };
   }
 
-  const sanitized = name.replace(/[^a-zA-Z0-9_-]/g, '-').toLowerCase();
+  // Preserve the case the user typed: the branch (and session folder) must
+  // match the session name's casing, e.g. "FEAT" → branch "FEAT", not "feat".
+  const sanitized = name.replace(/[^a-zA-Z0-9_-]/g, '-');
   const branch = sanitized;
 
   // Default layout: one folder per session holding every repo's worktree —
@@ -742,7 +744,8 @@ ipcMain.handle('checkout-branch', async (_event, { repoPath, branch, mode, baseP
     return { error: 'Not a git repository: ' + repoPath };
   }
 
-  const sanitized = branch.replace(/[^a-zA-Z0-9_-]/g, '-').toLowerCase();
+  // Preserve case so the session folder matches the branch's casing.
+  const sanitized = branch.replace(/[^a-zA-Z0-9_-]/g, '-');
   const repoBasename = path.basename(repoPath);
   // Same session-folder layout as create-task: ~/klaussy/sessions/<session>/<repo>.
   const worktreeDir = basePath || path.join(os.homedir(), 'klaussy', 'sessions', sanitized);
@@ -1153,7 +1156,8 @@ ipcMain.handle('duplicate-task', async (_event, { id }) => {
   if (!repoPath) return { error: 'No repo configured' };
 
   const baseName = inst.name + '-copy';
-  const sanitized = baseName.replace(/[^a-zA-Z0-9_-]/g, '-').toLowerCase();
+  // Preserve case so the duplicate's branch/folder match the session name.
+  const sanitized = baseName.replace(/[^a-zA-Z0-9_-]/g, '-');
   const branch = `task/${sanitized}`;
   const worktreeDir = getWorktreeDir(repoPath);
   const worktreePath = path.join(worktreeDir, sanitized);

--- a/renderer/app-functions-2.js
+++ b/renderer/app-functions-2.js
@@ -375,9 +375,13 @@ window.App = window.App || {};
           + '<input type="text" class="pr-picker-url" placeholder="Paste a GitHub PR URL" />'
           + '<button class="pr-picker-start" type="button" disabled>Start review</button>'
         + '</div>'
+        + '<div class="pr-picker-search-row">'
+          + '<input type="text" class="pr-picker-search" placeholder="Search loaded PRs by title, number, author or repo\u2026" autocomplete="off" spellcheck="false" />'
+        + '</div>'
         + '<div class="pr-picker-recent"></div>'
         + '<div class="pr-picker-list"><div class="pr-picker-loading">Loading open PRs\u2026</div></div>'
         + '<div class="pr-picker-authored"></div>'
+        + '<div class="pr-picker-no-matches" hidden>No loaded PRs match your search.</div>'
         + '<div class="pr-picker-footer"><button class="pr-picker-cancel">Cancel</button></div>'
       + '</div>';
     document.body.appendChild(overlay);
@@ -395,6 +399,54 @@ window.App = window.App || {};
     var recentEl = overlay.querySelector('.pr-picker-recent');
     var listEl = overlay.querySelector('.pr-picker-list');
     var authoredEl = overlay.querySelector('.pr-picker-authored');
+    var searchEl = overlay.querySelector('.pr-picker-search');
+    var noMatchesEl = overlay.querySelector('.pr-picker-no-matches');
+
+    // Client-side filter over whatever PRs are currently rendered across the
+    // three sections. Each row's textContent already carries number, title,
+    // author and (for the grouped list) repo, so a substring test covers them.
+    // Group/section headers hide when nothing under them survives.
+    function applyPrFilter() {
+      var q = (searchEl.value || '').trim().toLowerCase();
+      var anyVisible = false;
+      [recentEl, listEl, authoredEl].forEach(function (container) {
+        if (!container) return;
+        container.querySelectorAll('.pr-picker-item').forEach(function (item) {
+          var match = !q || item.textContent.toLowerCase().indexOf(q) !== -1;
+          item.style.display = match ? '' : 'none';
+          if (match) anyVisible = true;
+        });
+        // Per-repo subheadings inside the grouped list.
+        container.querySelectorAll('.pr-picker-repo').forEach(function (label) {
+          var n = label.nextElementSibling, vis = false;
+          while (n && !n.classList.contains('pr-picker-repo') && !n.classList.contains('pr-picker-section-head')) {
+            if (n.classList.contains('pr-picker-item') && n.style.display !== 'none') { vis = true; break; }
+            n = n.nextElementSibling;
+          }
+          label.style.display = vis ? '' : 'none';
+        });
+        // Section heading ("Recently reviewed" etc.) hides when its section has
+        // no surviving rows.
+        var head = container.querySelector('.pr-picker-section-head');
+        if (head) {
+          var hasVisible = Array.prototype.some.call(
+            container.querySelectorAll('.pr-picker-item'),
+            function (it) { return it.style.display !== 'none'; });
+          head.style.display = (!q || hasVisible) ? '' : 'none';
+        }
+      });
+      // Only call out "no matches" once the user has actually typed something.
+      noMatchesEl.hidden = !q || anyVisible;
+    }
+
+    searchEl.addEventListener('input', applyPrFilter);
+    // Sections fill in asynchronously and re-render on account switch; re-apply
+    // the active filter whenever their contents change. Watching childList only
+    // (not attributes) means our own display toggles don't retrigger this.
+    var filterObserver = new MutationObserver(applyPrFilter);
+    [recentEl, listEl, authoredEl].forEach(function (el) {
+      filterObserver.observe(el, { childList: true, subtree: true });
+    });
     // The account the picker is browsing as. Lists run under this account's
     // token (no global switch); only opening a review (pr.load) switches the
     // global active account. Defaults to whatever gh account is active.

--- a/renderer/app.js
+++ b/renderer/app.js
@@ -587,6 +587,14 @@ window.App = window.App || {};
   App.modalCreate = document.getElementById('modal-create');
   App.modalCancel = document.getElementById('modal-cancel');
   App.existingSessionSelect = document.getElementById('existing-session-select');
+  // Searchable dropdown over the resume-session picker (the select stays the
+  // source of truth; populateExistingSessions keeps rewriting its <option>s).
+  if (window.SearchableSelect) {
+    window.SearchableSelect.enhance(App.existingSessionSelect, {
+      placeholder: 'Pick a session…',
+      searchPlaceholder: 'Search sessions…',
+    });
+  }
   App.modalRepoRow = document.getElementById('modal-repo-row');
   App.modalRepoPathEl = document.getElementById('modal-repo-path');
   App.modalRepoBrowseBtn = document.getElementById('btn-modal-repo-browse');

--- a/renderer/app.js
+++ b/renderer/app.js
@@ -669,6 +669,16 @@ window.App = window.App || {};
       App.modalBaseSelect.classList.remove('modal-field-invalid');
       if (App.modalError) App.modalError.textContent = '';
     });
+    // Searchable dropdown over the base-branch picker (branch lists get long).
+    // It mirrors the select's `hidden` toggle, so it stays invisible until
+    // branches load.
+    if (window.SearchableSelect) {
+      window.SearchableSelect.enhance(App.modalBaseSelect, {
+        className: 'ss-base-branch',
+        placeholder: 'Base branch',
+        searchPlaceholder: 'Search branches…',
+      });
+    }
   }
 
   // Discovery promises, cached per modal-open so toggling a dropdown doesn't

--- a/renderer/index.html
+++ b/renderer/index.html
@@ -12,6 +12,7 @@
   <link rel="stylesheet" href="styles/03-pr.css">
   <link rel="stylesheet" href="styles/04-editor.css">
   <link rel="stylesheet" href="styles/05-pr-review-surface.css">
+  <link rel="stylesheet" href="styles/06-searchable-select.css">
 </head>
 <body>
   <!-- Main app -->
@@ -583,6 +584,7 @@
   <script src="inline-complete.js"></script>
   <script src="word-complete.js"></script>
   <script src="about-log.js"></script>
+  <script src="searchable-select.js"></script>
   <script src="project-switcher.js"></script>
   <script src="agent-router.js"></script>
   <script src="agents-panel.js"></script>

--- a/renderer/project-switcher.js
+++ b/renderer/project-switcher.js
@@ -16,6 +16,14 @@ window.ProjectSwitcher = (function () {
   var sessionSelect = document.getElementById('session-select');
   var taskList = document.getElementById('task-list');
 
+  // Searchable dropdowns over the native selects (the selects stay the source
+  // of truth; refresh() keeps rebuilding their <option>s and the enhancer
+  // mirrors them). No-op if the enhancer failed to load.
+  if (window.SearchableSelect) {
+    window.SearchableSelect.enhance(repoSelect, { searchPlaceholder: 'Search repos…' });
+    window.SearchableSelect.enhance(sessionSelect, { searchPlaceholder: 'Search sessions…' });
+  }
+
   function basename(p) {
     if (!p) return '';
     var parts = p.replace(/\/+$/, '').split('/');

--- a/renderer/searchable-select.js
+++ b/renderer/searchable-select.js
@@ -1,0 +1,227 @@
+// Progressive-enhancement searchable dropdown.
+//
+// Wraps a native <select> — which stays the source of truth — with a custom
+// trigger button + popover that has a search box at the top and a filterable,
+// optgroup-aware list. The native select keeps doing everything it did before:
+// callers still populate it via innerHTML/appendChild, read `.value`, and
+// listen for 'change'. Picking an item just sets the select's value and
+// dispatches a native 'change' event, so existing wiring is untouched.
+//
+// Re-population (an innerHTML rewrite) is picked up via a MutationObserver, so
+// dropdowns that fill in asynchronously (sessions discovery, sidebar repo
+// filters) light up automatically.
+window.SearchableSelect = (function () {
+  var openInstance = null; // only one popover open at a time
+
+  function enhance(select, opts) {
+    if (!select || select.__ssEnhanced) return select && select.__ss;
+    opts = opts || {};
+    select.__ssEnhanced = true;
+
+    // Wrap the select so the custom UI lives right where the select did,
+    // inheriting its flex sizing from the parent row.
+    var wrap = document.createElement('div');
+    wrap.className = 'searchable-select';
+    if (opts.className) wrap.classList.add(opts.className);
+    select.parentNode.insertBefore(wrap, select);
+    wrap.appendChild(select);
+    select.classList.add('ss-native');
+
+    var trigger = document.createElement('button');
+    trigger.type = 'button';
+    trigger.className = 'ss-trigger';
+    trigger.innerHTML = '<span class="ss-label"></span><span class="ss-caret">▾</span>';
+    wrap.appendChild(trigger);
+    var labelEl = trigger.querySelector('.ss-label');
+
+    var popover = document.createElement('div');
+    popover.className = 'ss-popover';
+    popover.hidden = true;
+    popover.innerHTML =
+      '<div class="ss-search-row">'
+        + '<input type="text" class="ss-search" autocomplete="off" spellcheck="false" '
+        + 'placeholder="' + (opts.searchPlaceholder || 'Search…') + '" />'
+      + '</div>'
+      + '<div class="ss-list" role="listbox"></div>';
+    wrap.appendChild(popover);
+    var searchInput = popover.querySelector('.ss-search');
+    var listEl = popover.querySelector('.ss-list');
+
+    var activeEl = null; // keyboard-highlighted item
+
+    function selectedOption() {
+      return select.options[select.selectedIndex] || null;
+    }
+
+    function syncLabel() {
+      var opt = selectedOption();
+      var text = opt ? opt.textContent : '';
+      labelEl.textContent = text || (opts.placeholder || 'Select…');
+      // Dim when the empty/"all"/placeholder option is selected.
+      trigger.classList.toggle('ss-placeholder', !opt || opt.value === '');
+      trigger.title = (opt && opt.title) || text || '';
+    }
+
+    function buildList() {
+      listEl.innerHTML = '';
+      var sel = select.value;
+
+      function addOption(opt) {
+        var item = document.createElement('div');
+        item.className = 'ss-item';
+        item.setAttribute('role', 'option');
+        item.dataset.value = opt.value;
+        item.textContent = opt.textContent;
+        if (opt.title) item.title = opt.title;
+        if (opt.disabled) item.classList.add('ss-disabled');
+        if (opt.value === sel) item.classList.add('ss-selected');
+        // mousedown (not click) so the search input doesn't blur-close first.
+        item.addEventListener('mousedown', function (e) {
+          e.preventDefault();
+          if (!opt.disabled) choose(opt.value);
+        });
+        item.addEventListener('mousemove', function () { setActive(item); });
+        listEl.appendChild(item);
+      }
+
+      Array.prototype.forEach.call(select.children, function (node) {
+        if (node.tagName === 'OPTGROUP') {
+          var head = document.createElement('div');
+          head.className = 'ss-group';
+          head.textContent = node.label;
+          listEl.appendChild(head);
+          Array.prototype.forEach.call(node.children, function (o) {
+            if (o.tagName === 'OPTION') addOption(o);
+          });
+        } else if (node.tagName === 'OPTION') {
+          addOption(node);
+        }
+      });
+
+      var empty = document.createElement('div');
+      empty.className = 'ss-empty';
+      empty.textContent = 'No matches';
+      empty.hidden = true;
+      listEl.appendChild(empty);
+
+      filter(searchInput.value);
+    }
+
+    function filter(q) {
+      q = (q || '').trim().toLowerCase();
+      var any = false;
+      listEl.querySelectorAll('.ss-item').forEach(function (item) {
+        var match = !q || item.textContent.toLowerCase().indexOf(q) !== -1;
+        item.hidden = !match;
+        if (match) any = true;
+      });
+      // Hide a group header when nothing under it survives the filter.
+      listEl.querySelectorAll('.ss-group').forEach(function (head) {
+        var n = head.nextElementSibling;
+        var visible = false;
+        while (n && !n.classList.contains('ss-group')) {
+          if (n.classList.contains('ss-item') && !n.hidden) { visible = true; break; }
+          n = n.nextElementSibling;
+        }
+        head.hidden = !visible;
+      });
+      var emptyEl = listEl.querySelector('.ss-empty');
+      if (emptyEl) emptyEl.hidden = any;
+      setActive(listEl.querySelector('.ss-item:not([hidden]):not(.ss-disabled)'));
+    }
+
+    function setActive(item) {
+      if (activeEl) activeEl.classList.remove('ss-active');
+      activeEl = item || null;
+      if (activeEl) {
+        activeEl.classList.add('ss-active');
+        activeEl.scrollIntoView({ block: 'nearest' });
+      }
+    }
+
+    function choose(value) {
+      if (select.value !== value) {
+        select.value = value;
+        select.dispatchEvent(new Event('change', { bubbles: true }));
+      }
+      syncLabel();
+      close();
+      trigger.focus();
+    }
+
+    function open() {
+      if (openInstance && openInstance !== api) openInstance.close();
+      openInstance = api;
+      buildList();
+      popover.hidden = false;
+      wrap.classList.add('ss-open');
+      searchInput.value = '';
+      filter('');
+      var selItem = listEl.querySelector('.ss-item.ss-selected:not([hidden])');
+      if (selItem) setActive(selItem);
+      setTimeout(function () { searchInput.focus(); }, 0);
+    }
+
+    function close() {
+      if (popover.hidden) return;
+      popover.hidden = true;
+      wrap.classList.remove('ss-open');
+      if (openInstance === api) openInstance = null;
+    }
+
+    trigger.addEventListener('click', function (e) {
+      e.preventDefault();
+      popover.hidden ? open() : close();
+    });
+
+    searchInput.addEventListener('input', function () { filter(searchInput.value); });
+
+    searchInput.addEventListener('keydown', function (e) {
+      var visible = Array.prototype.slice.call(
+        listEl.querySelectorAll('.ss-item:not([hidden]):not(.ss-disabled)'));
+      var idx = visible.indexOf(activeEl);
+      if (e.key === 'ArrowDown') {
+        e.preventDefault();
+        setActive(visible[Math.min(idx + 1, visible.length - 1)] || visible[0]);
+      } else if (e.key === 'ArrowUp') {
+        e.preventDefault();
+        setActive(visible[Math.max(idx - 1, 0)] || visible[0]);
+      } else if (e.key === 'Enter') {
+        e.preventDefault();
+        if (activeEl) choose(activeEl.dataset.value);
+      } else if (e.key === 'Escape') {
+        e.preventDefault();
+        close();
+        trigger.focus();
+      }
+    });
+
+    // Click outside closes.
+    document.addEventListener('mousedown', function (e) {
+      if (!popover.hidden && !wrap.contains(e.target)) close();
+    });
+
+    // External re-population (innerHTML rewrite) → refresh label, and rebuild
+    // the list if the popover is currently open.
+    var mo = new MutationObserver(function () {
+      syncLabel();
+      if (!popover.hidden) buildList();
+    });
+    mo.observe(select, { childList: true, subtree: true });
+
+    // Other code may set the value and dispatch 'change' — keep our label honest.
+    select.addEventListener('change', syncLabel);
+
+    syncLabel();
+
+    var api = {
+      open: open,
+      close: close,
+      refresh: function () { syncLabel(); if (!popover.hidden) buildList(); },
+    };
+    select.__ss = api;
+    return api;
+  }
+
+  return { enhance: enhance };
+})();

--- a/renderer/searchable-select.js
+++ b/renderer/searchable-select.js
@@ -201,13 +201,20 @@ window.SearchableSelect = (function () {
       if (!popover.hidden && !wrap.contains(e.target)) close();
     });
 
+    // Mirror the select's own `hidden` attribute onto the wrapper: some callers
+    // toggle `select.hidden` to show/hide the entire control (e.g. the base
+    // branch picker, hidden until branches load).
+    function syncHidden() { wrap.hidden = select.hidden; }
+    syncHidden();
+
     // External re-population (innerHTML rewrite) → refresh label, and rebuild
-    // the list if the popover is currently open.
+    // the list if the popover is currently open. Also catches `hidden` toggles.
     var mo = new MutationObserver(function () {
+      syncHidden();
       syncLabel();
       if (!popover.hidden) buildList();
     });
-    mo.observe(select, { childList: true, subtree: true });
+    mo.observe(select, { childList: true, subtree: true, attributes: true, attributeFilter: ['hidden'] });
 
     // Other code may set the value and dispatch 'change' — keep our label honest.
     select.addEventListener('change', syncLabel);

--- a/renderer/styles/06-searchable-select.css
+++ b/renderer/styles/06-searchable-select.css
@@ -8,6 +8,12 @@
   min-width: 0;
 }
 
+/* Author display above would otherwise override the [hidden] UA rule; keep the
+ * wrapper hideable so callers toggling the native select's `hidden` work. */
+.searchable-select[hidden] {
+  display: none;
+}
+
 /* The native select is kept for state/events but never shown. */
 .searchable-select .ss-native {
   display: none;
@@ -122,11 +128,13 @@
   padding: 6px 8px;
   border-radius: 4px;
   font-size: 12px;
+  line-height: 1.35;
   color: var(--text);
   cursor: pointer;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
+  /* Wrap long names so the full session/branch/repo is readable — the popover
+   * can't widen past the (overflow-hidden) sidebar without being clipped. */
+  white-space: normal;
+  overflow-wrap: anywhere;
 }
 
 .ss-item.ss-active {
@@ -166,6 +174,30 @@
   border-radius: 8px;
   padding: 12px;
   font-size: 13px;
+}
+
+/* Base-branch picker in the New Session source-repo row: compact, non-growing,
+ * matching the original .mr-base select. The popover needs more room than the
+ * trigger, so let it widen and anchor to the right edge. */
+.searchable-select.ss-base-branch {
+  flex: 0 0 auto;
+  max-width: 150px;
+}
+.ss-base-branch .ss-trigger {
+  background: var(--surface-hover);
+  color: var(--text-muted);
+  border-radius: 4px;
+  padding: 2px 4px;
+}
+.ss-base-branch .ss-trigger:hover,
+.ss-base-branch.ss-open .ss-trigger,
+.ss-base-branch .ss-trigger:focus {
+  color: var(--text);
+}
+.ss-base-branch .ss-popover {
+  left: auto;
+  right: 0;
+  min-width: 220px;
 }
 
 /* ── PR picker search box ─────────────────────────────────────────────── */

--- a/renderer/styles/06-searchable-select.css
+++ b/renderer/styles/06-searchable-select.css
@@ -1,0 +1,195 @@
+/* Searchable dropdown (SearchableSelect) — a custom trigger + popover that
+ * replaces the visual of a native <select> while the select itself stays in the
+ * DOM as the hidden source of truth. Also styles the PR picker's search box. */
+
+.searchable-select {
+  position: relative;
+  display: flex;
+  min-width: 0;
+}
+
+/* The native select is kept for state/events but never shown. */
+.searchable-select .ss-native {
+  display: none;
+}
+
+.ss-trigger {
+  flex: 1;
+  min-width: 0;
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  background: var(--input-bg);
+  color: var(--text);
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  padding: 4px 6px;
+  font-size: 11px;
+  font-family: 'SF Mono', 'Fira Code', Menlo, monospace;
+  text-align: left;
+  cursor: pointer;
+  outline: none;
+}
+
+.ss-trigger .ss-label {
+  flex: 1;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.ss-trigger.ss-placeholder .ss-label {
+  color: var(--text-muted, var(--text-dim, var(--text)));
+  opacity: 0.85;
+}
+
+.ss-trigger .ss-caret {
+  flex-shrink: 0;
+  opacity: 0.6;
+  font-size: 10px;
+}
+
+.searchable-select.ss-open .ss-trigger,
+.ss-trigger:focus {
+  border-color: var(--accent);
+}
+
+/* Mirror native validation styling onto the trigger. */
+.ss-native.modal-field-invalid + .ss-trigger {
+  border-color: var(--error);
+}
+
+/* Setting display on the popover would otherwise override the [hidden]
+ * attribute's UA display:none, leaving it permanently open. */
+.ss-popover[hidden] {
+  display: none;
+}
+
+.ss-popover {
+  position: absolute;
+  top: calc(100% + 4px);
+  left: 0;
+  right: 0;
+  z-index: 1000;
+  display: flex;
+  flex-direction: column;
+  max-height: 320px;
+  background: var(--surface, var(--bg));
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.35);
+  overflow: hidden;
+}
+
+.ss-search-row {
+  padding: 6px;
+  border-bottom: 1px solid var(--border);
+}
+
+.ss-search {
+  width: 100%;
+  box-sizing: border-box;
+  background: var(--input-bg, var(--bg));
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  padding: 5px 8px;
+  color: var(--text);
+  font-size: 12px;
+  font-family: inherit;
+  outline: none;
+}
+
+.ss-search:focus {
+  border-color: var(--accent);
+}
+
+.ss-list {
+  overflow-y: auto;
+  padding: 4px;
+}
+
+.ss-group {
+  padding: 6px 8px 2px;
+  font-size: 10px;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: var(--text-muted, var(--text-dim, var(--text)));
+  opacity: 0.8;
+}
+
+.ss-item {
+  padding: 6px 8px;
+  border-radius: 4px;
+  font-size: 12px;
+  color: var(--text);
+  cursor: pointer;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.ss-item.ss-active {
+  background: var(--surface-hover, rgba(127, 127, 127, 0.15));
+}
+
+.ss-item.ss-selected {
+  color: var(--accent);
+  font-weight: 600;
+}
+
+.ss-item.ss-disabled {
+  opacity: 0.5;
+  cursor: default;
+}
+
+.ss-empty {
+  padding: 10px 8px;
+  font-size: 12px;
+  text-align: center;
+  color: var(--text-muted, var(--text-dim, var(--text)));
+  opacity: 0.8;
+}
+
+/* Sidebar repo/session filters: keep the compact 11px monospace look. */
+#project-switcher .searchable-select {
+  flex: 1;
+}
+
+/* New Session modal "resume existing session" picker: larger dashed box to
+ * match the original select. */
+#existing-session-row .searchable-select {
+  flex: 1;
+}
+#existing-session-row .ss-trigger {
+  border-style: dashed;
+  border-radius: 8px;
+  padding: 12px;
+  font-size: 13px;
+}
+
+/* ── PR picker search box ─────────────────────────────────────────────── */
+.pr-picker-search-row {
+  padding: 8px 16px;
+  border-bottom: 1px solid var(--border);
+}
+.pr-picker-search {
+  width: 100%;
+  box-sizing: border-box;
+  padding: 6px 8px;
+  background: var(--input-bg, var(--bg));
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  color: var(--text);
+  font-size: 12px;
+  font-family: inherit;
+  outline: none;
+}
+.pr-picker-search:focus { border-color: var(--accent); }
+.pr-picker-no-matches {
+  padding: 16px;
+  text-align: center;
+  font-size: 12px;
+  color: var(--text-muted, var(--text-dim, var(--text)));
+  opacity: 0.8;
+}


### PR DESCRIPTION
## What

Adds type-to-filter search to the long-list dropdowns:

- **Repo + session sidebar filters** (`#project-select`, `#session-select`)
- **New Session resume-session picker** (`#existing-session-select`, optgroup-aware)
- **PR review picker** overlay — search box filtering loaded PRs by title, number, author, or repo across all sections

## How

A reusable `SearchableSelect.enhance(select, opts)` (renderer/searchable-select.js) wraps each native `<select>` with a custom trigger + popover that has a slim search box at the top and a filterable, optgroup-aware list. Progressive enhancement: the native `<select>` stays the source of truth, so existing populate code (`innerHTML`/`appendChild`), `.value` reads, and `change` listeners are untouched. Picking an item sets `select.value` and dispatches a native `change` event. A `MutationObserver` re-syncs when the select is repopulated asynchronously.

Keyboard nav (↑/↓/Enter/Esc), click-outside dismiss, and theme-variable styling included. The PR picker (already a custom overlay) gets a `.pr-picker-search` input with a `MutationObserver` so the filter re-applies as sections load / re-render on account switch.

## Verification

- `npm run lint` — clean
- `npm test` — 49/49 pass
- Manually verified in-app.

🤖 Generated with [Claude Code](https://claude.com/claude-code)