### PR TITLE
fix(tooling): escape raw control bytes that made four sources unsearchable

### DIFF
--- a/main/ipc/pr-review-checks.js
+++ b/main/ipc/pr-review-checks.js
@@ -400,7 +400,7 @@ ipcMain.handle('pr-review-check-annotations', async (_event, { checkRunId }) => 
         message: a.message || '',
         rawDetails: a.raw_details || '',
       };
-      const key = [norm.path, norm.startLine, norm.endLine, norm.level, norm.title, norm.message].join('');
+      const key = [norm.path, norm.startLine, norm.endLine, norm.level, norm.title, norm.message].join('\u0001');
       if (seen.has(key)) continue;
       seen.add(key);
       annotations.push(norm);

--- a/renderer/about-log.js
+++ b/renderer/about-log.js
@@ -1220,7 +1220,7 @@ window.Dialogs = (function () {
         var detail = s.type === 'stdio'
           ? (s.command + (s.args && s.args.length ? ' ' + s.args.join(' ') : ''))
           : s.url;
-        var key = [s.name, s.scope, s.projectName || '', s.type, detail, (s.envKeys || []).join(',')].join(' ');
+        var key = [s.name, s.scope, s.projectName || '', s.type, detail, (s.envKeys || []).join(',')].join('\u0000');
         if (!map[key]) {
           map[key] = { name: s.name, scope: s.scope, projectName: s.projectName, type: s.type, detail: detail, envKeys: s.envKeys || [], members: [] };
           order.push(key);

--- a/renderer/pr-panel.js
+++ b/renderer/pr-panel.js
@@ -1021,14 +1021,14 @@ window.PRPanel = (function () {
     src = src.replace(/```(\w*)\n?([\s\S]*?)```/g, function (_match, _lang, code) {
       var idx = blocks.length;
       blocks.push('<pre class="pr-code-block">' + escHtml(code.replace(/\n$/, '')) + '</pre>');
-      return ' CODEBLOCK' + idx + ' ';
+      return '\u0000CODEBLOCK' + idx + '\u0000';
     });
     src = escHtml(src)
       .replace(/`([^`]+)`/g, '<code class="pr-inline-code">$1</code>')
       .replace(/\*\*(.+?)\*\*/g, '<strong>$1</strong>')
       .replace(/(?<!\*)\*(?!\*)(.+?)(?<!\*)\*(?!\*)/g, '<em>$1</em>')
       .replace(/\n/g, '<br>');
-    src = src.replace(/ CODEBLOCK(\d+) /g, function (_, i) { return blocks[parseInt(i, 10)]; });
+    src = src.replace(/\u0000CODEBLOCK(\d+)\u0000/g, function (_, i) { return blocks[parseInt(i, 10)]; });
     return src;
   }
 

--- a/renderer/pr-review-checks.js
+++ b/renderer/pr-review-checks.js
@@ -599,7 +599,7 @@
     for (var i = 0; i < checks.length; i++) {
       if (String(checks[i].id) === String(checkId)) {
         var c = checks[i];
-        return [c.state || '', c.conclusion || '', c.completedAt || '', c.runId || ''].join(' ');
+        return [c.state || '', c.conclusion || '', c.completedAt || '', c.runId || ''].join('\u0000');
       }
     }
     return '';


### PR DESCRIPTION
## Summary

**There was no bug in the sign-in modal. This PR fixes the thing that made it look like there was.**

Four JS sources use raw control bytes as sentinels, written as actual bytes instead of escapes. One control byte makes `file(1)` report `data` instead of source, and **grep then treats the file as binary and prints nothing** - no match, no error, not even a `Binary file matches` note. Every search across these files silently returned empty, which is indistinguishable from "the code isn't there."

| File | Line | Byte | Purpose |
| --- | --- | --- | --- |
| `renderer/about-log.js` | 1223 | `0x00` | MCP dedup key separator |
| `renderer/pr-review-checks.js` | 602 | `0x00` | check dedup key separator |
| `renderer/pr-panel.js` | 1024, 1031 | `0x00` | CODEBLOCK sentinel + its regex |
| `main/ipc/pr-review-checks.js` | 403 | `0x01` | annotation dedup key separator |

## Why this matters

It already caused a false diagnosis. `about-log.js` (1819 lines) contains the **entire working in-app GitHub sign-in modal**: `window.Dialogs` at line 1, `showGhLogin` defined at 806 and exported at 1817, wired to `app-functions-2.js:683`, with all its CSS present. Because grep returned nothing, the feature was reported as deleted and was about to be "restored" on top of the perfectly functional original.

The other three files are core PR-review paths - precisely where anyone debugging PR review would search, and precisely where a silent-empty grep does the most damage. This will keep misleading every future reader and every code-search tool until the bytes are escaped.

## Changes

Each raw byte becomes its equivalent escape (`\u0000` / `\u0001`). Nothing else changes.

## Test Plan

**Runtime value is provably unchanged** - the escape yields the identical one-character string:

```
escape === raw NUL   : true
length               : 1 | codepoint: 0
join separator equal : true
```

**The one regex-literal use round-trips identically.** `pr-panel.js:1031` embeds the sentinel in a regex, so it got its own check - the escaped and raw forms produce byte-identical output:

```
escaped result : "<pre>alpha</pre> text <pre>beta</pre>"
raw result     : "<pre>alpha</pre> text <pre>beta</pre>"
IDENTICAL      : true
```

**Grep works again** (plain grep, no `-a`):

```
about-log.js showGhLogin      : 8
pr-panel.js CODEBLOCK         : 2
pr-review-checks.js (renderer): 90
pr-review-checks.js (main)    : 5
```

All four now report as `Unicode text, UTF-8 text` rather than `data`, and a repo-wide scan of every tracked non-binary file finds **0 remaining poisoned sources**.

- `node --check` passes on all four
- **141 tests pass**, lint clean across the full `main/`, `preload.js`, `renderer/` glob
- No behaviour change

## Checklist

- [x] Runtime equivalence proven, not assumed
- [x] Regex-literal use separately verified
- [x] Repo-wide scan for other occurrences
- [x] Tests + lint pass
- [x] No behaviour change

🤖 Generated with [Claude Code](https://claude.com/claude-code)
