### PR TITLE
fix(review): recover findings when a value contains a fenced code block

### DIFF
--- a/renderer/finding-parser.js
+++ b/renderer/finding-parser.js
@@ -243,11 +243,17 @@ window.FindingParser = (function () {
     var rest = text.slice(open + '<FINDINGS_JSON>'.length);
     var close = rest.indexOf('</FINDINGS_JSON>');
     var inner = close !== -1 ? rest.slice(0, close) : rest;
-    // Strip a leading ```json fence and a trailing ``` (closing fence may not
-    // have streamed in yet).
-    inner = inner.replace(/^\s*```[a-zA-Z0-9_-]*\s*/, '');
-    var fenceEnd = inner.lastIndexOf('```');
-    if (fenceEnd !== -1) inner = inner.slice(0, fenceEnd);
+    // Strip an outer ```json fence if present. The trailing ``` is stripped ONLY
+    // when a leading fence was actually removed — otherwise lastIndexOf('```')
+    // grabs the ``` inside a finding's value (a fenced code suggestion) and
+    // truncates the JSON mid-string. A missing trailing ``` is fine (the closing
+    // fence may not have streamed in yet).
+    var lead = inner.match(/^\s*```[a-zA-Z0-9_-]*\s*/);
+    if (lead) {
+      inner = inner.slice(lead[0].length);
+      var fenceEnd = inner.lastIndexOf('```');
+      if (fenceEnd !== -1) inner = inner.slice(0, fenceEnd);
+    }
     inner = inner.trim();
     if (!inner) return { findings: [], summary: null };
 

--- a/test/util/finding-parser.test.js
+++ b/test/util/finding-parser.test.js
@@ -52,6 +52,21 @@ test('truncated mid-stream: recovers the complete findings, drops the partial ta
   assert.equal(r.findings[1].path, 'b.js');
 });
 
+test('recovers findings when a value contains a fenced ``` code block (unfenced JSON)', () => {
+  // Regression: the trailing-fence strip used lastIndexOf('```'), which grabbed
+  // the ``` inside a finding's suggestion/body and truncated the JSON mid-value
+  // whenever the block itself was not wrapped in an outer ```json fence.
+  const inner = JSON.stringify({
+    findings: [{ severity: 'High', category: 'Correctness', path: 'm.js', line: 7, side: 'RIGHT', title: 'Guard null', code: 'x = foo.bar;', body: 'Add a guard.', suggestion: '```js\nif (!foo) return null;\n```' }],
+    summary: { verdict: 'Request Changes', highestRisk: ['null deref'], testCoverage: 'none' },
+  });
+  const r = FP.parseReviewFindings(wrap(inner));
+  assert.equal(r.findings.length, 1);
+  assert.equal(r.findings[0].severity, 'high');
+  assert.equal(r.findings[0].path, 'm.js');
+  assert.equal(r.summary.verdict, 'Request Changes');
+});
+
 test('clean approve: zero findings + summary renders as structured (not an unparsed dump)', () => {
   const r = FP.parseReviewFindings(wrap('{ "findings": [], "summary": { "verdict": "Approve", "highestRisk": [], "testCoverage": "good" } }'));
   assert.equal(r.structured, true);


### PR DESCRIPTION
## Summary

Pre-existing bug in the AI-review findings parser: `parseJsonContract` stripped a trailing ```` ``` ```` fence with `lastIndexOf`, which grabbed the closing fence **inside a finding value** (a fenced code suggestion) and truncated the JSON mid-string whenever the `<FINDINGS_JSON>` block was not wrapped in an outer ```` ```json ```` fence. `JSON.parse` then failed and the review rendered **zero findings** — hit on the common case of a finding that includes a suggested code change.

## Changes

- `renderer/finding-parser.js`: strip the trailing fence only when a leading ```` ```json ```` fence was actually removed (matched pair).
- `test/util/finding-parser.test.js`: regression test (unfenced JSON with a fenced code block in a value).

## Test Plan

- New test is red before the fix (`actual: 0`), green after.
- `npm run test` — 116/116 pass.
- Verified no regression: fenced-outer JSON and unfenced-with-code both yield findings.
- eslint clean.

## Checklist

- [x] Root-caused (not v0.12.0 regression — file unchanged since #23)
- [x] Failing test added, red→green verified
- [x] Full suite + lint green

🤖 Generated with [Claude Code](https://claude.com/claude-code)
