### PR TITLE
feat(tasks): fallback to plain shell if base branch freshening fails

### DIFF
--- a/e2e/create-task.spec.js
+++ b/e2e/create-task.spec.js
@@ -105,3 +105,65 @@ test('create-task preserves the session name casing in the branch', async ({ mai
     fs.rmSync(sessionDir, { recursive: true, force: true });
   }
 });
+
+function buildBaseRepoWithBrokenOrigin() {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'klaussy-e2e-base-'));
+  const git = (...args) => execFileSync('git', args, { cwd: dir, stdio: 'pipe' });
+  git('init', '-q', '-b', 'main');
+  git('config', 'user.email', 'e2e@klaussy.test');
+  git('config', 'user.name', 'e2e');
+  fs.writeFileSync(path.join(dir, 'README.md'), '# base\n');
+  git('add', '.');
+  git('commit', '-q', '-m', 'init');
+  git('remote', 'add', 'origin', 'https://github.com/invalid/invalid.git');
+  return dir;
+}
+
+test('create-task downgrades to shell and prints error if freshening fails', async ({ mainWindow }) => {
+  await mainWindow.waitForLoadState('networkidle');
+
+  const repo = buildBaseRepoWithBrokenOrigin();
+  const repoBasename = path.basename(repo);
+  const taskName = 'feat-fail-freshen';
+  const sessionDir = path.join(os.homedir(), 'klaussy', 'sessions', taskName);
+  const expectedWorktree = path.join(sessionDir, repoBasename);
+
+  let taskId = null;
+  try {
+    const result = await mainWindow.evaluate(
+      ({ name, repoPath }) => window.klaus.task.create(name, repoPath, 'claude', undefined, 'main'),
+      { name: taskName, repoPath: repo },
+    );
+
+    expect(result.id).toBeDefined();
+    taskId = result.id;
+    expect(result.mode).toBe('shell');
+    expect(result.warning).toContain('Could not fetch latest');
+
+    // Subscribe and verify the warning is printed in the terminal
+    const output = await mainWindow.evaluate((id) => new Promise((resolve) => {
+      let buf = '';
+      const unsub = window.klaus.terminal.onData(id, (data) => {
+        buf += data;
+        if (buf.includes('Failed to freshen base branch')) {
+          unsub();
+          resolve(buf);
+        }
+      });
+      // Safety timeout
+      setTimeout(() => { unsub(); resolve(buf); }, 5000);
+    }), taskId);
+
+    expect(output).toContain('Failed to freshen base branch from origin');
+    expect(output).toContain('Could not fetch latest');
+  } finally {
+    if (taskId != null) {
+      await mainWindow.evaluate((id) => window.klaus.task.kill(id), taskId).catch(() => {});
+    }
+    try { execFileSync('git', ['worktree', 'remove', '--force', expectedWorktree], { cwd: repo, stdio: 'pipe' }); } catch {}
+    try { execFileSync('git', ['branch', '-D', taskName], { cwd: repo, stdio: 'pipe' }); } catch {}
+    fs.rmSync(repo, { recursive: true, force: true });
+    fs.rmSync(sessionDir, { recursive: true, force: true });
+  }
+});
+

--- a/main/ipc/tasks.js
+++ b/main/ipc/tasks.js
@@ -550,7 +550,8 @@ ipcMain.handle('create-task', async (_event, { name, repoPath, mode, basePath, e
   } catch (e) { console.warn('[session-memory] seed skipped:', e.message); }
 
   const warning = [fallbackWarning, freshenWarning, reusedBranchWarning].filter(Boolean).join(' ') || null;
-  const result = spawnInWorktree(name, worktreePath, branch, mode || 'claude', null, envVars);
+  const launchMode = freshenWarning ? 'shell' : (mode || 'claude');
+  const result = spawnInWorktree(name, worktreePath, branch, launchMode, null, envVars, undefined, undefined, freshenWarning);
   if (result && !result.error) {
     if (warning) result.warning = warning;
     if (freshen.info) result.freshenInfo = freshen.info;

--- a/main/state/instances.js
+++ b/main/state/instances.js
@@ -50,6 +50,20 @@ function subscribeTerminalChannel(channel, webContents) {
   if (!subs) { subs = new Set(); terminalSubscribers.set(channel, subs); }
   if (subs.has(webContents)) return;
   subs.add(webContents);
+
+  const match = channel.match(/^terminal-data-(\d+)$/);
+  if (match) {
+    const id = parseInt(match[1], 10);
+    const inst = instances.get(id);
+    if (inst && inst.freshenWarning) {
+      const msg = `\r\n\x1b[31;1mError: Failed to freshen base branch from origin:\x1b[0m\r\n` +
+                  `\x1b[31m${inst.freshenWarning}\x1b[0m\r\n` +
+                  `\x1b[33mSpawning a plain shell so you can fix the underlying git issue.\x1b[0m\r\n\r\n`;
+      webContents.send(channel, msg);
+      inst.freshenWarning = null;
+    }
+  }
+
   // Auto-cleanup when the renderer goes away so we don't keep sending to
   // dead senders or leak Set entries. Each subscription adds one destroyed
   // listener; acceptable because Electron caps listeners generously and
@@ -277,7 +291,7 @@ function clearIdleTimer(inst) {
 
 // ---- PTY lifecycle ----
 
-function spawnInWorktree(name, worktreePath, branch, mode, resumeSessionId, extraEnv, prNumber, initialPrompt) {
+function spawnInWorktree(name, worktreePath, branch, mode, resumeSessionId, extraEnv, prNumber, initialPrompt, freshenWarning) {
   const id = nextId++;
   const userShell = defaultShell();
   extraEnv = sanitizeExtraEnv(extraEnv);
@@ -394,6 +408,7 @@ function spawnInWorktree(name, worktreePath, branch, mode, resumeSessionId, extr
     prNumber: prNumber || null,
     prBaseOwner: null,
     prBaseRepo: null,
+    freshenWarning: freshenWarning || null,
   };
   initIdleDetectionFields(instance);
   instances.set(id, instance);


### PR DESCRIPTION
## Summary

Automatically falls back to a plain shell and prints a warning/error when the repository base branch fails to freshen from origin during task creation.

## Changes

- Modified `main/ipc/tasks.js` to detect freshening warnings and spawn the task worktree in `shell` mode instead of failing.
- Updated `main/state/instances.js` to store the `freshenWarning` on spawn and send a diagnostic error message on client connection/subscription.
- Added a mock/test in `e2e/create-task.spec.js` that initializes a repository with a broken origin and asserts that `window.klaus.task.create` successfully falls back to `shell` mode and prints the appropriate error to the terminal.

## Test Plan

- [x] Tests pass locally (`npm run test:e2e` for the new test case)
- [x] Manually verified

## Checklist

- [x] Code follows project conventions (see CLAUDE.md)
- [x] No unrelated changes
- [x] Tests added/updated for new functionality
- [x] Documentation updated if needed
