### PR TITLE
fix(review): recover findings from malformed <FINDINGS_JSON>

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,8 @@ Klaussy/
 playwright-report/
 test-results/
 .playwright/
+# klaussy outputs
+pr-description.md
+REVIEW_OUTPUT.md
+plan.md
+.agents/session.json

--- a/renderer/finding-parser.js
+++ b/renderer/finding-parser.js
@@ -123,6 +123,40 @@ window.FindingParser = (function () {
     return objs;
   }
 
+  // Escape the invalid-JSON patterns agents emit constantly: raw control chars
+  // and unescaped `"` in string values (disambiguated by lookahead). Only runs
+  // after a strict JSON.parse has failed, so it can't regress the valid path.
+  function repairLooseJson(s) {
+    var out = '';
+    var inStr = false, esc = false;
+    for (var i = 0; i < s.length; i++) {
+      var ch = s[i];
+      if (!inStr) {
+        if (ch === '"') inStr = true;
+        out += ch;
+        continue;
+      }
+      if (esc) { out += ch; esc = false; continue; }
+      if (ch === '\\') { out += ch; esc = true; continue; }
+      if (ch === '"') {
+        var j = i + 1;
+        while (j < s.length && (s[j] === ' ' || s[j] === '\t' || s[j] === '\n' || s[j] === '\r')) j++;
+        var nx = s[j];
+        if (nx === undefined || nx === ',' || nx === '}' || nx === ']' || nx === ':') {
+          inStr = false; out += ch; continue; // real closing quote
+        }
+        out += '\\"'; continue;               // literal quote inside the value
+      }
+      if (ch === '\n') { out += '\\n'; continue; }
+      if (ch === '\r') { out += '\\r'; continue; }
+      if (ch === '\t') { out += '\\t'; continue; }
+      var code = s.charCodeAt(i);
+      if (code < 0x20) { out += '\\u' + ('0000' + code.toString(16)).slice(-4); continue; }
+      out += ch;
+    }
+    return out;
+  }
+
   function coerceSeverity(s) {
     var v = String(s == null ? '' : s).trim().toLowerCase();
     if (v === 'critical') return 'blocker';
@@ -228,25 +262,41 @@ window.FindingParser = (function () {
         summary = parsed.summary || null;
       }
     } catch (_) {
-      // Streaming / truncated: recover whatever complete finding objects exist.
-      var arrKey = inner.indexOf('"findings"');
-      var scanFrom = arrKey !== -1 ? inner.indexOf('[', arrKey) : inner.indexOf('[');
-      if (scanFrom !== -1) {
-        rawFindings = [];
-        var sources = extractObjectSources(inner.slice(scanFrom));
-        for (var i = 0; i < sources.length; i++) {
-          try { rawFindings.push(JSON.parse(sources[i])); } catch (_e) {}
+      // Dominant cause is invalid escaping, not truncation, so repair and retry
+      // the whole object first; the per-object scan below is only for genuinely
+      // truncated / mid-stream JSON.
+      var repaired = repairLooseJson(inner);
+      try {
+        var reparsed = JSON.parse(repaired);
+        if (Array.isArray(reparsed)) {
+          rawFindings = reparsed;
+        } else if (reparsed && typeof reparsed === 'object') {
+          rawFindings = Array.isArray(reparsed.findings) ? reparsed.findings : [];
+          summary = reparsed.summary || null;
         }
-      }
-      // Recover the sibling "summary" object too, so a parse failure in the
-      // findings array doesn't also drop the (intact) verdict banner.
-      var sumKey = inner.indexOf('"summary"');
-      if (sumKey !== -1) {
-        var sumBrace = inner.indexOf('{', sumKey);
-        if (sumBrace !== -1) {
-          var sumSources = extractObjectSources(inner.slice(sumBrace));
-          if (sumSources.length) {
-            try { summary = JSON.parse(sumSources[0]); } catch (_e2) {}
+      } catch (_r) {
+        // Still unparseable (truncated stream, or a repair the heuristic can't
+        // handle): recover whatever complete finding objects exist, from the
+        // repaired text so per-object parses benefit from the escaping fixes.
+        var arrKey = repaired.indexOf('"findings"');
+        var scanFrom = arrKey !== -1 ? repaired.indexOf('[', arrKey) : repaired.indexOf('[');
+        if (scanFrom !== -1) {
+          rawFindings = [];
+          var sources = extractObjectSources(repaired.slice(scanFrom));
+          for (var i = 0; i < sources.length; i++) {
+            try { rawFindings.push(JSON.parse(sources[i])); } catch (_e) {}
+          }
+        }
+        // Recover the sibling "summary" object too, so a parse failure in the
+        // findings array doesn't also drop the (intact) verdict banner.
+        var sumKey = repaired.indexOf('"summary"');
+        if (sumKey !== -1) {
+          var sumBrace = repaired.indexOf('{', sumKey);
+          if (sumBrace !== -1) {
+            var sumSources = extractObjectSources(repaired.slice(sumBrace));
+            if (sumSources.length) {
+              try { summary = JSON.parse(sumSources[0]); } catch (_e2) {}
+            }
           }
         }
       }
@@ -263,7 +313,10 @@ window.FindingParser = (function () {
 
     // Stage 0: structured JSON contract (preferred).
     var json = parseJsonContract(text);
-    if (json && json.findings.length) {
+    // Satisfied by findings OR a summary: a clean "Approve, zero findings"
+    // review is valid JSON with an empty array and a real summary, which would
+    // otherwise fall through to the legacy parser and render as a raw dump.
+    if (json && (json.findings.length || json.summary)) {
       return {
         preamble: text.slice(0, text.indexOf('<FINDINGS_JSON>')).trim(),
         findings: json.findings,

--- a/renderer/pr-review-findings.js
+++ b/renderer/pr-review-findings.js
@@ -481,6 +481,9 @@
       body = '<div class="pr-ai-body error">' + PR.escHtml(PR.aiReview.error) + '</div>';
     } else if (!PR.aiReview.finalText && PR.aiReview.requestId) {
       body = '<div class="pr-ai-body status-pulse">Working\u2026</div>';
+    } else if (PR.aiReview.findings.length === 0 && PR.aiReview.summary) {
+      // Clean approve: verdict banner already shows the outcome.
+      body = '<div class="pr-ai-no-findings">No line-level findings.</div>';
     } else if (PR.aiReview.findings.length === 0) {
       // Parser found nothing — show the raw text as one fallback card so the
       // user still sees the review even when the structured shape is off.

--- a/renderer/pr-review.js
+++ b/renderer/pr-review.js
@@ -531,6 +531,7 @@ window.PrReview = window.PrReview || {};
       PR.aiReview.error = agent.status === 'error' ? agent.error : null;
       PR.aiReview.cancelled = agent.status === 'cancelled';
       PR.aiReview.findings = [];
+      PR.aiReview.summary = null;
       PR.aiReview.usage = null;
       PR.aiReview.worktreePath = (agent.sourceContext && agent.sourceContext.worktreePath) || PR.aiReview.worktreePath;
 

--- a/renderer/styles/05-pr-review-surface.css
+++ b/renderer/styles/05-pr-review-surface.css
@@ -1890,6 +1890,13 @@ body.pr-review-popout #pr-review-root {
   overflow-y: auto;
 }
 
+.pr-ai-no-findings {
+  padding: 14px;
+  font-size: 13px;
+  color: var(--text-dim);
+  text-align: center;
+}
+
 .pr-ai-inline-code {
   background: rgba(128, 128, 128, 0.18);
   padding: 1px 5px;

--- a/test/util/finding-parser.test.js
+++ b/test/util/finding-parser.test.js
@@ -1,0 +1,66 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+// finding-parser.js is a renderer IIFE that assigns to window.FindingParser.
+// It touches no Electron/DOM API, so we can load it by stubbing `window` and
+// requiring the file, then read the parser off the stub.
+global.window = global.window || {};
+require('../../renderer/finding-parser');
+const FP = global.window.FindingParser;
+
+function wrap(inner) {
+  return 'Here is my review.\n<FINDINGS_JSON>\n' + inner + '\n</FINDINGS_JSON>';
+}
+
+// Regression: raw newlines / unescaped quotes in the `code`/`body` string
+// values made JSON.parse throw and collapsed the review to one "unparsed"
+// card. The lenient-repair fallback must recover these.
+
+test('valid JSON contract yields structured findings + summary', () => {
+  const r = FP.parseReviewFindings(wrap(JSON.stringify({
+    findings: [{ severity: 'High', category: 'Correctness', path: 'main.js', line: 42, side: 'RIGHT', title: 'Null deref', code: 'const x = foo.bar;', body: 'Guard the null case.', suggestion: 'if (!foo) return;' }],
+    summary: { verdict: 'Request Changes', highestRisk: ['null deref'], testCoverage: 'no tests' },
+  })));
+  assert.equal(r.structured, true);
+  assert.equal(r.findings.length, 1);
+  assert.equal(r.findings[0].severity, 'high');
+  assert.equal(r.findings[0].path, 'main.js');
+  assert.equal(r.summary.verdict, 'Request Changes');
+});
+
+test('recovers findings when code contains a raw (unescaped) newline', () => {
+  const inner = '{\n  "findings": [\n    { "severity": "High", "category": "Correctness", "path": "main.js", "line": 42, "side": "RIGHT", "title": "Null deref", "code": "const x = foo.bar;\nconst y = x.baz;", "body": "Guard it.", "suggestion": "if (!foo) return;" }\n  ],\n  "summary": { "verdict": "Request Changes", "highestRisk": ["null deref"], "testCoverage": "no tests" }\n}';
+  const r = FP.parseReviewFindings(wrap(inner));
+  assert.equal(r.findings.length, 1);
+  assert.equal(r.structured, true);
+  assert.equal(r.summary.verdict, 'Request Changes');
+});
+
+test('recovers findings when body contains an unescaped double-quote', () => {
+  const inner = '{ "findings": [ { "severity": "High", "category": "Correctness", "path": "m.js", "line": 5, "side": "RIGHT", "title": "Bad", "code": "x=1;", "body": "The "foo" variable is wrong.", "suggestion": "rename it" } ], "summary": { "verdict": "Block", "highestRisk": ["x"], "testCoverage": "none" } }';
+  const r = FP.parseReviewFindings(wrap(inner));
+  assert.equal(r.findings.length, 1);
+  assert.equal(r.findings[0].severity, 'high');
+});
+
+test('truncated mid-stream: recovers the complete findings, drops the partial tail', () => {
+  const inner = '{\n  "findings": [\n    { "severity": "High", "category": "Correctness", "path": "a.js", "line": 1, "side": "RIGHT", "title": "One", "code": "let a = 1;\nlet b = 2;", "body": "First.", "suggestion": "x" },\n    { "severity": "Low", "category": "Design", "path": "b.js", "line": 9, "side": "RIGHT", "title": "Two", "code": "y=2;", "body": "Second.", "suggestion": "z" },\n    { "severity": "Nit", "category": "Readability", "path": "c.js", "line": 3, "side": "RIGHT", "title": "Thre';
+  // Note: no closing </FINDINGS_JSON> — mid-stream.
+  const r = FP.parseReviewFindings('review\n<FINDINGS_JSON>\n' + inner);
+  assert.equal(r.findings.length, 2);
+  assert.equal(r.findings[0].path, 'a.js');
+  assert.equal(r.findings[1].path, 'b.js');
+});
+
+test('clean approve: zero findings + summary renders as structured (not an unparsed dump)', () => {
+  const r = FP.parseReviewFindings(wrap('{ "findings": [], "summary": { "verdict": "Approve", "highestRisk": [], "testCoverage": "good" } }'));
+  assert.equal(r.structured, true);
+  assert.equal(r.findings.length, 0);
+  assert.equal(r.summary.verdict, 'Approve');
+});
+
+test('genuinely unstructured text still falls back cleanly (no throw, no findings from JSON)', () => {
+  const r = FP.parseReviewFindings('Just some prose with no contract and no severity anchors.');
+  assert.equal(r.structured, false);
+  assert.equal(r.findings.length, 0);
+});


### PR DESCRIPTION
## Summary
The AI Review tab was showing a single **"Review (unparsed)"** card with 0 findings instead of finding cards + verdict banner.

**Root cause:** the `<FINDINGS_JSON>` contract asks the agent to quote each finding's `code` verbatim (up to 10 lines) and write a prose `body`, so models routinely emit raw newlines and unescaped `"` inside those JSON string values. `JSON.parse` throws, and the old streaming fallback re-ran `JSON.parse` on each recovered object — still invalid for the same reason — so every finding was dropped and the whole review rendered as raw text.

## Changes
- `repairLooseJson()` in `finding-parser.js`: escapes raw control chars and disambiguates literal inner quotes via lookahead. Runs **only after** a strict parse has already failed, so the valid-JSON path is untouched. The `catch` now tries a full lenient re-parse first (recovers all findings at once), falling back to per-object recovery only for genuinely truncated mid-stream JSON.
- Clean "Approve, zero findings" reviews (valid JSON, empty array + real summary) now render the verdict banner plus a short "No line-level findings" note instead of dumping raw JSON. `rehydrateAiReview` resets `summary` so a stale banner can't linger.
- `.gitignore`: ignore generated review/plan outputs.

## Test Plan
- New `test/util/finding-parser.test.js`: raw-newline, unescaped-quote, truncated-stream, clean-approve, and unstructured-fallback cases.
- Full suite: **113 pass, 0 fail**. eslint clean.
- Verified live in the running app: reviews now render as finding cards.

🤖 Generated with [Claude Code](https://claude.com/claude-code)