### PR TITLE
fix(gh): treat a GitHub REST outage as an outage, not a failed login

### DIFF
--- a/main/ipc/gh.js
+++ b/main/ipc/gh.js
@@ -8,6 +8,7 @@ const { execFileSync, spawn } = require('child_process');
 const { ipcMain, shell, BrowserWindow } = require('electron');
 const { loadConfig, saveConfig } = require('../util/config');
 const { ghExec, clearGhTokenCache, execFileP } = require('../util/exec');
+const { reconcileOutage, clearOutageProbeCache } = require('../util/gh-outage');
 const { allProviders, getProvider, binFor, installCommandFor, authMetaFor } = require('../state/ai-providers');
 const { discoverReposOnDisk } = require('./repo');
 
@@ -77,6 +78,15 @@ function readGhAccounts() {
   }
 }
 
+// readGhAccounts() plus the outage tiebreaker — see util/gh-outage.js. Prefer
+// this over the bare sync readGhAccounts() anywhere the verdict gates the user
+// out of the app, since gh reports a REST outage as an invalid token.
+async function readGhAccountsChecked() {
+  const result = readGhAccounts();
+  await reconcileOutage(result.accounts);
+  return result;
+}
+
 // Open URL in default browser. Scheme-restricted: a compromised renderer (or
 // xterm's WebLinksAddon auto-detecting a file:// / javascript: / smb: token in
 // the PTY stream) must not be able to hand an arbitrary URI to the OS opener.
@@ -94,25 +104,27 @@ ipcMain.handle('open-external', (_event, { url }) => {
 
 // List authed accounts with per-account validity. One bad token must NOT
 // hide the other accounts — see readGhAccounts() for the recovery path.
-ipcMain.handle('gh-list-accounts', async () => readGhAccounts());
+ipcMain.handle('gh-list-accounts', async () => readGhAccountsChecked());
 
 ipcMain.handle('gh-switch-account', async (_event, { username }) => {
   if (!username) return { error: 'Missing username' };
   // Refuse to switch into an account whose token gh has already flagged
   // invalid — `gh auth switch` succeeds in that case but every downstream
   // call then fails cryptically. Caller should route to the login flow.
-  const { accounts } = readGhAccounts();
+  const { accounts } = await readGhAccountsChecked();
   const target = accounts.find((a) => a.username === username);
   if (target && !target.valid) {
     // Drop cached owner→token entries — caller will re-auth and the next
     // gh call must read the fresh token, not whatever was cached for this
     // user when its token was still believed valid.
     clearGhTokenCache();
+    clearOutageProbeCache();
     return { error: 'invalid-token', needsLogin: true, username };
   }
   try {
     execFileSync('gh', ['auth', 'switch', '-u', username], { stdio: 'pipe', timeout: 5000 });
     clearGhTokenCache();
+    clearOutageProbeCache();
     return { ok: true };
   } catch (err) {
     return { error: (err.stderr ? err.stderr.toString() : err.message).trim() };
@@ -203,10 +215,15 @@ ipcMain.handle('gh-login-start', async (event, opts) => {
     clearTimeout(authTimer);
     if (code === 0) {
       // Re-read accounts so the renderer can refresh without a second IPC
-      // round-trip — and so we surface the freshly-logged-in username.
-      const { accounts } = readGhAccounts();
+      // round-trip — and so we surface the freshly-logged-in username. The
+      // checked read matters most here: during a REST outage gh calls the
+      // token it just minted invalid, which would bounce the user straight
+      // back into the login they just completed.
       clearGhTokenCache();
-      send('success', { accounts });
+      clearOutageProbeCache();
+      readGhAccountsChecked()
+        .then(({ accounts }) => send('success', { accounts }))
+        .catch(() => send('success', { accounts: readGhAccounts().accounts }));
       return;
     }
     if (signal === 'SIGTERM' || signal === 'SIGKILL') {
@@ -430,7 +447,7 @@ ipcMain.handle('gh-clone-repo', async (_event, { nameWithOwner }) => {
 // hold accounts across multiple hosts).
 ipcMain.handle('gh-detect-account-for-repo', async (_event, { owner, repo, prNumber }) => {
   if (!owner || !repo || !prNumber) return { error: 'missing owner/repo/prNumber' };
-  const { accounts: parsed, error } = readGhAccounts();
+  const { accounts: parsed, error } = await readGhAccountsChecked();
   if (parsed.length === 0 && error) return { error };
   // Skip accounts whose tokens gh has already flagged invalid — probing
   // them just wastes an API call that's guaranteed to 401.
@@ -483,6 +500,7 @@ ipcMain.handle('check-dependencies', async () => {
     refreshSpawnPath();
   } catch { /* during early init the bootstrap module may not be ready */ }
   clearGhTokenCache();
+  clearOutageProbeCache();
 
   const config = loadConfig();
   const claudeBin = config.claudePath || 'claude';
@@ -504,9 +522,12 @@ ipcMain.handle('check-dependencies', async () => {
   // Don't trust gh's exit code — it returns 1 if any account has a bad
   // token, even when others are fine. Treat gh as authed if at least one
   // account in the parsed status output is valid.
-  const ghStatus = ghVersion.ok ? readGhAccounts() : { accounts: [], error: 'gh not installed' };
+  const ghStatus = ghVersion.ok ? await readGhAccountsChecked() : { accounts: [], error: 'gh not installed' };
   const validAccounts = ghStatus.accounts.filter((a) => a.valid);
   const authed = validAccounts.length > 0;
+  // Accounts gh called invalid that GitHub still accepts — the user is signed
+  // in and must not be prompted, but calls may fail while the outage lasts.
+  const outage = validAccounts.some((a) => a.outage);
   const claudeVersion = probe(claudeBin, ['--version']);
 
   // Probe every supported AI CLI so the Setup Check can list install status +
@@ -556,6 +577,7 @@ ipcMain.handle('check-dependencies', async () => {
     gh: {
       installed: ghVersion.ok,
       authed,
+      outage,
       version: ghVersion.ok ? ghVersion.output.split('\n')[0] : null,
       authError: authed ? null : (ghStatus.error || null),
       accounts: ghStatus.accounts,

--- a/main/util/gh-error.js
+++ b/main/util/gh-error.js
@@ -62,6 +62,20 @@ function classifyGhError(raw, ctx = {}) {
       retryable: false,
     };
   }
+  // GitHub 5xx. Must be checked BEFORE the auth branch: gh appends its own
+  // "To re-authenticate, run: gh auth login" hint to failures it blames on the
+  // token, and during a REST outage it blames the token — so that phrase would
+  // match the auth branch below and tell the user to re-login over an outage no
+  // login can fix. See util/gh-outage.js for the same misdiagnosis at the
+  // account level.
+  if (has(/http 5\d\d|service unavailable|bad gateway|\bunicorn\b/i)) {
+    return {
+      kind: 'outage',
+      summary: `GitHub's API is returning server errors${target} — this isn't your connection or your login.`,
+      fix: 'Nothing to fix on your end — check githubstatus.com. Retry once GitHub recovers.',
+      retryable: true,
+    };
+  }
   if (has(/bad credentials|http 401|not logged in|no github hosts|gh auth login|authentication failed/i)) {
     return {
       kind: 'auth',

--- a/main/util/gh-outage.js
+++ b/main/util/gh-outage.js
@@ -1,0 +1,115 @@
+// Tell "this token is dead" apart from "GitHub is having an outage".
+//
+// `gh auth status` verifies a token by calling the REST API. When GitHub has a
+// REST degradation those endpoints 503, and gh reports "The token in keyring is
+// invalid" — the same wording it uses for a genuinely revoked token. Taking gh
+// at its word signs the user out mid-outage, and re-authenticating can't clear
+// it: the freshly minted token 503s exactly the same way, so the login prompt
+// returns on every check.
+//
+// /rate_limit is the tiebreaker. It stays served during REST degradation, and
+// it still authenticates — verified against the live API:
+//
+//   bogus token  -> 401            (no silent fall back to anonymous)
+//   no auth      -> 200, limit 60  (anonymous ceiling)
+//   valid token  -> 200, limit 5000
+//
+// So a 200 with a limit above the anonymous ceiling means GitHub accepts the
+// credential, and gh's "invalid" verdict is outage noise rather than a dead
+// token. Anything else (401, network error, timeout) is treated as no evidence
+// and we keep gh's verdict — this may only ever rescue an account, never
+// condemn one.
+
+const { execFileSync } = require('child_process');
+
+const LIVE_PROBE_TTL_MS = 60 * 1000;
+const PROBE_TIMEOUT_MS = 5000;
+const RATE_LIMIT_URL = 'https://api.github.com/rate_limit';
+const ANON_CORE_LIMIT = 60;
+
+const OUTAGE_REASON = 'GitHub API is degraded — your login is fine, but some requests may fail';
+
+// username -> { alive: boolean, at: ms }. Probing costs a network round trip,
+// and the callers that gate the UI (account list, PR account detect) can fire
+// several times per user action.
+const probeCache = new Map();
+
+function readTokenFor(username) {
+  try {
+    return execFileSync('gh', ['auth', 'token', '--user', username], {
+      stdio: 'pipe', timeout: PROBE_TIMEOUT_MS,
+    }).toString().trim();
+  } catch {
+    return '';
+  }
+}
+
+async function tokenAcceptedByGitHub(token, fetchImpl) {
+  const res = await fetchImpl(RATE_LIMIT_URL, {
+    method: 'GET',
+    headers: {
+      Authorization: `Bearer ${token}`,
+      Accept: 'application/vnd.github+json',
+      'X-GitHub-Api-Version': '2022-11-28',
+      'User-Agent': 'klaussy-desktop',
+    },
+    signal: AbortSignal.timeout(PROBE_TIMEOUT_MS),
+  });
+  if (res.status !== 200) return false;
+  const body = await res.json();
+  const limit = body?.resources?.core?.limit ?? 0;
+  return limit > ANON_CORE_LIMIT;
+}
+
+async function isTokenLive(username, deps) {
+  const { getToken, fetchImpl, now, cache } = deps;
+  const cached = cache.get(username);
+  if (cached && (now() - cached.at) < LIVE_PROBE_TTL_MS) return cached.alive;
+
+  let alive = false;
+  try {
+    const token = getToken(username);
+    if (token) alive = await tokenAcceptedByGitHub(token, fetchImpl);
+  } catch {
+    alive = false;
+  }
+  cache.set(username, { alive, at: now() });
+  return alive;
+}
+
+// Mutates and returns `accounts`: any entry gh flagged invalid whose token
+// GitHub still accepts is restored to valid and marked `outage: true`, so the
+// UI can explain the degradation instead of demanding a pointless re-login.
+async function reconcileOutage(accounts, deps = {}) {
+  const {
+    getToken = readTokenFor,
+    fetchImpl = globalThis.fetch,
+    now = Date.now,
+    cache = probeCache,
+  } = deps;
+
+  // The healthy path — every account valid — must cost zero network calls.
+  const suspect = accounts.filter((a) => !a.valid);
+  if (suspect.length === 0) return accounts;
+
+  await Promise.all(suspect.map(async (acc) => {
+    if (await isTokenLive(acc.username, { getToken, fetchImpl, now, cache })) {
+      acc.valid = true;
+      acc.outage = true;
+      acc.reason = OUTAGE_REASON;
+    }
+  }));
+  return accounts;
+}
+
+// Call alongside clearGhTokenCache() after a login or account switch: the
+// credential changed, so a cached verdict about the old one is meaningless.
+function clearOutageProbeCache() { probeCache.clear(); }
+
+module.exports = {
+  reconcileOutage,
+  clearOutageProbeCache,
+  OUTAGE_REASON,
+  LIVE_PROBE_TTL_MS,
+  ANON_CORE_LIMIT,
+};

--- a/renderer/app-functions-2.js
+++ b/renderer/app-functions-2.js
@@ -535,7 +535,10 @@ window.App = window.App || {};
       accountSelect.innerHTML = accounts.map(function (a) {
         var sel = a.username === selectedAccount ? ' selected' : '';
         var suffix = a.active ? ' (active)' : '';
+        // `outage` = gh called the token invalid but GitHub still accepts it.
+        // The account is fine; don't imply the user has to do anything.
         if (a.valid === false) suffix = ' (needs sign-in)';
+        else if (a.outage) suffix += ' (GitHub degraded)';
         return '<option value="' + AppUtils.escAttr(a.username) + '"' + sel + ' data-valid="' + (a.valid === false ? 'false' : 'true') + '">'
           + AppUtils.escHtml(a.username) + suffix
           + '</option>';
@@ -614,11 +617,16 @@ window.App = window.App || {};
       var result = await window.klaus.pr.recentRepos(selectedAccount);
       if (result.error) {
         var isAccess = /^(not-found|auth|sso|scope)$/.test(result.errorKind || '');
-        var text = isAccess
-          ? (result.errorSummary || result.error) + ' Switch accounts above, or paste a URL.'
-          : (result.error || '');
+        // An outage is nobody's fault and nothing to act on — say so plainly
+        // instead of dumping "gh: HTTP 503", and never route it to sign-in.
+        var isOutage = result.errorKind === 'outage';
+        var text = isOutage
+          ? (result.errorSummary || 'GitHub is having an outage.') + ' ' + (result.errorFix || '')
+          : isAccess
+            ? (result.errorSummary || result.error) + ' Switch accounts above, or paste a URL.'
+            : (result.error || '');
         listEl.innerHTML = '<div class="pr-picker-section-head">Recent pull requests</div>'
-          + '<div class="' + (isAccess ? 'pr-picker-empty' : 'pr-picker-error') + '">' + AppUtils.escHtml(text) + '</div>';
+          + '<div class="' + (isAccess || isOutage ? 'pr-picker-empty' : 'pr-picker-error') + '">' + AppUtils.escHtml(text) + '</div>';
         // Let the account-switch handler know the active account couldn't list
         // for access reasons, so it can offer to (re)sign in to that account.
         return { listErrorKind: isAccess ? (result.errorKind || 'unknown') : null };

--- a/test/util/gh-error.test.js
+++ b/test/util/gh-error.test.js
@@ -1,0 +1,63 @@
+const test = require('node:test');
+const assert = require('node:assert');
+
+const { classifyGhError } = require('../../main/util/gh-error');
+
+test('classifies a REST 503 as an outage, not a network fault', () => {
+  // Verbatim stderr from `gh api repos/o/r/pulls/27` during the 2026-07-16
+  // "Degraded REST API Availability" incident.
+  const cls = classifyGhError('gh: HTTP 503');
+
+  assert.equal(cls.kind, 'outage');
+  assert.equal(cls.retryable, true);
+  assert.match(cls.summary, /isn't your connection or your login/i);
+});
+
+test("an outage carrying gh's re-auth hint is not classified as auth", () => {
+  // The regression this ordering exists to prevent: gh staples its own
+  // "run: gh auth login" hint onto failures it blames on the token, and during
+  // an outage it blames the token. The auth branch would match that phrase and
+  // demand a login that cannot help.
+  const raw = [
+    'gh: HTTP 503',
+    'The token in keyring is invalid.',
+    'To re-authenticate, run: gh auth login -h github.com',
+  ].join('\n');
+
+  const cls = classifyGhError(raw);
+
+  assert.equal(cls.kind, 'outage', 'a 5xx must outrank the auth hint text');
+  assert.notEqual(cls.fix, 'gh auth login');
+});
+
+test('still classifies a real 401 as auth', () => {
+  const cls = classifyGhError('gh: HTTP 401: Bad credentials');
+
+  assert.equal(cls.kind, 'auth');
+  assert.equal(cls.fix, 'gh auth login');
+});
+
+test('other 5xx codes are outages too', () => {
+  for (const raw of ['gh: HTTP 500', 'gh: HTTP 502 Bad Gateway', 'gh: HTTP 504']) {
+    assert.equal(classifyGhError(raw).kind, 'outage', raw);
+  }
+});
+
+test('the unicorn error page is an outage', () => {
+  // GitHub serves an HTML "Unicorn!" page for 5xx; the body has no status code
+  // in it, so the page itself has to be recognisable.
+  const cls = classifyGhError('<!DOCTYPE html><title>Unicorn! &middot; GitHub</title>');
+
+  assert.equal(cls.kind, 'outage');
+});
+
+test('genuine network faults stay network, not outage', () => {
+  for (const raw of ['getaddrinfo ENOTFOUND api.github.com', 'socket hang up', 'ETIMEDOUT']) {
+    assert.equal(classifyGhError(raw).kind, 'network', raw);
+  }
+});
+
+test('SSO and scope errors are unaffected by the outage branch', () => {
+  assert.equal(classifyGhError('SAML enforcement').kind, 'sso');
+  assert.equal(classifyGhError('missing required scopes').kind, 'scope');
+});

--- a/test/util/gh-outage.test.js
+++ b/test/util/gh-outage.test.js
@@ -1,0 +1,111 @@
+const test = require('node:test');
+const assert = require('node:assert');
+
+const { reconcileOutage, ANON_CORE_LIMIT } = require('../../main/util/gh-outage');
+
+// Each test gets its own cache + clock so TTL behaviour is deterministic and
+// tests can't leak verdicts into each other.
+function harness({ status = 200, limit = 5000, token = 'gho_valid', json, fetchImpl } = {}) {
+  const calls = { fetch: 0, token: 0 };
+  return {
+    calls,
+    deps: {
+      cache: new Map(),
+      now: () => 1_000_000,
+      getToken: (u) => { calls.token += 1; return typeof token === 'function' ? token(u) : token; },
+      fetchImpl: fetchImpl || (async () => {
+        calls.fetch += 1;
+        return {
+          status,
+          json: async () => (json || { resources: { core: { limit } } }),
+        };
+      }),
+    },
+  };
+}
+
+const invalid = (username) => ({ username, active: false, valid: false, reason: 'Token is invalid' });
+
+test('rescues an account when GitHub still accepts the token (outage)', async () => {
+  const h = harness({ status: 200, limit: 5000 });
+  const accounts = [invalid('stephanie913')];
+
+  await reconcileOutage(accounts, h.deps);
+
+  assert.equal(accounts[0].valid, true, 'token GitHub accepts must not be treated as dead');
+  assert.equal(accounts[0].outage, true);
+  assert.match(accounts[0].reason, /degraded/i);
+});
+
+test('leaves a genuinely revoked token invalid (401)', async () => {
+  const h = harness({ status: 401 });
+  const accounts = [invalid('stephanie913')];
+
+  await reconcileOutage(accounts, h.deps);
+
+  assert.equal(accounts[0].valid, false, 'a 401 is real evidence the token is dead');
+  assert.equal(accounts[0].outage, undefined);
+});
+
+test('does not rescue on an anonymous-ceiling 200', async () => {
+  // Defensive: if a proxy or future gh behaviour ever answers /rate_limit
+  // without our credential, the anonymous limit must not read as "signed in".
+  const h = harness({ status: 200, limit: ANON_CORE_LIMIT });
+  const accounts = [invalid('stephanie913')];
+
+  await reconcileOutage(accounts, h.deps);
+
+  assert.equal(accounts[0].valid, false);
+});
+
+test('keeps gh verdict when the probe itself fails', async () => {
+  const h = harness({ fetchImpl: async () => { throw new Error('ENOTFOUND'); } });
+  const accounts = [invalid('stephanie913')];
+
+  await reconcileOutage(accounts, h.deps);
+
+  assert.equal(accounts[0].valid, false, 'no evidence must not rescue');
+});
+
+test('keeps gh verdict when no token can be read', async () => {
+  const h = harness({ token: '' });
+  const accounts = [invalid('stephanie913')];
+
+  await reconcileOutage(accounts, h.deps);
+
+  assert.equal(accounts[0].valid, false);
+  assert.equal(h.calls.fetch, 0, 'must not probe without a token');
+});
+
+test('healthy accounts cost no network calls', async () => {
+  const h = harness();
+  const accounts = [{ username: 'steph-dove', active: true, valid: true, reason: null }];
+
+  await reconcileOutage(accounts, h.deps);
+
+  assert.equal(h.calls.fetch, 0);
+  assert.equal(h.calls.token, 0);
+});
+
+test('probes each suspect account independently', async () => {
+  const h = harness({
+    token: (u) => (u === 'steph-dove' ? 'gho_valid' : ''),
+    status: 200,
+    limit: 5000,
+  });
+  const accounts = [invalid('stephanie913'), invalid('steph-dove')];
+
+  await reconcileOutage(accounts, h.deps);
+
+  assert.equal(accounts[0].valid, false, 'no token → stays invalid');
+  assert.equal(accounts[1].valid, true, 'live token → rescued');
+});
+
+test('caches a verdict within the TTL', async () => {
+  const h = harness({ status: 200, limit: 5000 });
+
+  await reconcileOutage([invalid('stephanie913')], h.deps);
+  await reconcileOutage([invalid('stephanie913')], h.deps);
+
+  assert.equal(h.calls.fetch, 1, 'second read inside the TTL must reuse the verdict');
+});


### PR DESCRIPTION
## Summary

A GitHub REST outage was signing users out of Klaussy, and no amount of re-authenticating fixed it.

`gh auth status` verifies a token by calling the REST API. During a REST degradation those calls 503, and gh reports **"The token in keyring is invalid"** — the exact wording it uses for a genuinely revoked token. Klaussy took gh at its word (`gh.js:507` computes `authed` from `valid`), so an outage read as a failed login. Re-authenticating could not clear it: the freshly minted token 503s the same way, so the prompt returned on every check.

Reported as "the github login seems to be broken, it keeps prompting me to login when I already did — especially on PR review". PR review is the worst-hit surface because it is almost entirely REST (`gh api <path>`), which is exactly what degrades.

## Changes

**`main/util/gh-outage.js` (new) — the tiebreaker.** When gh flags an account invalid, probe `/rate_limit` with that account's token. It stays served during REST degradation and still authenticates. Verified against the live API:

| credential | result |
| --- | --- |
| bogus token | `401` (no silent fall back to anonymous) |
| no auth | `200`, limit 60 (anonymous ceiling) |
| valid token | `200`, limit 5000 |

So a 200 above the anonymous ceiling means GitHub accepts the credential and gh's verdict is outage noise. The rule is deliberately one-directional — **it may only ever rescue an account, never condemn one.** A 401, network error, timeout, or unreadable token all keep gh's original verdict, so a genuinely revoked token still prompts exactly as it does today.

Wired into all five account-validity reads, including the login-success refresh — that one was bouncing users straight back into the login they had just completed. Healthy accounts short-circuit before any network call, and verdicts cache for 60s (cleared on login, switch, and re-check).

**`main/util/gh-error.js` — the same misdiagnosis, one layer up.** gh staples its own `To re-authenticate, run: gh auth login` hint onto failures it blames on the token, and during an outage it blames the token. `classifyGhError` matched that literal phrase and returned `kind: 'auth'` **before** reaching the 5xx branch — the ordering was the bug. Added an `outage` kind ahead of it, matching 5xx and GitHub's HTML unicorn page (which carries no status code, so the page itself has to be recognisable).

Splitting `outage` out of `network` is safe: nothing branches on that kind by name, and the only consumer is the auto-retry at `state/pr-review.js:229`, which reads `retryable` — still `true`.

**`renderer/app-functions-2.js` — the surfaces.** The PR picker renders an outage as a soft `pr-picker-empty` note instead of a raw `gh: HTTP 503` dump, and it is explicitly excluded from the path that offers to re-sign-in. The account dropdown shows `(GitHub degraded)` rather than `(needs sign-in)`.

## Test Plan

**Verified against the live 2026-07-16 "Degraded REST API Availability" incident**, not just fixtures.

Real keyring tokens through the real parser — this is the gate that was prompting for login:

```
gh verdict:       [{stephanie913, valid:false}, {steph-dove, valid:false}]
authed (before):  false
after tiebreaker: [{stephanie913, valid:true, outage:true}, {steph-dove, valid:true, outage:true}]
authed (after):   true
```

Real stderr from the exact call the PR picker makes:

```
real gh stderr: "gh: HTTP 503"
kind:      outage      (was: auth -> "gh auth login")
retryable: true
summary:   GitHub's API is returning server errors - this isn't your connection or your login.
```

Automated: **141 tests pass** (15 new), lint clean.
- `test/util/gh-outage.test.js` (8) — rescue on live token; **stay invalid on 401**; no rescue on an anonymous-ceiling 200; keep verdict when the probe throws or no token reads; zero network calls on the healthy path; per-account independence; TTL caching.
- `test/util/gh-error.test.js` (7) — 503 classifies as outage; **regression test pinning the ordering** so an outage carrying gh's re-auth hint is never classified as auth; a real 401 still classifies as auth; other 5xx; the unicorn page; genuine network faults stay `network`; SSO/scope unaffected.

## Caveats

This stops the false logout; it cannot make PR review *work* while GitHub's REST API is down — those calls still 503. What it buys is that once the incident clears you are still signed in, instead of having re-authenticated several times for nothing.

`check-dependencies` now returns a `gh.outage` flag, but no renderer surface consumes it yet. Separately, the in-app sign-in modal looks orphaned (the main-process flow and preload bridge are intact, but no renderer code calls `loginStart`) — worth its own issue.

## Checklist

- [x] Tests added and passing (141 total, 15 new)
- [x] Lint clean
- [x] Verified end-to-end against a real outage
- [x] No behaviour change on the healthy path (zero added network calls)
- [x] Conventional Commits

🤖 Generated with [Claude Code](https://claude.com/claude-code)
