### PR TITLE
feat: run-skill handoffs, agent-neutral action prompts, Windows cross-platform support

### DIFF
--- a/main/bootstrap/app-events.js
+++ b/main/bootstrap/app-events.js
@@ -7,6 +7,7 @@
 const path = require('path');
 const fs = require('fs');
 const { execSync, execFileSync, execFile } = require('child_process');
+const { whichBinSync } = require('../util/platform');
 const { app, ipcMain, dialog, BrowserWindow } = require('electron');
 const lspManager = require('../../lsp-manager');
 const { loadConfig, saveConfig, flushSaveConfig, runConfigMigrations } = require('../util/config');
@@ -163,11 +164,15 @@ function refreshSpawnPath() {
   } catch { /* shell or registry read failed; keep current PATH */ }
 }
 
-// Resolve whether a binary is reachable: a configured absolute path is checked
-// on disk; a bare name is looked up on PATH via `which`.
+// Resolve whether a binary is reachable: a configured path (contains a path
+// separator) is checked on disk; a bare name is looked up on PATH. Uses
+// whichBinSync so Windows resolves via `where.exe` + PATHEXT (finding
+// `claude.cmd`/`.exe`) rather than `which`, which doesn't exist on Windows and
+// made every agent read as "not installed" there. The separator test accepts
+// `\` too so a configured `C:\tools\claude.exe` isn't treated as a bare name.
 function binPresent(bin, cb) {
-  if (bin && bin.includes('/')) { cb(fs.existsSync(bin)); return; }
-  execFile('which', [bin], { timeout: 2000 }, (err) => cb(!err));
+  if (bin && /[/\\]/.test(bin)) { cb(fs.existsSync(bin)); return; }
+  cb(!!whichBinSync(bin));
 }
 
 // Startup nudge: gh is needed for PR/GitHub features, and at least ONE agent

--- a/main/ipc/claude-stream-ipc.js
+++ b/main/ipc/claude-stream-ipc.js
@@ -6,7 +6,8 @@
 
 const { ipcMain, BrowserWindow } = require('electron');
 const crypto = require('crypto');
-const { execFile, execFileSync } = require('child_process');
+const { execFileSync } = require('child_process');
+const { execHeadlessAgent, promptGoesOnStdin } = require('../util/agent-spawn');
 const { instances, spawnInWorktree } = require('../state/instances');
 const { isAgentMode } = require('../state/ai-providers');
 const { prReview, ensureWorktreeForActivePr, currentRepoPath, resolveFallbackBaseBranch } = require('../state/pr-review');
@@ -578,22 +579,16 @@ ipcMain.handle('pr-review-investigate-cancel', makeClaudeCancelHandler(investiga
 
 ipcMain.handle('explain-diff', async (_event, { worktreePath, file, hunk }) => {
   // PR review mode calls this without a worktree — fall back to the current
-  // project path (or the user's home as a last resort) since execFile insists
+  // project path (or the user's home as a last resort) since the spawn insists
   // on a valid cwd. Claude doesn't actually need repo context for this prompt.
   const cwd = worktreePath || currentRepoPath() || require('os').homedir();
-  return new Promise((resolve) => {
-    execFile('claude', ['-p', explainPrompt(file, hunk)], {
-      cwd,
-      timeout: 30000,
-      maxBuffer: 1024 * 1024,
-    }, (err, stdout, stderr) => {
-      if (err) {
-        resolve({ error: stderr || err.message });
-      } else {
-        resolve({ explanation: stdout.trim() });
-      }
-    });
-  });
+  // A Windows `.cmd` shim can't carry the multi-line prompt as an arg, so it
+  // goes on stdin (`claude -p` reads it); elsewhere it's a normal `-p <prompt>`
+  // arg. See util/agent-spawn.
+  const win = promptGoesOnStdin('claude');
+  const p = explainPrompt(file, hunk);
+  return execHeadlessAgent('claude', win ? ['-p'] : ['-p', p], { cwd, timeout: 30000 }, win ? p : null)
+    .then((res) => (res.error ? { error: res.error } : { explanation: res.stdout.trim() }));
 });
 
 // Streaming variant. Pipes claude stdout to the renderer in real time so the
@@ -765,17 +760,8 @@ SUGGESTED REPLY:
 
   const config = loadConfig();
   const claudeBin = config.claudePath || 'claude';
-  return new Promise((resolve) => {
-    execFile(claudeBin, ['-p', prompt], {
-      cwd: worktreePath,
-      timeout: 60000,
-      maxBuffer: 1024 * 1024,
-    }, (err, stdout, stderr) => {
-      if (err) {
-        resolve({ error: stderr || err.message });
-      } else {
-        resolve({ review: stdout.trim() });
-      }
-    });
-  });
+  // Windows `.cmd` shim: prompt on stdin (it can't take the multi-line arg).
+  const win = promptGoesOnStdin(claudeBin);
+  return execHeadlessAgent(claudeBin, win ? ['-p'] : ['-p', prompt], { cwd: worktreePath, timeout: 60000 }, win ? prompt : null)
+    .then((res) => (res.error ? { error: res.error } : { review: res.stdout.trim() }));
 });

--- a/main/ipc/skills.js
+++ b/main/ipc/skills.js
@@ -232,6 +232,55 @@ ipcMain.handle('write-skill-file', (_event, { filePath, content }) => {
   }
 });
 
+// Where klaussy scaffolds each agent's skills (relative to the worktree root).
+// klaussy writes the same <repo>-run skill into every selected agent's own dir,
+// so the Run App handoff must look in the dir for the TASK's agent — not assume
+// Claude's. Agents absent here have no skills mechanism (aider reads CONVENTIONS.md).
+const AGENT_SKILLS_DIRS = {
+  claude: ['.claude', 'skills'],
+  codex: ['.agents', 'skills'],
+  cline: ['.agents', 'skills'],
+  gemini: ['.gemini', 'skills'],
+  cursor: ['.cursor', 'skills'],
+  copilot: ['.github', 'skills'],
+  antigravity: ['.gemini', 'antigravity-cli', 'plugins', 'klaussy', 'skills'],
+  opencode: ['.opencode', 'skills'],
+};
+
+// Resolve the worktree's klaussy-generated `<repo>-<kind>` skill for a given
+// agent (kind = run / plan / debug / review / …). klaussy namespaces skills as
+// <sanitized-repo-name>-<kind>, so we match by the `-<kind>` suffix rather than
+// reconstructing the sanitized name (mirrors findRepoReviewSkill in
+// state/review-prompts.js). Returns the skill name so the renderer can name it
+// in an agent-neutral prompt; null when this agent has no such skill (repo
+// generated before it existed, agent has no skills mechanism, or not
+// klaussy-managed) — the caller falls back to a self-contained prose prompt.
+//
+// Ambiguity guard: some kinds are suffixes of others (`review` ⊂ `self-review` /
+// `address-review`; `commit` ⊂ `precommit`). Since every skill shares the same
+// `<repo>-` prefix, the plain kind's dir name is always the SHORTEST among the
+// `-<kind>` matches, so we pick the shortest — `<repo>-review`, never
+// `<repo>-self-review`.
+ipcMain.handle('resolve-skill', (_event, { worktreePath, agentId, kind } = {}) => {
+  if (!worktreePath || !pathUnderAnyRoot(worktreePath) || !kind) return null;
+  // No agentId → default to Claude's dir (safe fallback). A *known* agent that
+  // isn't mapped (aider, or a non-skill agent) → null, so we don't false-match
+  // one agent's skill against another that can't invoke it.
+  const rel = agentId ? AGENT_SKILLS_DIRS[agentId] : AGENT_SKILLS_DIRS.claude;
+  if (!rel) return null;
+  const suffix = '-' + kind;
+  try {
+    const skillsDir = path.join(worktreePath, ...rel);
+    const matches = fs.readdirSync(skillsDir, { withFileTypes: true })
+      .filter((e) => e.isDirectory() && e.name.endsWith(suffix)
+        && fs.existsSync(path.join(skillsDir, e.name, 'SKILL.md')))
+      .map((e) => e.name)
+      .sort((a, b) => a.length - b.length);
+    return matches[0] || null;
+  } catch { /* no skills dir for this agent — not generated yet */ }
+  return null;
+});
+
 // List CLAUDE.md memory files across scopes. Each scope has at most one
 // memory file — the dialog uses this to show what's there vs. missing.
 ipcMain.handle('list-memory-files', () => {

--- a/main/ipc/tasks.js
+++ b/main/ipc/tasks.js
@@ -703,7 +703,9 @@ ipcMain.handle('delete-session', async (_event, { worktreePaths }) => {
 ipcMain.handle('get-session-repos', (_event, { worktreePath }) => {
   try {
     if (typeof worktreePath !== 'string') return { session: null, repos: [] };
-    const m = worktreePath.replace(/\/+$/, '').match(/^(.*\/klaussy\/sessions\/([^/]+))\/([^/]+)$/);
+    // Normalize `\`→`/` so Windows session paths match too (Node fs/path accept
+    // forward slashes on Windows, so the derived paths below still work).
+    const m = worktreePath.replace(/\\/g, '/').replace(/\/+$/, '').match(/^(.*\/klaussy\/sessions\/([^/]+))\/([^/]+)$/);
     if (!m) return { session: null, repos: [] };
     const sessionDir = m[1];
     const sessionName = m[2];
@@ -1070,7 +1072,7 @@ ipcMain.handle('add-sub-terminal', (_event, { taskId, label, mode, initialPrompt
     // Seed an initial prompt (Plan/Debug/Review) at spawn rather than typing it
     // in after boot — shared staging with the cross-agent session-resume
     // handoff (see util/agent-prompt).
-    const staged = stageInitialPrompt(provider, agentCmd, initialPrompt, `${taskId}-${subId}`);
+    const staged = stageInitialPrompt(provider, agentCmd, initialPrompt, `${taskId}-${subId}`, userShell);
     agentCmd = staged.agentCmd;
     promptFile = staged.promptFile;
     needsEnter = staged.needsEnter;

--- a/main/state/ai-providers.js
+++ b/main/state/ai-providers.js
@@ -87,9 +87,14 @@ function claudeUsage(u) {
 // these through each agent's add-directory flag lets the agent READ and EDIT
 // its sibling worktrees, not just its own cwd — without them the agents treat
 function quotedSessionDirs(sessionDirs) {
+  // PowerShell (the Windows default shell) doesn't treat `\` as an escape, so
+  // JSON.stringify's doubled backslashes (`C:\\Users\\…`) would reach the agent
+  // verbatim and break the --add-dir path. Single-quote it literally there.
+  // POSIX shells keep the JSON double-quoted form (their paths have no `\`).
+  const isWin = process.platform === 'win32';
   return (Array.isArray(sessionDirs) ? sessionDirs : [])
     .filter((d) => typeof d === 'string' && d)
-    .map((d) => JSON.stringify(d));
+    .map((d) => (isWin ? `'${d.replace(/'/g, "''")}'` : JSON.stringify(d)));
 }
 
 const PROVIDERS = {
@@ -120,10 +125,18 @@ const PROVIDERS = {
     // Headless one-shot. mode 'text' → caller wants the clean final answer on
     // stdout; mode 'stream' → structured stream-json events. outputMode tells
     // spawnAgentStream how to read stdout: 'passthrough' (stdout IS the
-    buildHeadlessRun(_bin, { prompt, mode, model /*, allowEdits */ } = {}) {
+    buildHeadlessRun(_bin, { prompt, mode, model, promptOnStdin /*, allowEdits */ } = {}) {
       // Claude's headless `-p` already edits within cwd on the autonomous
       // surfaces today, so allowEdits needs no extra flag here.
       const m = model ? ['--model', model] : [];
+      // Windows (promptOnStdin): `claude -p` with no positional reads the prompt
+      // from stdin, so the multi-line prompt never has to survive a cmd.exe
+      // command line (see util/agent-spawn). stdinInput carries it to the child.
+      if (promptOnStdin) {
+        return mode === 'stream'
+          ? { args: [...m, '-p', '--output-format', 'stream-json', '--verbose'], stdinInput: prompt, outputMode: 'passthrough' }
+          : { args: [...m, '-p'], stdinInput: prompt, outputMode: 'passthrough' };
+      }
       return mode === 'stream'
         ? { args: [...m, '-p', prompt, '--output-format', 'stream-json', '--verbose'], outputMode: 'passthrough' }
         : { args: [...m, '-p', prompt], outputMode: 'passthrough' };
@@ -219,7 +232,7 @@ const PROVIDERS = {
       if (resumeLatest) return `${top} resume --last`;
       return top;
     },
-    buildHeadlessRun(_bin, { prompt, mode, allowEdits, model } = {}) {
+    buildHeadlessRun(_bin, { prompt, mode, allowEdits, model, promptOnStdin } = {}) {
       // `codex exec --json` always emits JSONL (no clean-text plain mode). For
       // text surfaces we extract the agent_message text ('json-text'); for
       // stream surfaces we translate Codex events into Claude-shaped stream-
@@ -229,8 +242,12 @@ const PROVIDERS = {
       // sandbox, so grant scoped workspace writes. `codex exec` is already non-
       // interactive (no `--ask-for-approval` flag — verified), and this is NOT
       if (allowEdits) args.push('--sandbox', 'workspace-write');
-      args.push('--json', prompt);
-      return { args, outputMode: mode === 'stream' ? 'json-translate' : 'json-text' };
+      // Windows: the prompt (positional) goes on stdin so it survives the
+      // `.cmd` shim (see util/agent-spawn). VERIFY `codex exec --json` reads
+      // stdin when no positional prompt is given.
+      args.push('--json');
+      if (!promptOnStdin) args.push(prompt);
+      return { args, stdinInput: promptOnStdin ? prompt : undefined, outputMode: mode === 'stream' ? 'json-translate' : 'json-text' };
     },
     sessionDir() {
       // Global, date-bucketed; not resolvable from a worktree path.
@@ -388,17 +405,20 @@ const PROVIDERS = {
       if (resumeLatest) return `${base} --resume latest`;
       return base;
     },
-    buildHeadlessRun(_bin, { prompt, mode, allowEdits, trust, model } = {}) {
+    buildHeadlessRun(_bin, { prompt, mode, allowEdits, trust, model, promptOnStdin } = {}) {
       // VERIFIED (gemini-cli 0.44.1): `-p` = non-interactive; `-o stream-json`
       // = NDJSON we translate into Claude-shaped events; `--approval-mode
       // auto_edit` auto-approves edit tools. `--skip-trust` clears the trusted-
       const args = [];
       if (trust) args.push('--skip-trust');
       if (model) args.push('-m', model);
-      args.push('-p', prompt);
+      // Windows: prompt on stdin so it survives the `.cmd` shim (util/agent-spawn).
+      // `-p` requires a value and would greedily consume the next flag, so drop
+      // it and let gemini read the piped stdin as the prompt. VERIFY on gemini-cli.
+      if (!promptOnStdin) args.push('-p', prompt);
       if (mode === 'stream') args.push('--output-format', 'stream-json');
       if (allowEdits) args.push('--approval-mode', 'auto_edit');
-      return { args, outputMode: mode === 'stream' ? 'json-translate' : 'passthrough' };
+      return { args, stdinInput: promptOnStdin ? prompt : undefined, outputMode: mode === 'stream' ? 'json-translate' : 'passthrough' };
     },
     sessionDir() {
       return path.join(home(), '.gemini', 'tmp');
@@ -533,14 +553,18 @@ const PROVIDERS = {
       if (resumeLatest) return `${bin} --continue`;
       return bin;
     },
-    buildHeadlessRun(_bin, { prompt, mode, allowEdits } = {}) {
+    buildHeadlessRun(_bin, { prompt, mode, allowEdits, promptOnStdin } = {}) {
       // `copilot -p -s` (silent) prints only the final response. Stream mode
       // uses JSONL we translate into Claude-shaped events. VERIFY on a real install.
-      const args = ['-p', prompt];
+      // Windows `.cmd`: prompt on stdin. `-p` takes the next token as its value,
+      // so keeping it would swallow `-s`; drop it and pipe stdin. VERIFY copilot
+      // reads stdin.
+      const args = [];
+      if (!promptOnStdin) args.push('-p', prompt);
       if (mode === 'stream') args.push('--output-format', 'json'); else args.push('-s');
       // Allow the write tool for autonomous-edit surfaces. VERIFY exact tool name.
       if (allowEdits) args.push('--allow-tool', 'write');
-      return { args, outputMode: mode === 'stream' ? 'json-translate' : 'passthrough' };
+      return { args, stdinInput: promptOnStdin ? prompt : undefined, outputMode: mode === 'stream' ? 'json-translate' : 'passthrough' };
     },
     sessionDir() {
       return path.join(home(), '.copilot', 'session-state');
@@ -612,15 +636,19 @@ const PROVIDERS = {
       if (resumeLatest) return `${base} --continue`;
       return base;
     },
-    buildHeadlessRun(_bin, { prompt, mode, allowEdits, model } = {}) {
+    buildHeadlessRun(_bin, { prompt, mode, allowEdits, model, promptOnStdin } = {}) {
       // `-p` non-interactive. text → clean stdout (passthrough); stream → NDJSON
       // we translate into Claude-shaped events. `--force` auto-approves writes
       // for the autonomous-edit surfaces. args is passed to spawn() directly.
-      const args = ['-p', prompt];
+      // Windows `.cmd` (only if cursor-agent is shimmed rather than a native
+      // binary): prompt on stdin; `-p` would swallow the next flag, so drop it.
+      // VERIFY cursor-agent reads stdin.
+      const args = [];
+      if (!promptOnStdin) args.push('-p', prompt);
       if (model) args.push('--model', model);
       if (allowEdits) args.push('--force');
       if (mode === 'stream') args.push('--output-format', 'stream-json');
-      return { args, outputMode: mode === 'stream' ? 'json-translate' : 'passthrough' };
+      return { args, stdinInput: promptOnStdin ? prompt : undefined, outputMode: mode === 'stream' ? 'json-translate' : 'passthrough' };
     },
     sessionDir() {
       return path.join(home(), '.cursor');
@@ -694,7 +722,7 @@ const PROVIDERS = {
       if (resumeSessionId) return `${base} --id ${resumeSessionId}`;
       return base;
     },
-    buildHeadlessRun(_bin, { prompt, mode, allowEdits, model } = {}) {
+    buildHeadlessRun(_bin, { prompt, mode, allowEdits, model, promptOnStdin } = {}) {
       // `--json` → NDJSON we translate into Claude-shaped events; otherwise the
       // task prints clean text we pass through. `--yolo` auto-approves tools for
       // the autonomous-edit surfaces. The prompt is the trailing positional arg.
@@ -702,8 +730,10 @@ const PROVIDERS = {
       if (model) args.push('--model', model);
       if (allowEdits) args.push('--yolo');
       if (mode === 'stream') args.push('--json');
-      args.push(prompt);
-      return { args, outputMode: mode === 'stream' ? 'json-translate' : 'passthrough' };
+      // Windows `.cmd`: prompt on stdin instead of the positional (util/agent-spawn).
+      // VERIFY cline reads stdin when no positional prompt is given.
+      if (!promptOnStdin) args.push(prompt);
+      return { args, stdinInput: promptOnStdin ? prompt : undefined, outputMode: mode === 'stream' ? 'json-translate' : 'passthrough' };
     },
     sessionDir() {
       return path.join(home(), '.cline');
@@ -771,7 +801,7 @@ const PROVIDERS = {
       if (resumeLatest) return `${base} --continue`;
       return base;
     },
-    buildHeadlessRun(_bin, { prompt, mode, allowEdits, model } = {}) {
+    buildHeadlessRun(_bin, { prompt, mode, allowEdits, model, promptOnStdin } = {}) {
       // `run` is the non-interactive subcommand; `--format json` streams JSONL we
       // translate, else stdout passes through. `--auto` auto-approves tools on
       // autonomous-edit surfaces (else a headless edit blocks on a TTY-less prompt).
@@ -779,12 +809,18 @@ const PROVIDERS = {
       if (model) args.push('--model', model);
       if (allowEdits) args.push('--auto');
       if (mode === 'stream') args.push('--format', 'json');
-      args.push(prompt);
-      return { args, outputMode: mode === 'stream' ? 'json-translate' : 'passthrough' };
+      // Windows `.cmd`: prompt on stdin instead of the positional (util/agent-spawn).
+      // VERIFY `opencode run` reads stdin when no positional prompt is given.
+      if (!promptOnStdin) args.push(prompt);
+      return { args, stdinInput: promptOnStdin ? prompt : undefined, outputMode: mode === 'stream' ? 'json-translate' : 'passthrough' };
     },
     sessionDir() {
-      // opencode stores data under its XDG data dir.
-      return path.join(home(), '.local', 'share', 'opencode');
+      // opencode stores data under its XDG data dir: $XDG_DATA_HOME if set,
+      // else %LOCALAPPDATA% on Windows, else ~/.local/share on POSIX.
+      const xdg = process.env.XDG_DATA_HOME
+        || (process.platform === 'win32' ? process.env.LOCALAPPDATA : null)
+        || path.join(home(), '.local', 'share');
+      return path.join(xdg, 'opencode');
     },
     // No tailable session files, so interactive-TUI token tracking isn't wired
     // (headless runs track live here). JSONL is one {type, part} object per line,
@@ -980,6 +1016,10 @@ function installCommandFor(id, platform = process.platform) {
   const cmd = INSTALL_COMMANDS[id];
   if (!cmd) return null;
   if (typeof cmd === 'string') return cmd;
+  // Never fall back to the POSIX (`linux`) command on Windows: it's a
+  // `curl … | bash` pipe that would be injected verbatim into the generated
+  // PowerShell installer and fail. No win32 entry → no automated install there.
+  if (platform === 'win32') return cmd.win32 || null;
   return cmd[platform] || cmd.linux || null;
 }
 

--- a/main/state/claude-streaming.js
+++ b/main/state/claude-streaming.js
@@ -22,7 +22,7 @@
 //   * accumulated text lives in the registry so a late-mounting consumer
 //     can render the catch-up content immediately
 
-const { spawn } = require('child_process');
+const { spawnHeadlessAgent, promptGoesOnStdin } = require('../util/agent-spawn');
 const { loadConfig } = require('../util/config');
 const { appendStderr } = require('../util/exec');
 const agentRegistry = require('./agent-registry');
@@ -146,13 +146,19 @@ function spawnClaudeStream({
 
   // Pinned model/version for this agent (Gemini today), '' = the agent default.
   const model = (config.agentModel || {})[prov.id] || '';
-  const run = prov.buildHeadlessRun(bin, { prompt, mode, allowEdits, trust, model });
+  // When the CLI is a Windows `.cmd` shim it can't carry the multi-line prompt
+  // as a command-line arg (see util/agent-spawn), so providers return it on
+  // `stdinInput` instead and the helper writes it to stdin. False for native
+  // binaries and everywhere off Windows — the prompt stays a normal arg and
+  // behaviour is unchanged.
+  const promptOnStdin = promptGoesOnStdin(bin);
+  const run = prov.buildHeadlessRun(bin, { prompt, mode, allowEdits, trust, model, promptOnStdin });
   let proc;
   try {
-    proc = spawn(bin, run.args, {
+    proc = spawnHeadlessAgent(bin, run.args, {
       cwd,
-      stdio: ['ignore', 'pipe', 'pipe'],
-    });
+      stdio: [run.stdinInput != null ? 'pipe' : 'ignore', 'pipe', 'pipe'],
+    }, run.stdinInput);
   } catch (err) {
     authSlot.release(); // never spawned — free the concurrency slot
     throw err;

--- a/main/state/instances.js
+++ b/main/state/instances.js
@@ -309,7 +309,7 @@ function spawnInWorktree(name, worktreePath, branch, mode, resumeSessionId, extr
     // from the prior (different-agent) session, passed at spawn rather than
     // typed in (see util/agent-prompt + state/session-handoff).
     if (initialPrompt) {
-      const staged = stageInitialPrompt(provider, agentCmd, initialPrompt, `handoff-${id}`);
+      const staged = stageInitialPrompt(provider, agentCmd, initialPrompt, `handoff-${id}`, userShell);
       agentCmd = staged.agentCmd;
       promptFile = staged.promptFile;
       needsEnter = staged.needsEnter;

--- a/main/state/pr-chat-pty.js
+++ b/main/state/pr-chat-pty.js
@@ -23,6 +23,7 @@ const pty = require('node-pty');
 const { loadConfig } = require('../util/config');
 const { sanitizeExtraEnv } = require('../util/exec');
 const { defaultShell, shellRunCmdArgs } = require('../util/platform');
+const { promptFileArg } = require('../util/agent-prompt');
 const { getProvider, binFor } = require('./ai-providers');
 const { ensureWorktreeConsentSync } = require('../util/agent-consent');
 const { beginSession } = require('../util/agent-concurrency');
@@ -110,7 +111,7 @@ function startOrAttachChat({ worktreePath, provider = 'claude', seedPrompt, onDa
   const model = (config.agentModel || {})[prov.id] || '';
   const agentCmd = prov.buildInteractiveCmd(bin, { trust: consent.trust, model });
   const promptFlag = prov.interactivePromptFlag ? `${prov.interactivePromptFlag} ` : '';
-  const quotedPrompt = `"$(cat '${promptFile.replace(/'/g, "'\\''")}')"`;
+  const quotedPrompt = promptFileArg(promptFile, userShell);
   const shellCmd = `${agentCmd} ${promptFlag}${quotedPrompt}`;
   const args = shellRunCmdArgs(userShell, shellCmd);
 

--- a/main/state/pr-implement-pty.js
+++ b/main/state/pr-implement-pty.js
@@ -27,6 +27,7 @@ const pty = require('node-pty');
 const { loadConfig } = require('../util/config');
 const { sanitizeExtraEnv } = require('../util/exec');
 const { defaultShell, shellRunCmdArgs } = require('../util/platform');
+const { promptFileArg } = require('../util/agent-prompt');
 const { getProvider, binFor } = require('./ai-providers');
 const { ensureWorktreeConsentSync } = require('../util/agent-consent');
 const { beginSession } = require('../util/agent-concurrency');
@@ -259,7 +260,7 @@ function startImplementPty({ requestId, worktreePath, prompt, provider = 'claude
   // need a flag to execute it interactively (Gemini: `-i`). interactivePromptFlag
   // supplies that; default is none.
   const promptFlag = prov.interactivePromptFlag ? `${prov.interactivePromptFlag} ` : '';
-  const quotedPrompt = `"$(cat '${promptFile.replace(/'/g, "'\\''")}')"`;
+  const quotedPrompt = promptFileArg(promptFile, userShell);
   const shellCmd = `${agentCmd} ${promptFlag}${quotedPrompt}`;
   const args = shellRunCmdArgs(userShell, shellCmd);
 

--- a/main/state/precommit-hook.js
+++ b/main/state/precommit-hook.js
@@ -388,6 +388,17 @@ function startPrecommitServer() {
   // gate the whole feature there rather than half-install it.
   if (process.platform === 'win32') {
     console.warn('[precommit-hook] git-hook review not yet supported on Windows — skipping');
+    // Self-heal: a prior build installed the git hooks on Windows too, but the
+    // client script only gets written alongside a running server — which never
+    // starts here. Those orphaned hooks then `exec node <missing client>` and
+    // exit 1, BLOCKING every commit/push. Remove any we left behind (marker-
+    // gated, restores each repo's original hook). installHookForRepo is also
+    // gated below so we never re-install them.
+    try {
+      if ((loadConfig().precommitHookRepos || []).length) uninstallAllHooks();
+    } catch (e) {
+      console.warn('[precommit-hook] Windows hook cleanup failed:', e.message);
+    }
     return;
   }
   // Each instance owns a unique per-pid socket, so there's nothing to steal —
@@ -684,6 +695,11 @@ function installOneHook(hooksDir, hookName, repoPath) {
 // any pre-existing foreign hooks. No-op when the preference is off.
 function installHookForRepo(repoPath) {
   try {
+    // Windows: the socket server + client scripts aren't wired up yet (see
+    // startPrecommitServer's win32 gate), so installing the git hooks would
+    // leave a `node <missing client>` that exits 1 and blocks every commit/push.
+    // Never install on Windows until the named-pipe server lands.
+    if (process.platform === 'win32') return;
     const config = loadConfig();
     // Install when EITHER the review or the comment cleanup is enabled — both
     // run through the same pre-commit hook + socket server. Comment cleanup is

--- a/main/state/repo-intel.js
+++ b/main/state/repo-intel.js
@@ -265,10 +265,18 @@ async function pickInstaller() {
     await execFileP('uv', ['--version'], { timeout: 10000 });
     return { kind: 'uv' };
   } catch { /* no uv */ }
-  for (const py of ['python3', 'python']) {
+  // Interpreter candidates differ by OS. Stock python.org Windows installs ship
+  // the `py` launcher (invoked `py -3`) and NO `python3` — and a bare `python`
+  // is often the Microsoft Store alias stub — so `py -3` goes first on Windows.
+  // macOS/Linux reliably have `python3`. Each candidate carries its own prefix
+  // args (`pyArgs`) so callers can rebuild the exact interpreter invocation.
+  const candidates = process.platform === 'win32'
+    ? [{ py: 'py', pyArgs: ['-3'] }, { py: 'python', pyArgs: [] }, { py: 'python3', pyArgs: [] }]
+    : [{ py: 'python3', pyArgs: [] }, { py: 'python', pyArgs: [] }];
+  for (const c of candidates) {
     try {
-      await execFileP(py, ['-m', 'pip', '--version'], { timeout: 10000 });
-      return { kind: 'pip', py };
+      await execFileP(c.py, [...c.pyArgs, '-m', 'pip', '--version'], { timeout: 10000 });
+      return { kind: 'pip', py: c.py, pyArgs: c.pyArgs };
     } catch { /* try next */ }
   }
   return null;
@@ -280,7 +288,7 @@ async function pickInstaller() {
 // the externally-managed escape hatch. Wires PATH via `pipx ensurepath` +
 // refreshSpawnPath so the freshly-installed pipx is usable this session.
 // Returns true only if `pipx` is callable afterwards.
-async function bootstrapPipx(py) {
+async function bootstrapPipx(py, pyArgs = []) {
   const BIG = { timeout: 5 * 60 * 1000, maxBuffer: 16 * 1024 * 1024 };
   console.log('[repo-intel] no pipx/uv found — bootstrapping pipx in the background');
   let installed = false;
@@ -291,13 +299,13 @@ async function bootstrapPipx(py) {
   } catch { /* no brew, or brew install failed — try pip below */ }
   if (!installed && py) {
     try {
-      await execFileP(py, ['-m', 'pip', 'install', '--user', 'pipx'], BIG);
+      await execFileP(py, [...pyArgs, '-m', 'pip', 'install', '--user', 'pipx'], BIG);
       installed = true;
     } catch (err) {
       const msg = (err && err.stderr ? String(err.stderr) : '') + '\n' + ((err && err.message) || '');
       if (/externally-managed-environment|PEP ?668|break-system-packages/i.test(msg)) {
         try {
-          await execFileP(py, ['-m', 'pip', 'install', '--user', '--break-system-packages', 'pipx'], BIG);
+          await execFileP(py, [...pyArgs, '-m', 'pip', 'install', '--user', '--break-system-packages', 'pipx'], BIG);
           installed = true;
         } catch { /* give up on pip bootstrap */ }
       }
@@ -305,7 +313,7 @@ async function bootstrapPipx(py) {
   }
   if (!installed) return false;
   // Wire the new pipx onto PATH for this session.
-  try { await execFileP(py || 'python3', ['-m', 'pipx', 'ensurepath'], { timeout: 30000 }); } catch {}
+  try { await execFileP(py || 'python3', [...pyArgs, '-m', 'pipx', 'ensurepath'], { timeout: 30000 }); } catch {}
   try { require('../bootstrap/app-events').refreshSpawnPath(); } catch {}
   try { await execFileP('pipx', ['--version'], { timeout: 10000 }); return true; }
   catch { return false; }
@@ -338,7 +346,7 @@ function ensureReviewTools() {
     // user in the background and prefer it, so the tools land in clean venvs
     // instead of leaning on pip's PEP 668 escape hatch. Falls back to pip if the
     // bootstrap doesn't take.
-    if (installer.kind === 'pip' && await bootstrapPipx(installer.py)) {
+    if (installer.kind === 'pip' && await bootstrapPipx(installer.py, installer.pyArgs)) {
       console.log('[repo-intel] bootstrapped pipx');
       installer = { kind: 'pipx' };
     }
@@ -355,11 +363,11 @@ function ensureReviewTools() {
       // the plain install; retry once with --break-system-packages — the
       // documented escape hatch, safe here since --user can't touch system pkgs.
       try {
-        return await execFileP(installer.py, ['-m', 'pip', 'install', '--user', pkg], BIG);
+        return await execFileP(installer.py, [...(installer.pyArgs || []), '-m', 'pip', 'install', '--user', pkg], BIG);
       } catch (err) {
         const msg = (err && err.stderr ? String(err.stderr) : '') + '\n' + ((err && err.message) || '');
         if (/externally-managed-environment|PEP ?668|break-system-packages/i.test(msg)) {
-          return execFileP(installer.py, ['-m', 'pip', 'install', '--user', '--break-system-packages', pkg], BIG);
+          return execFileP(installer.py, [...(installer.pyArgs || []), '-m', 'pip', 'install', '--user', '--break-system-packages', pkg], BIG);
         }
         throw err;
       }
@@ -421,11 +429,11 @@ async function upgradeReviewToolsIfDue() {
           await execFileP('uv', ['tool', 'upgrade', pkg], BIG);
         } else {
           try {
-            await execFileP(installer.py, ['-m', 'pip', 'install', '--user', '-U', pkg], BIG);
+            await execFileP(installer.py, [...(installer.pyArgs || []), '-m', 'pip', 'install', '--user', '-U', pkg], BIG);
           } catch (err) {
             const msg = (err && err.stderr ? String(err.stderr) : '') + '\n' + ((err && err.message) || '');
             if (/externally-managed-environment|PEP ?668|break-system-packages/i.test(msg)) {
-              await execFileP(installer.py, ['-m', 'pip', 'install', '--user', '-U', '--break-system-packages', pkg], BIG);
+              await execFileP(installer.py, [...(installer.pyArgs || []), '-m', 'pip', 'install', '--user', '-U', '--break-system-packages', pkg], BIG);
             }
           }
         }

--- a/main/util/agent-prompt.js
+++ b/main/util/agent-prompt.js
@@ -11,6 +11,7 @@ const fs = require('fs');
 const os = require('os');
 const path = require('path');
 const crypto = require('crypto');
+const { isPosixShell } = require('./platform');
 
 // Returns { agentCmd, promptFile, needsEnter }:
 //   agentCmd  — the command with the staged prompt appended (or unchanged if no
@@ -18,7 +19,20 @@ const crypto = require('crypto');
 //   promptFile — tempfile path to unlink on PTY exit (null if nothing staged)
 //   needsEnter — true for TUIs (codex) that pre-fill but wait for an Enter to
 //               submit; the caller nudges the PTY with '\r' once it's up.
-function stageInitialPrompt(provider, agentCmd, prompt, tag = 'prompt') {
+// Build the shell expression that expands a staged prompt file into a single
+// argument, matching the shell the command will run under (see shellRunCmdArgs).
+// POSIX shells (mac/Linux, or Git Bash on Windows) use `$(cat …)`; the Windows
+// default shell is PowerShell, which needs `(Get-Content -Raw …)` — `$(cat
+// 'file')` there runs Get-Content and flattens the newlines via $OFS, defeating
+// the whole point of staging a multi-line prompt to a file.
+function promptFileArg(promptFile, shellPath = null) {
+  const usePosix = isPosixShell(shellPath) || process.platform !== 'win32';
+  return usePosix
+    ? `"$(cat '${promptFile.replace(/'/g, "'\\''")}')"`
+    : `(Get-Content -Raw -LiteralPath '${promptFile.replace(/'/g, "''")}')`;
+}
+
+function stageInitialPrompt(provider, agentCmd, prompt, tag = 'prompt', shellPath = null) {
   if (!prompt || !prompt.trim()) return { agentCmd, promptFile: null, needsEnter: false };
   try {
     const dir = path.join(os.tmpdir(), 'klaussy-action-prompts');
@@ -26,7 +40,7 @@ function stageInitialPrompt(provider, agentCmd, prompt, tag = 'prompt') {
     const promptFile = path.join(dir, `${tag}-${crypto.randomBytes(6).toString('hex')}.txt`);
     fs.writeFileSync(promptFile, prompt);
     const promptFlag = provider.interactivePromptFlag ? `${provider.interactivePromptFlag} ` : '';
-    const quoted = `"$(cat '${promptFile.replace(/'/g, "'\\''")}')"`;
+    const quoted = promptFileArg(promptFile, shellPath);
     return {
       agentCmd: `${agentCmd} ${promptFlag}${quoted}`,
       promptFile,
@@ -38,4 +52,4 @@ function stageInitialPrompt(provider, agentCmd, prompt, tag = 'prompt') {
   }
 }
 
-module.exports = { stageInitialPrompt };
+module.exports = { stageInitialPrompt, promptFileArg };

--- a/main/util/agent-spawn.js
+++ b/main/util/agent-spawn.js
@@ -1,0 +1,111 @@
+// Cross-platform headless spawn for the agent CLIs.
+//
+// macOS/Linux: a bare `spawn(bin, args)` resolves the CLI on PATH and passes
+// each arg (including a large multi-line prompt) as its own argv element — no
+// shell, no quoting concerns. That path is preserved exactly.
+//
+// Windows is the problem the rest of this file exists for. The agent CLIs are
+// installed as npm `.cmd` shims (`claude.cmd`, `gemini.cmd`, …). Node can't
+// spawn a `.cmd` directly — `CreateProcess` only appends `.exe` (never consults
+// PATHEXT), and Node 24 refuses `.cmd`/`.bat` without a shell — so `spawn('claude')`
+// throws ENOENT. Routing through the shell fixes the launch, but a `.cmd` runs
+// under cmd.exe, whose command line CANNOT carry a multi-line argument (a newline
+// terminates the command). The review prompts are large and multi-line, so the
+// prompt must arrive on STDIN instead; callers pass `stdinInput` and build
+// `args` as short single-line flags only. A resolved native `.exe` has neither
+// problem and is spawned directly with the full args array.
+//
+// This whole module no-ops to plain `spawn` off Windows, so it's safe to route
+// every headless agent launch through it.
+
+const { spawn } = require('child_process');
+const { whichBinSync } = require('./platform');
+
+const IS_WIN = process.platform === 'win32';
+
+// Whether a headless prompt must be delivered on stdin rather than as a
+// command-line arg for this bin: true only on Windows when the CLI resolves to a
+// `.cmd`/`.bat` shim (which can't carry a multi-line arg through cmd.exe). A
+// native `.exe` (e.g. antigravity's `agy`) takes the multi-line arg fine, so it
+// stays arg-based. Callers pass the result as `promptOnStdin` to buildHeadlessRun.
+function promptGoesOnStdin(bin) {
+  if (!IS_WIN || !bin) return false;
+  const resolved = whichBinSync(bin) || bin;
+  return /\.(cmd|bat)$/i.test(resolved);
+}
+
+function writeStdin(proc, stdinInput) {
+  if (stdinInput == null || !proc.stdin) return;
+  try {
+    proc.stdin.write(stdinInput);
+    proc.stdin.end();
+  } catch { /* child already gone / pipe closed — its own exit handling covers it */ }
+}
+
+// Spawn a headless agent process. `stdinInput` (optional) is written to the
+// child's stdin then closed — required on Windows for `.cmd` shims (see header),
+// harmless elsewhere. `opts.stdio` must include a writable stdin ('pipe') when
+// stdinInput is used.
+function spawnHeadlessAgent(bin, args, opts = {}, stdinInput = null) {
+  if (!IS_WIN) {
+    const proc = spawn(bin, args, opts);
+    writeStdin(proc, stdinInput);
+    return proc;
+  }
+  // Resolve the real target via where.exe (whichBinSync) so we know whether it's
+  // a native .exe or a .cmd/.bat shim. Fall back to the bare name if unresolved.
+  const resolved = whichBinSync(bin) || bin;
+  const isShim = /\.(cmd|bat)$/i.test(resolved);
+  const proc = isShim
+    // .cmd/.bat: go through the shell so cmd.exe runs the shim. The npm global
+    // shim path has no spaces (`%APPDATA%\npm\…`), and args are short flags (the
+    // prompt is on stdin), so shell:true's unquoted join is safe for the common
+    // case. NOTE: a username with a space in the profile path is a known gap.
+    ? spawn(resolved, args, { ...opts, shell: true })
+    // native .exe: spawn directly — a multi-line argv element is fine here.
+    : spawn(resolved, args, opts);
+  writeStdin(proc, stdinInput);
+  return proc;
+}
+
+// Buffered one-shot variant of spawnHeadlessAgent, shaped like child_process
+// execFile but with the same Windows `.cmd`/stdin handling. Resolves (never
+// rejects) with { stdout, stderr, error? }. `opts`: { cwd, timeout, maxBuffer }.
+function execHeadlessAgent(bin, args, opts = {}, stdinInput = null) {
+  const { cwd, timeout = 0, maxBuffer = 1024 * 1024 } = opts;
+  return new Promise((resolve) => {
+    let proc;
+    try {
+      proc = spawnHeadlessAgent(bin, args, {
+        cwd,
+        stdio: [stdinInput != null ? 'pipe' : 'ignore', 'pipe', 'pipe'],
+      }, stdinInput);
+    } catch (err) {
+      resolve({ stdout: '', stderr: '', error: err.message });
+      return;
+    }
+    let stdout = '';
+    let stderr = '';
+    let overflow = false;
+    let timedOut = false;
+    const timer = timeout ? setTimeout(() => { timedOut = true; try { proc.kill(); } catch { /* already gone */ } }, timeout) : null;
+    proc.stdout.on('data', (d) => {
+      stdout += d;
+      if (stdout.length > maxBuffer) { overflow = true; try { proc.kill(); } catch { /* already gone */ } }
+    });
+    proc.stderr.on('data', (d) => { stderr += d; });
+    proc.on('error', (err) => {
+      if (timer) clearTimeout(timer);
+      resolve({ stdout, stderr, error: err.message });
+    });
+    proc.on('close', (code) => {
+      if (timer) clearTimeout(timer);
+      if (timedOut) return resolve({ stdout, stderr, error: `timed out after ${timeout}ms` });
+      if (overflow) return resolve({ stdout, stderr, error: 'maxBuffer exceeded' });
+      if (code !== 0) return resolve({ stdout, stderr, error: stderr || `exited with code ${code}` });
+      resolve({ stdout, stderr });
+    });
+  });
+}
+
+module.exports = { spawnHeadlessAgent, execHeadlessAgent, promptGoesOnStdin };

--- a/main/util/git-repo.js
+++ b/main/util/git-repo.js
@@ -34,7 +34,10 @@ function baseRepoForWorktree(worktreePath) {
 function sessionSiblingWorktrees(worktreePath) {
   try {
     if (typeof worktreePath !== 'string') return [];
-    const m = worktreePath.replace(/\/+$/, '').match(/^(.*\/klaussy\/sessions\/[^/]+)\/([^/]+)$/);
+    // Normalize `\`→`/` first so Windows session paths (C:\Users\..\klaussy\
+    // sessions\name\repo) match too; Node's fs/path accept forward slashes on
+    // Windows, so the derived paths below still work.
+    const m = worktreePath.replace(/\\/g, '/').replace(/\/+$/, '').match(/^(.*\/klaussy\/sessions\/[^/]+)\/([^/]+)$/);
     if (!m) return [];
     const sessionDir = m[1];
     const current = m[2];

--- a/preload.js
+++ b/preload.js
@@ -779,6 +779,7 @@ contextBridge.exposeInMainWorld('klaus', {
     createMemory: (filePath) => ipcRenderer.invoke('create-memory-file', { filePath }),
     listMcp: () => ipcRenderer.invoke('list-mcp-servers'),
     listPlugins: () => ipcRenderer.invoke('list-plugins'),
+    resolveSkill: (worktreePath, agentId, kind) => ipcRenderer.invoke('resolve-skill', { worktreePath, agentId, kind }),
   },
 
   // ---- mcp: manage MCP server connections across every agent ----

--- a/renderer/file-browser.js
+++ b/renderer/file-browser.js
@@ -247,19 +247,76 @@ window.FileBrowser = (function () {
     }
   }
 
-  // "Figure out how to run this app and run it" flow. Hands off to Claude Code
-  // in a sub-terminal, which inspects the repo, picks a command, and runs it
-  // (with tool-use approval) interactively.
-  function runApp() {
+  // Built-in template used when the worktree has no <repo>-run skill (a repo
+  // generated before klaussy-agents 0.14, or one klaussy doesn't manage). Mirrors
+  // the run skill's body so unmanaged repos still get the structured flow — the
+  // skill body is repo-agnostic (only its frontmatter name is namespaced), so
+  // this stays a faithful fallback. Same prefer-skill-else-template shape as the
+  // PR-review flow's PR_REVIEW_TEMPLATE.
+  var RUN_APP_FALLBACK_PROMPT = [
+    'Run this project\'s app in the current working directory and drive it far',
+    'enough to observe its behavior — don\'t just start it and call it done.',
+    '',
+    '1. Read CLAUDE.md — its Commands section is the source of truth for how this',
+    '   project installs, builds, and runs. Prefer a run / start / serve / dev',
+    '   entry, a CLI entrypoint, or a server command. If it exposes more than one',
+    '   (e.g. a CLI and a server) and it\'s ambiguous which to run, ask.',
+    '2. Read any .claude/rules/*.md whose paths glob covers the code you\'ll',
+    '   exercise — it may note required env vars, ports, or setup.',
+    '3. If CLAUDE.md names no run command, fall back to the stack default',
+    '   (package.json scripts dev/start/serve, pyproject [project.scripts],',
+    '   go run, cargo run). If you still can\'t tell, ask — don\'t guess and run',
+    '   something destructive.',
+    '4. Install/build first only if needed. If the app needs an env var, config,',
+    '   or secret that isn\'t present, STOP and ask rather than inventing a value.',
+    '5. For a one-shot (CLI/script/build) invoke it directly, starting with a',
+    '   cheap --help/--version sanity call then a representative real command. For',
+    '   a long-running process (server/watcher/daemon), start it in the background,',
+    '   wait for its ready signal, drive it from a second command, then tear it',
+    '   down — don\'t leave a stray process running.',
+    '6. Capture the actual output and state plainly whether it matches expected',
+    '   behavior. If it failed, show the real error; don\'t paper over it.',
+    '',
+    'Do NOT change code to make the app run, and never use production credentials',
+    'or a production service — local/dev only unless I say otherwise.',
+  ].join('\n');
+
+  // "Figure out how to run this app and run it" flow. Hands off to the task's
+  // OWN agent (Claude / Codex / Gemini / …) in a sub-terminal via
+  // openClaudeSubTerminal, which resolves the agent from the parent task's mode
+  // exactly like the Plan/Debug/Review actions — not a hardcoded `claude`.
+  //
+  // The seed prompt is agent-neutral prose — NOT a Claude `/<skill>` slash
+  // command. klaussy scaffolds the same <repo>-run skill into every agent's own
+  // skills dir (klaussy-agents >= 0.14), and these skills are model-invoked by
+  // description across all agents, so naming the skill in plain prose triggers
+  // it everywhere Claude's slash syntax would only work in Claude. We resolve
+  // the skill in the TASK agent's own dir (a Gemini task looks in .gemini/skills,
+  // not .claude/skills); if this agent has no run skill (aider, or a repo
+  // generated before it existed), we seed the self-contained RUN_APP_FALLBACK_-
+  // PROMPT instead — also plain prose that any agent can follow directly.
+  async function runApp() {
     var taskId = AppState.activeTaskId;
     if (taskId == null) return;
-    var prompt = 'Find how to run this app in the current working directory ' +
-      'and run it. Show its output. If there is ambiguity between dev vs prod ' +
-      'or between multiple entry points, pick the most likely dev entry point ' +
-      'and note your choice.';
-    var command = 'claude ' + shellQuote(prompt);
-    if (window.TerminalManager && window.TerminalManager.runInSubTerminal) {
-      window.TerminalManager.runInSubTerminal(taskId, '▶ Run App', command);
+    var task = AppState.tasks.get(taskId);
+    var worktree = task ? task.worktreePath : null;
+
+    // Resolve the agent the same way openClaudeSubTerminal will when it spawns,
+    // so we look for the skill in the dir of the agent that actually runs.
+    var defaultAgent = (AppState.savedPrefs && (AppState.savedPrefs.defaultProvider || AppState.savedPrefs.defaultMode)) || 'claude';
+    var agentMode = (task && task.mode && task.mode !== 'shell') ? task.mode : defaultAgent;
+
+    var skillName = null;
+    if (worktree && window.klaus && window.klaus.skills && window.klaus.skills.resolveSkill) {
+      try { skillName = await window.klaus.skills.resolveSkill(worktree, agentMode, 'run'); } catch (_e) { /* fall back to prose */ }
+    }
+
+    var prompt = skillName
+      ? 'Use your "' + skillName + '" skill to run this project\'s app in the current '
+        + 'working directory and drive it end-to-end, then report what you observed.'
+      : RUN_APP_FALLBACK_PROMPT;
+    if (window.TerminalManager && window.TerminalManager.openClaudeSubTerminal) {
+      window.TerminalManager.openClaudeSubTerminal(taskId, '▶ Run App', prompt);
     }
   }
 

--- a/renderer/plan-modal.js
+++ b/renderer/plan-modal.js
@@ -13,31 +13,40 @@ window.ActionModal = (function () {
   var tabs = overlay ? overlay.querySelectorAll('.plan-modal-tab') : [];
   var contents = overlay ? overlay.querySelectorAll('.plan-tab-content') : [];
 
-  // Plan flow runs locally (no cloud round-trip), so it gets the full prompt
-  // inlined the same way Review does. The earlier `/ultraplan` slash command
-  // launched a remote session which has no access to the user's chat context
-  // (or any uncommitted code) — for a worktree-scoped tab that's the wrong
-  // shape. Debug stays as a local slash command since `/debug` ships with
-  // Claude Code itself.
+  // Each action prefers the repo's own klaussy-generated <repo>-<action> skill
+  // (resolved per-agent — a Codex task looks in Codex's skills dir), seeded with
+  // an agent-neutral "use your <skill> skill" prompt that any agent's skill
+  // system triggers on by name. The inlined prompts below are the FALLBACK for
+  // repos that have no such skill (generated before it existed, or not
+  // klaussy-managed); they're project-agnostic and self-contained.
+  //
+  // Plan flow runs locally (no cloud round-trip), so its fallback is inlined the
+  // same way Review's is. The earlier `/ultraplan` slash command launched a
+  // remote session which has no access to the user's chat context (or any
+  // uncommitted code) — for a worktree-scoped tab that's the wrong shape. Debug
+  // no longer uses Claude Code's built-in `/debug` slash (meaningless to other
+  // agents); its fallback is the agent-neutral DEBUG_PROMPT.
   //
   // The prompt itself is intentionally project-agnostic: Klaussy users invoke
   // it from their own repos, not from this one, so anything Klaussy-specific
   // would be wrong advice in the spawned tab.
   //
-  // Self-contained — no Claude Code plugin install required. Shape borrowed
-  // from the official `feature-dev` skill (parallel exploration, multi-
-  // architect compare, post-implementation review) but the specialized agent
-  // bodies (the analysis approach, architect process, reviewer process) are
-  // inlined here so every spawned tab has them whether or not the user has
-  // any plugins installed. All sub-Agent calls use `subagent_type: general-
-  // purpose`, which ships with Claude Code by default. Anti-patterns kept as
-  // universal craft rules; the prompt instructs Claude to read the target
-  // repo's CLAUDE.md / README / CONTRIBUTING for project-specific rules and
-  // append them to its working list.
+  // Self-contained and agent-neutral — no plugin install required, and no
+  // Claude-specific tool assumptions (it runs in whichever agent the task uses).
+  // Shape borrowed from the official `feature-dev` skill (parallel exploration,
+  // multi-architect compare, post-implementation review) but the specialized
+  // agent bodies (the analysis approach, architect process, reviewer process)
+  // are inlined here so every spawned tab has them. Parallelism is expressed
+  // generically ("use your subagent mechanism, or work through them one at a
+  // time") so agents without a spawn primitive still complete the flow; progress
+  // is a plain checklist rather than any specific todo tool. Anti-patterns kept
+  // as universal craft rules; the prompt instructs the agent to read the target
+  // repo's CLAUDE.md / AGENTS.md / README / CONTRIBUTING for project-specific
+  // rules and append them to its working list.
   var PLAN_PROMPT = [
     'You are helping plan and implement a task. Follow these phases in order — do NOT skip Phase 3 (clarifying questions).',
     '',
-    'Use TodoWrite throughout: create one task per phase up front, mark each in_progress when starting and completed when done. The flow is long-running, and the todo list keeps the user oriented.',
+    'Track progress throughout: keep a running checklist with one item per phase, marking each in progress when you start it and done when you finish (use your task-tracking tool if you have one). The flow is long-running, and the checklist keeps the user oriented.',
     '',
     '## Phase 1 — Discovery',
     '',
@@ -54,7 +63,7 @@ window.ActionModal = (function () {
     '',
     '## Phase 2 — Understand (parallel exploration)',
     '',
-    'Launch 2–3 explore subagents IN PARALLEL via the Agent tool with `subagent_type: general-purpose`. Pass each agent BOTH the analysis approach AND the angle below in its prompt — they need that context inline because they don\'t see this master prompt. Mark this phase\'s todo in_progress when the agents are dispatched.',
+    'Launch 2–3 exploration subagents IN PARALLEL using your agent/subagent mechanism (whatever your tool calls it — Task, subagent, spawn). If you have no way to spawn subagents, work through the angles below yourself, one at a time. Pass each subagent BOTH the analysis approach AND its angle inline — they don\'t see this master prompt. Mark this phase in progress when exploration starts.',
     '',
     '### Analysis approach (every explore agent uses this)',
     '',
@@ -84,11 +93,11 @@ window.ActionModal = (function () {
     '',
     'If the user replies "your call" or "no preference," commit to a recommendation and explicitly confirm it.',
     '',
-    '## Phase 4 — Design (parallel architectures, in plan mode)',
+    '## Phase 4 — Design (parallel architectures — design only, no edits)',
     '',
-    '**Enter plan mode now** — design and approval must happen before any edits. Stay in plan mode through Phase 5.',
+    '**Design only from here — make NO file edits.** Design and approval must happen before any code changes. Stay read-only through Phase 5.',
     '',
-    'Launch 2–3 architect subagents IN PARALLEL via the Agent tool with `subagent_type: general-purpose`. Pass each agent the architect process below + their priority + the user\'s task + the answers from Phase 3 + the file list and findings from Phase 2 — they need all of that inline.',
+    'Launch 2–3 architect subagents IN PARALLEL using your agent/subagent mechanism (or, if you can\'t spawn subagents, produce each architecture yourself in turn). Pass each the architect process below + their priority + the user\'s task + the answers from Phase 3 + the file list and findings from Phase 2 — they need all of that inline.',
     '',
     '### Architect process (every architect uses this)',
     '',
@@ -111,11 +120,11 @@ window.ActionModal = (function () {
     '',
     '## Phase 5 — Approval gate',
     '',
-    'Still in plan mode. Write the chosen plan to the plan file, and output the complete plan in your chat response so the user can see it immediately. To prevent blocking or proceeding without review, you MUST end your turn here by calling no other tools (do NOT run the terminal command `ExitPlanMode` or make any edits yet). Ask the user to confirm the plan in the chat. Once the user replies to approve, run the terminal command `ExitPlanMode` in your next turn to register the plan with the desktop app, and then proceed to Phase 6.',
+    'Still making no edits. Write the chosen plan to a plan file (any filename containing "plan", e.g. `plan.md`), and output the complete plan in your response so the user can see it immediately. Stop here and wait — do NOT run the `ExitPlanMode` command or make any edits yet. Ask the user to confirm the plan. Once the user replies to approve, run the terminal command `ExitPlanMode` (a Klaussy CLI on your PATH — works from any agent) to register the plan with the desktop app, and then proceed to Phase 6.',
     '',
     '## Phase 6 — Implementation',
     '',
-    'Work in small, independently-shippable batches. Update TodoWrite as each batch starts and completes. After each batch:',
+    'Work in small, independently-shippable batches. Update your checklist as each batch starts and completes. After each batch:',
     '- Verify the code parses / compiles / lints (`node -c`, `tsc --noEmit`, `cargo check`, etc., as the language requires).',
     '- Briefly state what changed (1–2 sentences).',
     '- Pause if the next batch touches a different surface area or needs a separate user decision.',
@@ -124,7 +133,7 @@ window.ActionModal = (function () {
     '',
     '## Phase 7 — Quality review (parallel)',
     '',
-    'After implementation, launch 3 reviewer subagents IN PARALLEL via the Agent tool with `subagent_type: general-purpose`. Pass each agent the reviewer process below + their focus + the diff (`git diff main...HEAD` or equivalent) + any context files they\'ll need.',
+    'After implementation, launch 3 reviewer subagents IN PARALLEL using your agent/subagent mechanism (or review each focus yourself in turn if you can\'t spawn subagents). Pass each the reviewer process below + their focus + the diff (`git diff main...HEAD` or equivalent) + any context files they\'ll need.',
     '',
     '### Reviewer process (every reviewer uses this)',
     '',
@@ -149,7 +158,7 @@ window.ActionModal = (function () {
     '',
     '## Phase 8 — Summary',
     '',
-    'Write a 3–5 line summary: what was built, key decisions, files modified, suggested next steps. Mark all TodoWrite tasks complete.',
+    'Write a 3–5 line summary: what was built, key decisions, files modified, suggested next steps. Mark all checklist items complete.',
     '',
     '## Anti-patterns to avoid (universal craft rules)',
     '',
@@ -171,8 +180,27 @@ window.ActionModal = (function () {
     '{{TASK}}',
   ].join('\n');
 
+  // Agent-neutral debug fallback — used when the repo has no <repo>-debug skill.
+  // Replaces the old `/debug ` seed, which was a Claude Code built-in slash
+  // command and meant nothing to Codex/Gemini/etc. Prose any agent can follow;
+  // mirrors the klaussy debug skill's phases (reproduce → root-cause read-only →
+  // failing test → minimal fix → verify). The user's details are appended.
+  var DEBUG_PROMPT = [
+    'Help me debug and fix this issue. Work through it methodically:',
+    '',
+    '1. Reproduce it — establish the exact steps and the observed vs expected behavior before changing anything.',
+    '2. Diagnose the root cause read-only — trace the code path and confirm a hypothesis with evidence (logs, a minimal repro), don\'t guess.',
+    '3. Write a failing test that captures the bug, where the project has a test suite.',
+    '4. Apply the smallest fix that addresses the root cause, not the symptom.',
+    '5. Verify — the new test passes and the full suite still passes. Report what was wrong and what you changed.',
+    '',
+    'The issue:',
+    '',
+    '',
+  ].join('\n');
+
   // Per-action config — title shown at the top of the modal, the submission
-  // builder for the new Claude tab, and a human label for the tab itself.
+  // builder for the new agent tab, and a human label for the tab itself.
   // Review runs a fixed multi-phase prompt and skips the modal entirely, so
   // it has no entry here.
   var ACTIONS = {
@@ -181,6 +209,12 @@ window.ActionModal = (function () {
       title: 'Plan a task',
       submitLabel: 'Plan',
       hint: 'Provide details. A new agent tab opens on this worktree and runs a multi-agent flow: discovery → parallel exploration → clarify → parallel architectures → approve → implement → parallel review → summary. All local, no cloud round-trip.',
+      // Preferred path: delegate to the repo's own <repo>-plan skill by name
+      // (agent-neutral — every agent's skill system triggers on the name).
+      skillSeed: function (skillName, content) {
+        return 'Use your "' + skillName + '" skill to plan and implement this task:\n\n' + content;
+      },
+      // Fallback when the repo has no plan skill: the self-contained prompt.
       buildSubmission: function (content) {
         return PLAN_PROMPT.replace('{{TASK}}', content);
       },
@@ -189,18 +223,21 @@ window.ActionModal = (function () {
       label: 'Debug',
       title: 'Debug an issue',
       submitLabel: 'Debug',
-      hint: 'Provide details. A new agent tab will open on this worktree and run <code>/debug</code>.',
+      hint: 'Provide details. A new agent tab opens on this worktree and runs the repo\'s debug flow.',
+      skillSeed: function (skillName, content) {
+        return 'Use your "' + skillName + '" skill to debug this issue:\n\n' + content;
+      },
       buildSubmission: function (content) {
-        return '/debug ' + content;
+        return DEBUG_PROMPT + content;
       },
     },
   };
 
-  // Review runs this prompt as-is in a new Claude tab. It contains
-  // {{BASE_BRANCH}} and {{REPO_SPECIFIC_CHECKS}} placeholders; the prompt
-  // itself instructs Claude how to resolve them ("default to dev if
-  // available, otherwise main" / fallback to CLAUDE.md), so we do not
-  // substitute them here.
+  // Review runs this prompt as-is in a new agent tab (agent-neutral — no Claude-
+  // specific tool assumptions). It contains {{BASE_BRANCH}} and
+  // {{REPO_SPECIFIC_CHECKS}} placeholders; the prompt itself instructs the agent
+  // how to resolve them ("default to dev if available, otherwise main" /
+  // fallback to CLAUDE.md), so we do not substitute them here.
   var REVIEW_PROMPT = [
     'You are conducting a thorough PR review. Follow these phases in order.',
     '',
@@ -215,7 +252,7 @@ window.ActionModal = (function () {
     '1. Run `git diff --stat <base-ref>...HEAD` and count the total lines changed (additions + deletions). The three-dot `...` form scopes the diff to your branch only (changes since it diverged from the base).',
     '2. Run `git diff <base-ref>...HEAD` to get the full diff.',
     '3. Run `git log <base-ref>..HEAD --oneline` to understand commit history and intent.',
-    '4. **Read the full file (not just the diff hunks) for every changed file** listed in the stat output. These are independent reads — issue them all in a single batch of parallel tool calls (one assistant message containing multiple Read tool_use blocks), not sequentially.',
+    '4. **Read the full file (not just the diff hunks) for every changed file** listed in the stat output. These are independent reads — batch them in parallel if your tools allow, otherwise read them one after another; just make sure every changed file is read in full.',
     '5. If the branch name contains a ticket reference (e.g. FEAT-1234), note it for context.',
     '',
     'Store the diff output, file contents, and commit log — you will need them in the next phase.',
@@ -309,7 +346,7 @@ window.ActionModal = (function () {
     '',
     '## Parallel Review',
     '',
-    'This PR is large enough to benefit from focused, parallel review. Use the **Agent tool** with `subagent_type: general-purpose` to launch the selected review sub-agents **simultaneously in a single assistant message** (parallel tool calls).',
+    'This PR is large enough to benefit from focused, parallel review. Launch the selected review sub-agents **simultaneously** using your agent/subagent mechanism (whatever your tool provides). If you have no way to spawn sub-agents, apply each lens below yourself, one at a time, and combine the findings.',
     '',
     'For each sub-agent, compose the prompt body as: the **Common scaffold** below (with `[PASTE THE FULL DIFF HERE]` and `[PASTE THE COMMIT LOG HERE]` replaced by the actual diff and commit log from Phase 1), then the sub-agent\'s `## Lens` section, then its `## Additional rules` if any.',
     '',
@@ -779,6 +816,25 @@ window.ActionModal = (function () {
     }
   }
 
+  // Resolve the repo's <repo>-<kind> skill for the task's agent, so an action
+  // can delegate to it by name instead of firing a Claude-flavored inline
+  // prompt. Same agent resolution as repoIntelFor (parent task's agent, else
+  // the default). Returns null when the agent has no such skill — the caller
+  // falls back to the inlined prompt. Never throws.
+  async function resolveSkillFor(taskId, kind) {
+    try {
+      var task = AppState.tasks.get(taskId);
+      if (!task || !task.worktreePath) return null;
+      if (!(window.klaus && window.klaus.skills && window.klaus.skills.resolveSkill)) return null;
+      var defaultAgent = (AppState.savedPrefs && (AppState.savedPrefs.defaultProvider || AppState.savedPrefs.defaultMode)) || 'claude';
+      var agent = (task.mode && task.mode !== 'shell') ? task.mode : defaultAgent;
+      return await window.klaus.skills.resolveSkill(task.worktreePath, agent, kind);
+    } catch (e) {
+      console.warn('[plan-modal resolve-skill]', e);
+      return null;
+    }
+  }
+
   // Session context: when this worktree is part of a multi-repo session,
   // tell the agent about ALL the repos so it plans for the whole space, not
   // just its own checkout. '' for single-repo / non-session worktrees. The
@@ -820,7 +876,10 @@ window.ActionModal = (function () {
     submitBtn.disabled = true;
     submitBtn.textContent = 'Starting…';
     try {
-      var command = cfg.buildSubmission(content);
+      // Prefer the repo's own <repo>-<action> skill (agent-neutral seed); fall
+      // back to the inlined prompt when the agent has no such skill.
+      var skillName = cfg.skillSeed ? await resolveSkillFor(currentTaskId, currentAction) : null;
+      var command = skillName ? cfg.skillSeed(skillName, content) : cfg.buildSubmission(content);
       // Multi-repo session awareness first (the full space), then this repo's
       // conventions/graph context.
       var sessionCtx = await sessionContextFor(currentTaskId);
@@ -844,17 +903,25 @@ window.ActionModal = (function () {
     }
   }
 
-  // Review has no modal — it just spawns a Claude sub-tab and fires the
-  // full review prompt. Returns the same shape as openClaudeSubTerminal so
-  // the caller can surface errors. When repo intel is cached we substitute
-  // the {{REPO_SPECIFIC_CHECKS}} placeholder with it; otherwise the
-  // placeholder stays and the prompt's own fallback (read CLAUDE.md) applies.
+  // Review has no modal — it just spawns an agent sub-tab and fires the review.
+  // Returns the same shape as openClaudeSubTerminal so the caller can surface
+  // errors. Prefers the repo's own <repo>-review skill (agent-neutral seed);
+  // otherwise falls back to the inlined REVIEW_PROMPT. Repo-intel/session
+  // context is appended either way — substituted into the fallback's
+  // {{REPO_SPECIFIC_CHECKS}} placeholder, or appended to the skill seed.
   async function runReview(taskId) {
-    var prompt = REVIEW_PROMPT;
+    var skillName = await resolveSkillFor(taskId, 'review');
     var sessionCtx = await sessionContextFor(taskId);
     var intel = await repoIntelFor(taskId);
     var block = [sessionCtx, intel].filter(Boolean).join('\n\n');
-    if (block) prompt = prompt.split('{{REPO_SPECIFIC_CHECKS}}').join('\n' + block + '\n');
+    var prompt;
+    if (skillName) {
+      prompt = 'Use your "' + skillName + '" skill to review this branch and report the findings.';
+      if (block) prompt += '\n\n' + block;
+    } else {
+      prompt = REVIEW_PROMPT;
+      if (block) prompt = prompt.split('{{REPO_SPECIFIC_CHECKS}}').join('\n' + block + '\n');
+    }
     return TerminalManager.openClaudeSubTerminal(taskId, 'Review', prompt);
   }
 


### PR DESCRIPTION
## Summary

Two threads of work:

1. **Run-skill handoffs + agent-neutral action prompts.** The **Run App / Plan / Debug / Review** actions now prefer the repo's own per-agent `<repo>-<kind>` skill (resolved in the task agent's own skills dir) via an agent-neutral "use your skill" seed, falling back to self-contained prose that carries no Claude-specific tool assumptions.
2. **Windows cross-platform support (macOS / Linux / Windows).** An audit found the app worked on macOS/Linux but broke on Windows in several places; all fixes here are `win32`-gated, so macOS/Linux behavior is unchanged.

## Changes

- **Skills:** new `resolve-skill` IPC (`main/ipc/skills.js`, `preload.js`) matching `<repo>-<kind>` in the task agent's skills dir; `runApp` and the Plan/Debug/Review handoffs prefer it (`renderer/file-browser.js`, `renderer/plan-modal.js`). De-Claude-flavored the inline fallback prompts (dropped `TodoWrite` / `Agent tool` / `subagent_type` / plan-mode assumptions).
- **Windows — commit blocker (highest impact):** `precommit-hook.js` no longer installs git hooks on Windows (their Node client is never written there, so the hooks `exec node <missing>` → exit 1 → blocked every commit/push); also self-heals repos a prior build already hooked.
- **Windows — AI review:** new `main/util/agent-spawn.js` resolves the CLI via `where.exe` and delivers the prompt on **stdin** for `.cmd` shims (which can't carry a multi-line arg through cmd.exe); native `.exe` agents stay arg-based. Wired through `claude-streaming.js` and both `claude-stream-ipc.js` exec sites, with `promptOnStdin` branches per provider.
- **Windows — misc:** `py -3` interpreter fallback (`repo-intel.js`); PowerShell-aware prompt staging (`agent-prompt.js`); `binPresent` via `where.exe`; session-path regexes accept `\`; `quotedSessionDirs` / opencode path / cursor install per-OS fixes.

## Test Plan

- `npm run test` — **115/115** unit tests pass.
- `npm run test:e2e` — **52/52** Playwright e2e pass (covers agent spawn/stream, explain-diff, plan-approval, app launch — the refactored primitives).
- `npm run lint` — clean.
- Exercised each provider's `buildHeadlessRun`: non-Windows args are **byte-identical** to before (zero regression); stdin branch moves the prompt off the command line.

## Checklist

- [x] Tests pass (unit + e2e)
- [x] Lint clean
- [x] macOS/Linux behavior unchanged (all Windows fixes are `win32`-gated)
- [ ] **Windows not yet validated on real hardware** — the per-CLI stdin assumptions (marked `VERIFY` in `ai-providers.js`) and `.cmd`/PowerShell paths need a validation pass on Windows. The pre-commit git-hook review + `ExitPlanMode` gate remain disabled on Windows by design (named-pipe server is separately scoped).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
