### PR TITLE
release: v0.7.0 — move release home to klaussy-desktop

### DIFF
--- a/.github/workflows/build-platforms.yml
+++ b/.github/workflows/build-platforms.yml
@@ -20,6 +20,12 @@ on:
         type: string
         default: ''
 
+# contents:write lets the default GITHUB_TOKEN attach artifacts to a release on
+# THIS repo (klaussy-desktop) — the canonical release home. The feedback-repo
+# upload still needs the cross-repo FEEDBACK_REPO_TOKEN PAT.
+permissions:
+  contents: write
+
 jobs:
   build:
     strategy:
@@ -99,8 +105,8 @@ jobs:
           ESIGNER_CREDENTIAL_ID: ${{ inputs.sign && secrets.ESIGNER_CREDENTIAL_ID || '' }}
 
       # Best-effort upload to GH Actions artifact cache (14-day retention for
-      # ad-hoc debugging). The canonical destination is the feedback release
-      # below, so don't fail the run if this step hits storage quota.
+      # ad-hoc debugging). The canonical destination is the klaussy-desktop
+      # release below, so don't fail the run if this step hits storage quota.
       - name: Upload artifacts
         uses: actions/upload-artifact@v5
         continue-on-error: true
@@ -111,28 +117,50 @@ jobs:
           retention-days: 14
 
       # When release_tag is set, attach the built artifacts directly to the
-      # release on klaussy-desktop-feedback so the auto-updater (which polls
-      # that repo, not this one) and end users get a download link without a
-      # manual "trigger CI → grab artifacts → re-upload" step.
+      # release on klaussy-desktop (the canonical home) so the auto-updater
+      # (which, as of v0.7.0, polls this repo) and end users get a download
+      # link without a manual "trigger CI → grab artifacts → re-upload" step.
+      #
+      # Auth: the default GITHUB_TOKEN writes to this repo (see permissions
+      # block above) — no PAT needed.
+      - name: Upload artifacts to klaussy-desktop release
+        if: ${{ always() && inputs.release_tag != '' }}
+        shell: bash
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          # `gh release upload --clobber` so re-running the workflow on the same
+          # tag overwrites prior artifacts instead of failing.
+          mapfile -t files < <(ls dist/Klaussy-*.exe dist/Klaussy-*.AppImage dist/Klaussy-*.deb dist/latest.yml dist/latest-linux.yml 2>/dev/null || true)
+          if [ "${#files[@]}" -eq 0 ]; then
+            echo "::warning::No platform artifacts found in dist/; nothing to upload."
+            exit 0
+          fi
+          gh release upload "${{ inputs.release_tag }}" "${files[@]}" \
+            --repo steph-dove/klaussy-desktop \
+            --clobber
+
+      # MIGRATION BRIDGE (temporary): clients installed at v0.6.0 and earlier
+      # still poll klaussy-desktop-feedback for updates, so mirror this release
+      # there too. Once v0.7.0 (which polls klaussy-desktop) is broadly
+      # installed, this step can be deleted.
       #
       # Auth: GITHUB_TOKEN can't write to a different repo. A fine-scoped PAT
       # stored as FEEDBACK_REPO_TOKEN (contents:write on klaussy-desktop-feedback,
       # nothing else) is required. Without it the step is skipped.
-      - name: Upload artifacts to feedback release
+      - name: Mirror artifacts to feedback release (migration bridge)
         if: ${{ always() && inputs.release_tag != '' }}
         shell: bash
         env:
           GH_TOKEN: ${{ secrets.FEEDBACK_REPO_TOKEN }}
         run: |
           if [ -z "$GH_TOKEN" ]; then
-            echo "::warning::release_tag was provided but FEEDBACK_REPO_TOKEN is not set; skipping release upload."
+            echo "::warning::release_tag was provided but FEEDBACK_REPO_TOKEN is not set; skipping feedback-repo mirror."
             exit 0
           fi
-          # `gh release upload --clobber` so re-running the workflow on the same
-          # tag overwrites prior artifacts instead of failing.
           mapfile -t files < <(ls dist/Klaussy-*.exe dist/Klaussy-*.AppImage dist/Klaussy-*.deb dist/latest.yml dist/latest-linux.yml 2>/dev/null || true)
           if [ "${#files[@]}" -eq 0 ]; then
-            echo "::warning::No platform artifacts found in dist/; nothing to upload."
+            echo "::warning::No platform artifacts found in dist/; nothing to mirror."
             exit 0
           fi
           gh release upload "${{ inputs.release_tag }}" "${files[@]}" \

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Designed by an ex-GitHub, ex-Twitch, and ex-Microsoft engineer, Klaussy Desktop 
 
 Prebuilt, signed, and notarized binaries are available for macOS, Windows, and Linux. Free for individual use — no account or access key required.
 
-➡️ **[Download the Latest Release](https://github.com/steph-dove/klaussy-desktop-feedback/releases/latest)** &nbsp;|&nbsp; **[★ Star this Repo](https://github.com/steph-dove/klaussy-desktop)** &nbsp;|&nbsp; 💬 **[Join the Discord](https://discord.gg/ZxNhsuMyYu)**
+➡️ **[Download the Latest Release](https://github.com/steph-dove/klaussy-desktop/releases/latest)** &nbsp;|&nbsp; **[★ Star this Repo](https://github.com/steph-dove/klaussy-desktop)** &nbsp;|&nbsp; 💬 **[Join the Discord](https://discord.gg/ZxNhsuMyYu)**
 
 *   **macOS:** signed + notarized using Apple Developer ID. Drag `Klaussy.app` to `/Applications`.
 *   **Windows:** signed with an EV Code Signing certificate. Run the installer.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -26,7 +26,7 @@ public disclosure.
 ## Supported versions
 
 Security fixes are released against the **latest version** only. Always update
-to the newest release: <https://github.com/steph-dove/klaussy-desktop-feedback/releases/latest>.
+to the newest release: <https://github.com/steph-dove/klaussy-desktop/releases/latest>.
 
 ## Scope notes
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "klaussy-desktop",
   "productName": "Klaussy",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "description": "Multi-terminal Claude Code worktree manager + GitHub PR reviewer for macOS, Windows, and Linux",
   "main": "main.js",
   "author": {
@@ -187,7 +187,7 @@
     "publish": {
       "provider": "github",
       "owner": "steph-dove",
-      "repo": "klaussy-desktop-feedback",
+      "repo": "klaussy-desktop",
       "releaseType": "release"
     }
   }


### PR DESCRIPTION
Cuts **v0.7.0** and migrates the release / auto-update home from `klaussy-desktop-feedback` to `klaussy-desktop`.

## What's in v0.7.0 (since v0.6.0)
- feat: promote local Ollama to first-class agent & background PR monitor auto-fixer
- feat(intel): minimize prompt tokens via path-scoped rules + graph summaries
- feat(sidebar): session grouping, broadcast command bar, diff scope toggle
- feat(plan): Plan tab with Plan/Design view + plan-approval gate
- chore(license): remove licensing/activation — Klaussy is free
- test(e2e): full UI-path Playwright coverage + README polish

> Note: the `chore/force-klaussy-agents-upgrade` commit is intentionally **not** included.

## Release-home migration
- `package.json` → `build.publish.repo: klaussy-desktop` (the electron-updater feed). v0.7.0+ clients poll klaussy-desktop.
- `build-platforms.yml`: primary upload to klaussy-desktop via default `GITHUB_TOKEN` (added `permissions: contents: write`); **temporary migration-bridge** step mirrors the release to klaussy-desktop-feedback via `FEEDBACK_REPO_TOKEN` so existing v0.6.0 clients auto-update onto v0.7.0 and switch their feed. Remove the bridge once v0.7.0 is broadly installed.
- README / SECURITY download links → klaussy-desktop/releases/latest.

🤖 Generated with [Claude Code](https://claude.com/claude-code)