### PR TITLE
release: v0.7.2 — pr-review & plan/session UI fixes

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "klaussy-desktop",
   "productName": "Klaussy",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "description": "Multi-terminal Claude Code worktree manager + GitHub PR reviewer for macOS, Windows, and Linux",
   "main": "main.js",
   "author": {


### PR DESCRIPTION
## Summary
Patch release **v0.7.2**. Version bump only; ships everything merged to `main` since v0.7.1.

### Changes since v0.7.1
- **fix(pr-review):** only post inline finding comments on lines actually in the diff
- **fix(pr-review):** stop boxing prose suggestions as code
- **fix(pr-review):** inline diff anchor handling
- **feat(plan):** per-phase status icons + broader checklist parsing
- **feat(changes):** style per-repo sub-group headers in session scope
- **feat(release):** `npm run release:mac` dual-publishes mac artifacts

## Verification
- `npm run lint` clean
- `npm test` — 75/75 pass

## Release plan (after merge)
Tag `v0.7.2` → trigger `build-platforms.yml` (Linux + Windows, auto dual-publish to both repos via the create-if-missing fix) → local `npm run dist` + `npm run release:mac` for macOS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)