### PR TITLE
release: v0.7.1 — discoverable, dismissible broadcast bar

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "klaussy-desktop",
   "productName": "Klaussy",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "description": "Multi-terminal Claude Code worktree manager + GitHub PR reviewer for macOS, Windows, and Linux",
   "main": "main.js",
   "author": {

--- a/renderer/app.js
+++ b/renderer/app.js
@@ -987,15 +987,57 @@ window.App = window.App || {};
   // ---- Broadcast command bar logic ----
   var broadcastInput = document.getElementById('broadcast-input');
   var broadcastSend = document.getElementById('btn-broadcast-send');
+  var broadcastClose = document.getElementById('btn-broadcast-close');
+  var broadcastToggle = document.getElementById('broadcast-toggle');
+  var broadcastBar = document.getElementById('broadcast-bar');
+
+  // The session a broadcast would target: an explicitly selected session
+  // group, or the session that owns the currently focused terminal. Returns
+  // null when the user isn't inside a recognized session (e.g. a standalone
+  // local-folder task), which is also our cue to hide the broadcast UI.
+  function broadcastTargetSession() {
+    if (AppState.activeSessionName) return AppState.activeSessionName;
+    var t = AppState.activeTaskId != null ? AppState.tasks.get(AppState.activeTaskId) : null;
+    return (t && window.Sidebar) ? window.Sidebar.getSessionName(t) : null;
+  }
+
+  var broadcastExpanded = false;
+  try { broadcastExpanded = localStorage.getItem('broadcastExpanded') === '1'; } catch (e) {}
+
+  // Reconcile the collapsed pill / expanded bar against the current context
+  // and the user's persisted preference. Called whenever the active session or
+  // task changes.
+  function updateBroadcastUI() {
+    var inSession = !!broadcastTargetSession();
+    if (!inSession) {
+      if (broadcastBar) broadcastBar.classList.add('hidden');
+      if (broadcastToggle) broadcastToggle.classList.add('hidden');
+      return;
+    }
+    if (broadcastBar) broadcastBar.classList.toggle('hidden', !broadcastExpanded);
+    if (broadcastToggle) broadcastToggle.classList.toggle('hidden', broadcastExpanded);
+  }
+
+  function setBroadcastExpanded(expanded) {
+    broadcastExpanded = expanded;
+    try { localStorage.setItem('broadcastExpanded', expanded ? '1' : '0'); } catch (e) {}
+    updateBroadcastUI();
+    if (expanded && broadcastInput) broadcastInput.focus();
+  }
 
   async function sendBroadcast() {
     var val = broadcastInput.value.trim();
     if (!val) return;
-    broadcastInput.value = '';
+
+    var target = broadcastTargetSession();
+    if (!target) {
+      window.toast.error('Select a session to broadcast to');
+      return;
+    }
 
     var activeTasks = [];
     AppState.tasks.forEach(function(t) {
-      if (window.Sidebar && window.Sidebar.getSessionName(t) === AppState.activeSessionName) {
+      if (window.Sidebar && window.Sidebar.getSessionName(t) === target) {
         activeTasks.push(t);
       }
     });
@@ -1005,11 +1047,12 @@ window.App = window.App || {};
       return;
     }
 
+    broadcastInput.value = '';
     activeTasks.forEach(function(task) {
       window.klaus.terminal.write(task.id, val + '\r');
     });
 
-    window.toast.success('Broadcasted command to ' + activeTasks.length + ' terminals');
+    window.toast.success('Broadcasted command to ' + activeTasks.length + ' ' + (activeTasks.length === 1 ? 'agent' : 'agents'));
   }
 
   if (broadcastInput && broadcastSend) {
@@ -1017,6 +1060,9 @@ window.App = window.App || {};
       if (e.key === 'Enter') {
         e.preventDefault();
         sendBroadcast();
+      } else if (e.key === 'Escape') {
+        e.preventDefault();
+        setBroadcastExpanded(false);
       }
     });
     broadcastSend.addEventListener('click', function (e) {
@@ -1024,6 +1070,25 @@ window.App = window.App || {};
       sendBroadcast();
     });
   }
+  if (broadcastToggle) {
+    broadcastToggle.addEventListener('click', function (e) {
+      e.stopPropagation();
+      setBroadcastExpanded(true);
+    });
+  }
+  if (broadcastClose) {
+    broadcastClose.addEventListener('click', function (e) {
+      e.stopPropagation();
+      setBroadcastExpanded(false);
+    });
+  }
+
+  window.BroadcastBar = {
+    update: updateBroadcastUI,
+    expand: function () { setBroadcastExpanded(true); },
+    collapse: function () { setBroadcastExpanded(false); }
+  };
+  updateBroadcastUI();
 
   App.btnRunApp = document.getElementById('btn-run-app');
   if (App.btnRunApp) {

--- a/renderer/index.html
+++ b/renderer/index.html
@@ -244,10 +244,15 @@
           </div>
         </div>
         <div id="terminals"></div>
+        <button id="broadcast-toggle" class="hidden" title="Broadcast a command to every agent in this session">
+          <span class="broadcast-icon">&#128362;</span>
+          <span>Broadcast</span>
+        </button>
         <div id="broadcast-bar" class="hidden">
           <span class="broadcast-icon">&#128362;</span>
           <input type="text" id="broadcast-input" placeholder="Broadcast command to all active agents in session... (Enter to send)" autocomplete="off" spellcheck="false" />
           <button id="btn-broadcast-send">Send</button>
+          <button id="btn-broadcast-close" title="Dismiss" aria-label="Dismiss">&times;</button>
         </div>
       </div>
 

--- a/renderer/sidebar-manager.js
+++ b/renderer/sidebar-manager.js
@@ -21,10 +21,7 @@ window.Sidebar = (function () {
     taskList.querySelectorAll('.task-item').forEach(function(item) {
       item.classList.remove('active');
     });
-    var broadcastBar = document.getElementById('broadcast-bar');
-    if (broadcastBar) {
-      broadcastBar.classList.remove('hidden');
-    }
+    if (window.BroadcastBar) window.BroadcastBar.update();
     if (window.DiffPanel) {
       window.DiffPanel.updateSession(sessionName);
       window.DiffPanel.show();

--- a/renderer/styles/01-base.css
+++ b/renderer/styles/01-base.css
@@ -2887,3 +2887,59 @@ body.task-branchless #ahead-behind {
 #btn-broadcast-send:active {
   transform: scale(0.96);
 }
+
+#btn-broadcast-close {
+  background: transparent;
+  border: none;
+  color: var(--text-muted);
+  font-size: 18px;
+  line-height: 1;
+  padding: 0 2px;
+  cursor: pointer;
+  transition: color 0.2s, transform 0.1s;
+}
+
+#btn-broadcast-close:hover {
+  color: var(--text);
+}
+
+#btn-broadcast-close:active {
+  transform: scale(0.9);
+}
+
+/* Collapsed launcher — always visible inside a session, click to expand */
+#broadcast-toggle {
+  position: absolute;
+  bottom: 20px;
+  left: 50%;
+  transform: translateX(-50%);
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  background: rgba(22, 22, 28, 0.85);
+  backdrop-filter: blur(16px);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  box-shadow: 0 12px 40px rgba(0, 0, 0, 0.5), inset 0 1px 0 rgba(255, 255, 255, 0.03);
+  border-radius: 9999px;
+  padding: 8px 18px;
+  color: var(--text);
+  font-size: 12px;
+  font-weight: 600;
+  font-family: inherit;
+  cursor: pointer;
+  z-index: 1000;
+  transition: border-color 0.2s, box-shadow 0.2s, transform 0.2s cubic-bezier(0.4, 0, 0.2, 1), opacity 0.2s;
+  animation: slideUp 0.4s cubic-bezier(0.16, 1, 0.3, 1);
+}
+
+#broadcast-toggle:hover {
+  border-color: rgba(255, 255, 255, 0.16);
+  transform: translate(-50%, -2px);
+  box-shadow: 0 16px 48px rgba(0, 0, 0, 0.55), inset 0 1px 0 rgba(255, 255, 255, 0.05);
+}
+
+#broadcast-toggle.hidden {
+  opacity: 0;
+  transform: translate(-50%, 20px);
+  pointer-events: none;
+}

--- a/renderer/terminal-manager.js
+++ b/renderer/terminal-manager.js
@@ -962,6 +962,7 @@ window.TerminalManager = (function () {
         switchToTask(remaining[0]);
       } else {
         emptyState.style.display = 'flex';
+        if (window.BroadcastBar) window.BroadcastBar.update();
         if (window.BranchlessUI) window.BranchlessUI.apply(null);
         if (window.closeFileViewerOnTaskSwitch) window.closeFileViewerOnTaskSwitch(null);
       }
@@ -976,10 +977,7 @@ window.TerminalManager = (function () {
     AppState.activeSessionName = null;
     Sidebar.hideUnreadBadge(id);
 
-    var broadcastBar = document.getElementById('broadcast-bar');
-    if (broadcastBar) {
-      broadcastBar.classList.add('hidden');
-    }
+    if (window.BroadcastBar) window.BroadcastBar.update();
 
     taskList.querySelectorAll('.session-group-header').forEach(function (el) {
       el.classList.remove('active');


### PR DESCRIPTION
## Summary
Patch release **v0.7.1**. Makes the in-session **broadcast** feature discoverable instead of only surfacing when a session group header is selected.

- Persistent **"📢 Broadcast" pill** at the bottom of the terminal area whenever you're inside a recognized session — including when an individual agent terminal is focused (previously the bar disappeared on terminal focus).
- Click the pill → expands into the input bar; **✕** or **Esc** collapses it back. Choice persists across restarts (`localStorage`).
- Broadcast resolves its target session dynamically (selected session group, or the session owning the focused terminal) and refuses to send with a clear toast when not in a session — avoids matching unrelated `null`-session tasks. Input is no longer cleared on error.
- New `window.BroadcastBar` controller (`update`/`expand`/`collapse`) replaces the direct show/hide calls in `sidebar-manager` and `terminal-manager`.

## Files
- `renderer/index.html` — `#broadcast-toggle` pill + `#btn-broadcast-close`
- `renderer/app.js` — `window.BroadcastBar` controller, persisted state, dynamic target resolution
- `renderer/sidebar-manager.js` / `renderer/terminal-manager.js` — call `BroadcastBar.update()` at session-select / task-switch / last-task-closed
- `renderer/styles/01-base.css` — pill + close-button styles
- `package.json` — 0.7.0 → 0.7.1

## Verification
- `npm run lint` clean
- `npm test` — 75/75 pass
- Launched the app locally and confirmed the pill/expand/collapse flow

🤖 Generated with [Claude Code](https://claude.com/claude-code)