### PR TITLE
Review surface: suggestion-only comments, verdict recovery, per-file local commits

### DIFF
--- a/main/ipc/pr-review.js
+++ b/main/ipc/pr-review.js
@@ -921,25 +921,36 @@ function ensureWorktreeScratchIgnored(worktreePath) {
   } catch (_) { /* best-effort */ }
 }
 
-ipcMain.handle('pr-review-commit-local', async (_event, { message, worktreeHint }) => {
+ipcMain.handle('pr-review-commit-local', async (_event, { message, worktreeHint, files }) => {
   if (!prReview.active) return { error: 'No active PR review' };
   if (!message || !message.trim()) return { error: 'Commit message required' };
   const wt = activePrWorktree(worktreeHint);
   if (!wt) return { error: 'No worktree for this PR yet' };
 
+  // When the panel sends an explicit file list, stage + commit only those
+  // paths so unchecked files stay out of the commit. Empty/absent list keeps
+  // the legacy "stage everything" behavior for any older caller.
+  const selected = Array.isArray(files)
+    ? files.filter((f) => typeof f === 'string' && f.trim())
+    : [];
+  const scoped = selected.length > 0;
+
   try {
     // Ignore agent scratch before staging so `git add -A` can't sweep it in.
     ensureWorktreeScratchIgnored(wt.worktreePath);
-    await execFileP('git', ['add', '-A'], { cwd: wt.worktreePath });
+    const addArgs = scoped ? ['add', '--', ...selected] : ['add', '-A'];
+    await execFileP('git', addArgs, { cwd: wt.worktreePath });
   } catch (err) {
     return { error: 'git add failed: ' + (err.stderr || err.message) };
   }
   try {
     // --allow-empty=false is the default; if there's nothing to commit, fail
-    // loudly rather than silently producing a no-op commit message.
-    const { stdout } = await execFileP('git', ['commit', '-m', message], {
-      cwd: wt.worktreePath,
-    });
+    // loudly rather than silently producing a no-op commit message. The
+    // trailing pathspec limits the commit to the selected files even if the
+    // index happened to hold other staged changes.
+    const commitArgs = ['commit', '-m', message];
+    if (scoped) commitArgs.push('--', ...selected);
+    const { stdout } = await execFileP('git', commitArgs, { cwd: wt.worktreePath });
     return { ok: true, output: (stdout || '').trim() };
   } catch (err) {
     return { error: 'git commit failed: ' + (err.stderr || err.message) };

--- a/preload.js
+++ b/preload.js
@@ -415,7 +415,7 @@ contextBridge.exposeInMainWorld('klaus', {
     readWorktreeFile: (worktreePath, relPath) =>
       ipcRenderer.invoke('pr-review-read-file', { worktreePath, relPath }),
     localState: (worktreeHint) => ipcRenderer.invoke('pr-review-local-state', { worktreeHint }),
-    commitLocal: (message, worktreeHint) => ipcRenderer.invoke('pr-review-commit-local', { message, worktreeHint }),
+    commitLocal: (message, worktreeHint, files) => ipcRenderer.invoke('pr-review-commit-local', { message, worktreeHint, files }),
     pushLocal: (worktreeHint, opts) => ipcRenderer.invoke('pr-review-push-local', { worktreeHint, stash: !!(opts && opts.stash) }),
     resolveConflicts: (worktreeHint) => ipcRenderer.invoke('pr-review-resolve-conflicts', { worktreeHint }),
     cacheGetByPr: (owner, repo, number) =>

--- a/renderer/finding-parser.js
+++ b/renderer/finding-parser.js
@@ -238,6 +238,18 @@ window.FindingParser = (function () {
           try { rawFindings.push(JSON.parse(sources[i])); } catch (_e) {}
         }
       }
+      // Recover the sibling "summary" object too, so a parse failure in the
+      // findings array doesn't also drop the (intact) verdict banner.
+      var sumKey = inner.indexOf('"summary"');
+      if (sumKey !== -1) {
+        var sumBrace = inner.indexOf('{', sumKey);
+        if (sumBrace !== -1) {
+          var sumSources = extractObjectSources(inner.slice(sumBrace));
+          if (sumSources.length) {
+            try { summary = JSON.parse(sumSources[0]); } catch (_e2) {}
+          }
+        }
+      }
     }
     if (!rawFindings) return null;
     var findings = rawFindings.map(normalizeJsonFinding).filter(Boolean);

--- a/renderer/pr-review-implement.js
+++ b/renderer/pr-review-implement.js
@@ -317,6 +317,14 @@
     return PR.pendingComments.some(function (c) { return c.fromFindingId === findingId; });
   };
 
+  // Add-to-PR and Copy send only the text under a finding's "Suggested change:"
+  // label. Reads live f.text (pencil edits flow through); no label sends all.
+  PR.findingSuggestionText = function(f) {
+    var text = (f && f.text) || '';
+    var m = text.match(/(?:^|\n)[ \t]*Suggested change:[ \t]*\n*/i);
+    return m ? text.slice(m.index + m[0].length).trim() : text.trim();
+  };
+
   // Add a finding to the PR. Two paths:
   //   - verified inline location → push onto pendingComments so the draft
   //     appears anchored to the file:line in the diff, and the user can
@@ -325,6 +333,7 @@
   //     comment (legacy behavior, with attribution prefix).
   // The commentStatus lifecycle (posting/posted/failed) only applies to the
   // issue-comment path — drafts are purely client-side until submitted.
+
   PR.postFindingAsComment = async function(f) {
     // Toggle-off when the user clicks the button on an already-drafted
     // finding: pull the draft back out of pendingComments.
@@ -336,11 +345,9 @@
     }
     if (f.commentStatus === 'posting' || f.commentStatus === 'posted') return;
 
-    // Post the review block as the reviewer's own words. No bot attribution:
-    // the finding is theirs to stand behind, and the prompt already strips the
-    // AI tells (em dashes, filler, signposting) so it reads like a human wrote
-    // it. Whether or not they edited the text, it posts verbatim.
-    var attributedBody = f.text || '';
+    // Just the suggested change, posted as the reviewer's own words (no bot
+    // attribution). Body/severity/location stay on the card as reference.
+    var attributedBody = PR.findingSuggestionText(f);
 
     if (f.postMode === 'inline' && f.locationVerified && f.path && f.line) {
       PR.pendingComments.push({
@@ -426,12 +433,10 @@
     if (PR.lastState) PR.render(PR.lastState);
   };
 
-  // Copy a finding's markdown body to the clipboard — whatever is currently
-  // in the review block, edits and all. Flips a transient state flag for a
-  // ~1.5s "Copied" label.
+  // Copy the same suggested-change text Add-to-PR posts, so paste matches send.
   PR.copyFindingAsMarkdown = async function(f) {
     try {
-      await navigator.clipboard.writeText(f.text || '');
+      await navigator.clipboard.writeText(PR.findingSuggestionText(f));
       f.copyStatus = 'copied';
       PR.repaintAiReviewTab();
       setTimeout(function () {

--- a/renderer/pr-review-terminal.js
+++ b/renderer/pr-review-terminal.js
@@ -144,14 +144,21 @@
       + '</div>';
     }
 
+    // Per-file staging: only checked files are committed. Default unchecked so
+    // nothing lands in a commit unless the user explicitly picks it.
+    var selected = PR.localSelectedFiles || (PR.localSelectedFiles = {});
     var fileListHtml = files.length
       ? '<ul class="pr-local-file-list">'
           + files.map(function (f) {
-              return '<li><code class="pr-local-file-status">' + PR.escHtml(f.status) + '</code> '
-                + PR.escHtml(f.file) + '</li>';
+              return '<li class="pr-local-file-item"><label class="pr-local-file-label">'
+                + '<input type="checkbox" class="pr-local-file-check" data-file="' + PR.escHtml(f.file) + '"'
+                  + (selected[f.file] ? ' checked' : '') + (PR.localBusy ? ' disabled' : '') + '> '
+                + '<code class="pr-local-file-status">' + PR.escHtml(f.status) + '</code> '
+                + PR.escHtml(f.file) + '</label></li>';
             }).join('')
         + '</ul>'
       : '';
+    var selectedCount = files.filter(function (f) { return selected[f.file]; }).length;
 
     var diffHtml = (files.length && PR.localChanges.diff)
       ? '<details class="pr-local-diff"><summary>View diff</summary>'
@@ -165,8 +172,8 @@
             + ' value="' + PR.escHtml(PR.localCommitMsg || '') + '"'
             + (PR.localBusy ? ' disabled' : '') + '>'
           + '<button class="pr-review-btn pr-local-commit-btn" type="button"'
-            + (PR.localBusy ? ' disabled' : '') + '>'
-            + (PR.localBusy === 'committing' ? 'Committing…' : 'Commit')
+            + ((PR.localBusy || !selectedCount) ? ' disabled' : '') + '>'
+            + (PR.localBusy === 'committing' ? 'Committing…' : 'Commit' + (selectedCount ? ' (' + selectedCount + ')' : ''))
           + '</button>'
         + '</div>'
       : '';
@@ -232,6 +239,25 @@
     });
 
     var commitBtn = section.querySelector('.pr-local-commit-btn');
+
+    // Keep the selection set + Commit button in sync as boxes are toggled,
+    // without a full repaint (which would collapse the diff view / drop focus).
+    var checks = section.querySelectorAll('.pr-local-file-check');
+    Array.prototype.forEach.call(checks, function (cb) {
+      cb.addEventListener('change', function () {
+        var file = cb.getAttribute('data-file');
+        if (!file) return;
+        PR.localSelectedFiles = PR.localSelectedFiles || {};
+        if (cb.checked) PR.localSelectedFiles[file] = true;
+        else delete PR.localSelectedFiles[file];
+        var n = section.querySelectorAll('.pr-local-file-check:checked').length;
+        if (commitBtn) {
+          commitBtn.disabled = !!PR.localBusy || n === 0;
+          if (!PR.localBusy) commitBtn.textContent = 'Commit' + (n ? ' (' + n + ')' : '');
+        }
+      });
+    });
+
     if (commitBtn) commitBtn.addEventListener('click', function () {
       var msg = msgInput ? msgInput.value.trim() : (PR.localCommitMsg || '').trim();
       if (!msg) {
@@ -239,20 +265,32 @@
         PR.repaintAiReviewTab();
         return;
       }
+      // Read the checked files straight from the DOM so stale set entries
+      // (files that vanished after a prior commit) can't sneak in.
+      var selectedFiles = Array.prototype.map.call(
+        section.querySelectorAll('.pr-local-file-check:checked'),
+        function (cb) { return cb.getAttribute('data-file'); }
+      ).filter(Boolean);
+      if (!selectedFiles.length) {
+        PR.localBanner = { kind: 'error', text: 'Select at least one file to commit.' };
+        PR.repaintAiReviewTab();
+        return;
+      }
       PR.localCommitMsg = msg;
       PR.localBusy = 'committing';
       PR.localBanner = null;
       PR.repaintAiReviewTab();
-      window.klaus.pr.commitLocal(msg, PR.aiReview.worktreePath || null).then(function (r) {
+      window.klaus.pr.commitLocal(msg, PR.aiReview.worktreePath || null, selectedFiles).then(function (r) {
         PR.localBusy = null;
         if (r && r.error) {
           PR.localBanner = { kind: 'error', text: r.error };
           PR.repaintAiReviewTab();
         } else {
           PR.localBanner = { kind: 'ok', text: 'Committed.' };
-          // Clear the message field on success so the next commit starts
-          // with the default again.
+          // Clear the message field + selection on success so the next commit
+          // starts clean.
           PR.localCommitMsg = 'Apply review feedback';
+          PR.localSelectedFiles = {};
           PR.refreshLocalChanges();
         }
       });

--- a/renderer/pr-review.js
+++ b/renderer/pr-review.js
@@ -366,6 +366,7 @@ window.PrReview = window.PrReview || {};
       // briefly show stale file names while the new PR's state is fetched.
       PR.localChanges = null;
       PR.localCommitMsg = 'Apply review feedback';
+      PR.localSelectedFiles = {};
       PR.localBusy = null;
       PR.localBanner = null;
       // Fire-and-forget. Pass the PR number explicitly — lastState isn't

--- a/renderer/styles/05-pr-review-surface.css
+++ b/renderer/styles/05-pr-review-surface.css
@@ -1040,6 +1040,17 @@ body.pr-review-popout #pr-review-root {
   font-family: 'SF Mono', Menlo, monospace;
   font-size: 11px;
 }
+.pr-local-file-label {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  cursor: pointer;
+}
+.pr-local-file-check {
+  flex-shrink: 0;
+  cursor: pointer;
+  margin: 0;
+}
 .pr-local-file-status {
   display: inline-block;
   width: 22px;


### PR DESCRIPTION
## Summary
Three changes to the AI review surface.

1. **Post/copy only the suggested change.** Add-to-PR and Copy now send just the text under a finding's `Suggested change:` label instead of the full review block. Reads the live finding text so ✎ edits flow through; no-label findings fall back to the whole text. Finding card render is unchanged.

2. **Recover the verdict summary on parse fallback.** When the `<FINDINGS_JSON>` contract fails clean `JSON.parse`, the fallback recovered findings but dropped the summary — so one unescaped char in a code snippet silently hid the verdict/highest-risk/coverage banner. Now recovers the summary object with the same brace-matched scan.

3. **Per-file local commits.** The Local changes panel committed everything via `git add -A`. Each file now has a checkbox (unchecked by default); Commit stages/commits only the checked paths, so unchecked files and agent scratch stay out.

## Changes
- `renderer/pr-review-implement.js` — `findingSuggestionText()`; Copy + Add-to-PR use it.
- `renderer/finding-parser.js` — recover `summary` in the fallback parse path.
- `renderer/pr-review-terminal.js`, `renderer/pr-review.js`, `preload.js`, `main/ipc/pr-review.js`, CSS — per-file staging.

## Test Plan
- `findingSuggestionText()` verified on prose / code / legacy findings.
- Parser: malformed-JSON case recovers the summary; clean path unchanged.
- Scoped commit verified in a throwaway repo (only checked files committed).
- eslint + klaussy pre-commit gate pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)