### PR TITLE
fix(pr-review): inline anchoring, account-pinned posting, terminal rendering

### DIFF
--- a/main/ipc/pr-review-comments.js
+++ b/main/ipc/pr-review-comments.js
@@ -6,12 +6,20 @@
 const { ipcMain } = require('electron');
 const log = require('electron-log');
 const { execFile, execFileSync, spawn } = require('child_process');
-const { ghExec, ghExecP, appendStderr, execFileP } = require('../util/exec');
+const { ghExec, ghExecP, resolveGhEnv, appendStderr, execFileP } = require('../util/exec');
 const { ghJson, ghText } = require('../util/gh-json');
 const { humanizeComment } = require('../util/humanize-comment');
 const {
   prReview, currentRepoPath, sanitizePrReview, broadcastPrReview, fetchThreadsForActive,
 } = require('../state/pr-review');
+
+// Pin every gh call in an active review to the account it runs under, so
+// posting survives global-account drift and works for org repos. Falls back to
+// the ambient account when there's no pinned account or its token won't read.
+function reviewGhEnv(cwd) {
+  const account = prReview.active && prReview.active.account;
+  return { ...process.env, ...resolveGhEnv({ account, cwd }) };
+}
 
 // G4: post all pending review comments + decision as one review. The GitHub
 // REST endpoint accepts `comments` inline so we only make one network call.
@@ -32,6 +40,7 @@ ipcMain.handle('pr-add-issue-comment', async (_event, { body }) => {
   return new Promise((resolve) => {
     const proc = spawn('gh', ['api', endpoint, '--method', 'POST', '--input', '-'], {
       cwd,
+      env: reviewGhEnv(cwd),
       stdio: ['pipe', 'pipe', 'pipe'],
     });
     let stdoutBuf = '', stderrBuf = '';
@@ -74,7 +83,7 @@ ipcMain.handle('pr-edit-issue-comment', async (_event, { commentId, body }) => {
   // `spawn` is imported at the top of the file.
   return new Promise((resolve) => {
     const proc = spawn('gh', ['api', endpoint, '--method', 'PATCH', '--input', '-'], {
-      cwd, stdio: ['pipe', 'pipe', 'pipe'],
+      cwd, env: reviewGhEnv(cwd), stdio: ['pipe', 'pipe', 'pipe'],
     });
     let stdoutBuf = '', stderrBuf = '';
     proc.stdout.on('data', (c) => { stdoutBuf += c.toString(); });
@@ -112,7 +121,7 @@ ipcMain.handle('pr-edit-review-comment', async (_event, { commentId, body }) => 
   // `spawn` is imported at the top of the file.
   return new Promise((resolve) => {
     const proc = spawn('gh', ['api', endpoint, '--method', 'PATCH', '--input', '-'], {
-      cwd, stdio: ['pipe', 'pipe', 'pipe'],
+      cwd, env: reviewGhEnv(cwd), stdio: ['pipe', 'pipe', 'pipe'],
     });
     let stdoutBuf = '', stderrBuf = '';
     proc.stdout.on('data', (c) => { stdoutBuf += c.toString(); });
@@ -142,7 +151,7 @@ ipcMain.handle('pr-current-user', async () => {
   if (cachedCurrentUser) return { login: cachedCurrentUser };
   try {
     const out = execFileSync('gh', ['api', 'user', '--jq', '.login'], {
-      stdio: 'pipe', timeout: 10000,
+      stdio: 'pipe', timeout: 10000, env: reviewGhEnv(currentRepoPath() || require('os').homedir()),
     }).toString().trim();
     if (out) cachedCurrentUser = out;
     return { login: cachedCurrentUser };
@@ -171,6 +180,7 @@ ipcMain.handle('pr-reply-to-review-comment', async (_event, { inReplyTo, body })
   return new Promise((resolve) => {
     const proc = spawn('gh', ['api', endpoint, '--method', 'POST', '--input', '-'], {
       cwd,
+      env: reviewGhEnv(cwd),
       stdio: ['pipe', 'pipe', 'pipe'],
     });
     let stdoutBuf = '', stderrBuf = '';
@@ -212,7 +222,7 @@ ipcMain.handle('pr-review-resolve-thread', async (_event, { threadId, resolve })
       'api', 'graphql',
       '-f', 'query=' + mutation,
       '-F', 'id=' + threadId,
-    ], { cwd, stdio: 'pipe', timeout: 15000 });
+    ], { cwd, ghAccount: prReview.active.account, stdio: 'pipe', timeout: 15000 });
   } catch (err) {
     return { error: err.stderr ? err.stderr.toString() : err.message };
   }
@@ -267,6 +277,7 @@ ipcMain.handle('pr-submit-review', async (_event, { event, body, comments }) => 
   const reviewResult = await new Promise((resolve) => {
     const proc = spawn('gh', ['api', endpoint, '--method', 'POST', '--input', '-'], {
       cwd,
+      env: reviewGhEnv(cwd),
       stdio: ['pipe', 'pipe', 'pipe'],
     });
     let stdoutBuf = '', stderrBuf = '';
@@ -318,6 +329,7 @@ ipcMain.handle('pr-submit-review', async (_event, { event, body, comments }) => 
     const res = await new Promise((resolve) => {
       const proc = spawn('gh', ['api', issueEndpoint, '--method', 'POST', '--input', '-'], {
         cwd,
+        env: reviewGhEnv(cwd),
         stdio: ['pipe', 'pipe', 'pipe'],
       });
       let stdoutBuf = '', stderrBuf = '';

--- a/main/util/exec.js
+++ b/main/util/exec.js
@@ -67,10 +67,22 @@ function ghEnvForRepo(repoDir) {
   }
 }
 
-function ghExec(args, opts) {
-  const env = ghEnvForRepo(opts.cwd);
+// Resolve the GH_TOKEN env for a gh call, most specific first: an explicit
+// review account (survives global-account drift; the only thing that works for
+// org repos), then the repo owner, then {} (gh's ambient active account).
+function resolveGhEnv({ account, cwd } = {}) {
+  if (account) {
+    const acct = ghEnvForAccount(account);
+    if (acct.GH_TOKEN) return acct;
+  }
+  return ghEnvForRepo(cwd);
+}
+
+function ghExec(args, opts = {}) {
+  const { ghAccount, ...rest } = opts;
+  const env = resolveGhEnv({ account: ghAccount, cwd: rest.cwd });
   return execFileSync('gh', args, {
-    ...opts,
+    ...rest,
     env: { ...process.env, ...env },
   });
 }
@@ -78,10 +90,11 @@ function ghExec(args, opts) {
 // Async variant for background work (timers, polling) — sync ghExec freezes
 // the main thread for the full gh round-trip, which is unacceptable at
 // 30-second cadence across N tasks.
-async function ghExecP(args, opts) {
-  const env = ghEnvForRepo(opts && opts.cwd);
+async function ghExecP(args, opts = {}) {
+  const { ghAccount, ...rest } = opts;
+  const env = resolveGhEnv({ account: ghAccount, cwd: rest.cwd });
   return execFileP('gh', args, {
-    ...(opts || {}),
+    ...rest,
     env: { ...process.env, ...env },
   });
 }
@@ -154,6 +167,7 @@ module.exports = {
   appendStderr,
   ghEnvForRepo,
   ghEnvForAccount,
+  resolveGhEnv,
   ghExec,
   ghExecP,
   clearGhTokenCache,

--- a/renderer/pr-review-findings.js
+++ b/renderer/pr-review-findings.js
@@ -271,32 +271,37 @@
   // line (or finding the true one nearby). Fire-and-forget: updates the
   // finding state and repaints on completion.
   PR.verifyFindingLocations = function() {
-    if (!PR.aiReview.worktreePath) return;
+    var diffText = PR.lastState && PR.lastState.diff;
+    var changedSync = false;
     PR.aiReview.findings.forEach(function (f) {
       if (!f.path || !f.line) return;
-      // Downgrade any inline finding whose line isn't part of the PR diff —
-      // including ones cached as inline-verified by a Klaussy version that
-      // didn't check the diff. Without this they'd 422 on submit. Cheap,
-      // synchronous, and runs before the verified-skip below.
-      if (f.postMode === 'inline' &&
-          !PR.isLineInDiff(PR.lastState && PR.lastState.diff, f.path, f.line, f.side || 'RIGHT')) {
-        f.locationVerified = false;
-        f.lineNotInDiff = true;
-        f.postMode = 'issue';
+      // Anchor from the PR diff alone (no worktree needed): an inline comment
+      // only needs the cited line to be in the diff, which lets a "just opened,
+      // not checked out" review post inline instead of general comments.
+      if (!(f.locationVerified && f.verifiedSnippet)) {
+        // Guard the null-diff case explicitly (isLineInDiff is optimistic there)
+        // so we never mark inline without a diff to confirm the anchor.
+        var inDiff = !!diffText && PR.isLineInDiff(diffText, f.path, f.line, f.side || 'RIGHT');
+        var mode = inDiff ? 'inline' : 'issue';
+        if (f.locationVerified !== inDiff || f.lineNotInDiff !== !inDiff || f.postMode !== mode) {
+          f.locationVerified = inDiff;
+          f.lineNotInDiff = !inDiff;
+          f.postMode = mode;
+          changedSync = true;
+        }
       }
-      // Re-verify cached findings missing the file snippet — happens for
-      // findings cached from a Klaussy version that didn't capture the file
-      // content. Skip only when fully verified.
+      // A readable worktree refines the exact line + snippet below and may
+      // override the decision above; its absence or failure no longer strands
+      // the finding as a general comment.
+      if (!PR.aiReview.worktreePath) return;
       if (f.locationVerified && f.verifiedSnippet) return;
       if (f._verifyInFlight) return;
       f._verifyInFlight = true;
       window.klaus.pr.readWorktreeFile(PR.aiReview.worktreePath, f.path).then(function (r) {
         f._verifyInFlight = false;
         if (!r || r.error || !r.content) {
-          // File missing / unreadable → we can't verify. Leave postMode
-          // at 'inline' if the AI gave us a location — submitReview will
-          // surface a server-side error if the path is truly bad, which
-          // is more diagnostic than a silent fallback.
+          // Can't read the file → keep the diff-based anchor decided above
+          // (already a valid inline anchor when the line is in the diff).
           f.locationVerifyError = r && r.error ? r.error : 'unreadable';
           PR.repaintAiReviewTab();
           return;
@@ -318,7 +323,6 @@
         // GitHub rejects inline anchors that aren't part of the PR diff (422
         // "line must be part of the diff"). Gate inline mode on the line
         // actually being in the diff and fall back to an issue comment otherwise.
-        var diffText = PR.lastState && PR.lastState.diff;
         var inDiff = match && PR.isLineInDiff(diffText, f.path, match.line, f.side || 'RIGHT');
         if (match && inDiff) {
           f.line = match.line;
@@ -376,6 +380,7 @@
         PR.repaintAiReviewTab();
       });
     });
+    if (changedSync) PR.repaintAiReviewTab();
   };
 
   // Whether repo-intel (conventions + import graph from klaussy-repo-conventions) is

--- a/renderer/pr-review.js
+++ b/renderer/pr-review.js
@@ -1536,6 +1536,10 @@ window.PrReview = window.PrReview || {};
     if (cached.implementAllSummary) PR.aiReview.implementAllSummary = cached.implementAllSummary;
     if (cached.implementAllUsage) PR.aiReview.implementAllUsage = cached.implementAllUsage;
     if (cached.usage) PR.aiReview.usage = cached.usage;
+    // Re-derive anchors from the current diff after restoring cached per-finding
+    // state — otherwise a review cached with stale postMode/locationVerified
+    // (e.g. from before diff-based anchoring) stays wrong on reopen.
+    PR.verifyFindingLocations();
     PR.repaintAiReviewTab();
     // Tab badge was set to 0 in the new-PR reset; rerender meta to update it.
     var tabBtn = PR.hostEl.querySelector('.pr-review-tab[data-tab="ai-review"]');

--- a/renderer/styles/05-pr-review-surface.css
+++ b/renderer/styles/05-pr-review-surface.css
@@ -934,15 +934,15 @@ body.pr-review-popout #pr-review-root {
 .pr-implement-terminal-body {
   flex: 1;
   min-height: 0;
-  padding: 6px 8px;
   background: var(--term-bg);
   overflow: hidden;
 }
-.pr-implement-terminal-body .xterm,
-.pr-implement-terminal-body .xterm-viewport,
-.pr-implement-terminal-body .xterm-screen {
-  height: 100% !important;
-  width: 100% !important;
+/* Pad the .xterm, never this wrapper: FitAddon measures the wrapper for its row
+   count and subtracts the xterm's own padding, so padding the wrapper desyncs
+   rows from the viewport and paints black bands. Mirrors .terminal-body. */
+.pr-implement-terminal-body > .xterm {
+  height: 100%;
+  padding: 6px 8px;
 }
 
 /* Empty state shown in the Terminal tab when no implement run is active. */

--- a/test/util/exec.test.js
+++ b/test/util/exec.test.js
@@ -2,7 +2,21 @@ require('../setup');
 
 const test = require('node:test');
 const assert = require('node:assert/strict');
-const { appendStderr, sanitizeExtraEnv, runWithConcurrency, STDERR_CAP_BYTES } = require('../../main/util/exec');
+const { appendStderr, sanitizeExtraEnv, runWithConcurrency, STDERR_CAP_BYTES, resolveGhEnv } = require('../../main/util/exec');
+
+// --- resolveGhEnv ---
+
+test('resolveGhEnv falls through to {} when neither account nor repo resolves', () => {
+  // Junk account (no such gh user) and a non-repo cwd: both lookups fail, so
+  // the fallback chain must terminate at {} without throwing.
+  const env = resolveGhEnv({ account: 'no-such-gh-user-xyz-123', cwd: '/nonexistent-xyz-path' });
+  assert.deepEqual(env, {});
+});
+
+test('resolveGhEnv tolerates empty / missing input', () => {
+  assert.equal(typeof resolveGhEnv(), 'object');
+  assert.equal(typeof resolveGhEnv({}), 'object');
+});
 
 // --- appendStderr ---
 


### PR DESCRIPTION
Three PR-review fixes, each a separate commit.

## 1. Anchor findings inline without a local checkout
`verifyFindingLocations` bailed immediately when the PR wasn't checked out (no worktree), so every finding posted as a general comment even though the AI gave a `path`+`line`. Diff-membership is now the primary, synchronous inline gate — if the cited line is in the PR diff, we anchor inline with no worktree. The worktree read is a refinement (exact line + snippet) and its absence/failure no longer downgrades an in-diff finding. Null-diff is guarded (never mark inline without a diff), and anchors are re-derived after a cache restore so a stale `postMode` can't stick.

## 2. Pin gh posting to the review's account
Comment/submit posting used plain `gh` (the globally-active account). Org-repo PRs are only visible to one account, so when the active account drifted, posting 404'd "Not Found". Added `resolveGhEnv({account, cwd})` (review-account token → repo-owner token → ambient) and routed every gh call in an active review through it (`ghExec`/`ghExecP` gain an optional `ghAccount`). Posting now survives account drift and works for org repos.

## 3. Terminal black bands
`.pr-implement-terminal-body` (the element FitAddon measures) carried `padding` and forced the viewport/screen to `100% !important`. FitAddon subtracts the *xterm's* padding, not the wrapper's, so the wrapper padding desynced rows from the viewport and painted black bands over the composer/status line. Moved padding onto `.xterm` and dropped the overrides, mirroring the working main terminal.

## Test Plan
- eslint clean; full suite 115 pass / 0 fail (2 new `resolveGhEnv` tests).
- Verified live: terminal renders cleanly; findings anchor inline on a "just opened" PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)