### PR TITLE
fix: agent tab labels + AI review finding cards

### DIFF
--- a/main/ipc/tasks.js
+++ b/main/ipc/tasks.js
@@ -550,8 +550,9 @@ ipcMain.handle('create-task', async (_event, { name, repoPath, mode, basePath, e
   } catch (e) { console.warn('[session-memory] seed skipped:', e.message); }
 
   const warning = [fallbackWarning, freshenWarning, reusedBranchWarning].filter(Boolean).join(' ') || null;
-  const launchMode = freshenWarning ? 'shell' : (mode || 'claude');
-  const result = spawnInWorktree(name, worktreePath, branch, launchMode, null, envVars, undefined, undefined, freshenWarning);
+  // A freshen warning is non-fatal, so keep the chosen agent instead of
+  // downgrading to a shell (which mislabeled agent tabs as "Shell").
+  const result = spawnInWorktree(name, worktreePath, branch, mode || 'claude', null, envVars, undefined, undefined, freshenWarning);
   if (result && !result.error) {
     if (warning) result.warning = warning;
     if (freshen.info) result.freshenInfo = freshen.info;

--- a/renderer/finding-parser.js
+++ b/renderer/finding-parser.js
@@ -142,8 +142,21 @@ window.FindingParser = (function () {
         var j = i + 1;
         while (j < s.length && (s[j] === ' ' || s[j] === '\t' || s[j] === '\n' || s[j] === '\r')) j++;
         var nx = s[j];
-        if (nx === undefined || nx === ',' || nx === '}' || nx === ']' || nx === ':') {
+        if (nx === undefined || nx === '}' || nx === ']' || nx === ':') {
           inStr = false; out += ch; continue; // real closing quote
+        }
+        if (nx === ',') {
+          // A comma after the quote is ambiguous: a value-terminating comma
+          // starts the next JSON token, but a comma in prose ("returns "ok",
+          // but…") is just more words, so only close when a real JSON token
+          // actually follows — else we corrupt the object and drop the finding.
+          var k = j + 1;
+          while (k < s.length && (s[k] === ' ' || s[k] === '\t' || s[k] === '\n' || s[k] === '\r')) k++;
+          var after = s.slice(k);
+          if (after === '' || after[0] === '"' || after[0] === '{' || after[0] === '[' ||
+              /^-?\d/.test(after) || /^(true|false|null)\b/.test(after)) {
+            inStr = false; out += ch; continue; // real closing quote
+          }
         }
         out += '\\"'; continue;               // literal quote inside the value
       }

--- a/test/util/finding-parser.test.js
+++ b/test/util/finding-parser.test.js
@@ -43,6 +43,19 @@ test('recovers findings when body contains an unescaped double-quote', () => {
   assert.equal(r.findings[0].severity, 'high');
 });
 
+test('recovers findings when body has an inner quote followed by a comma (verdict-but-no-cards regression)', () => {
+  // Regression: an inner quote followed by `,`/`}`/`]`/`:` ("returns "ok", but
+  // …") was misread as the value's closing quote, corrupting the object so
+  // every finding was dropped while the quote-free summary survived — the exact
+  // "Request Changes verdict shows, zero cards render" symptom.
+  const inner = '{ "findings": [ { "severity": "High", "category": "Correctness", "path": "m.js", "line": 5, "side": "RIGHT", "title": "Ignored return", "code": "x=1;", "body": "The call returns "ok", but the caller ignores it.", "suggestion": "check the result" } ], "summary": { "verdict": "Request Changes", "highestRisk": ["ignored return"], "testCoverage": "none" } }';
+  const r = FP.parseReviewFindings(wrap(inner));
+  assert.equal(r.findings.length, 1);
+  assert.equal(r.findings[0].severity, 'high');
+  assert.equal(r.findings[0].path, 'm.js');
+  assert.equal(r.summary.verdict, 'Request Changes');
+});
+
 test('truncated mid-stream: recovers the complete findings, drops the partial tail', () => {
   const inner = '{\n  "findings": [\n    { "severity": "High", "category": "Correctness", "path": "a.js", "line": 1, "side": "RIGHT", "title": "One", "code": "let a = 1;\nlet b = 2;", "body": "First.", "suggestion": "x" },\n    { "severity": "Low", "category": "Design", "path": "b.js", "line": 9, "side": "RIGHT", "title": "Two", "code": "y=2;", "body": "Second.", "suggestion": "z" },\n    { "severity": "Nit", "category": "Readability", "path": "c.js", "line": 3, "side": "RIGHT", "title": "Thre';
   // Note: no closing </FINDINGS_JSON> — mid-stream.


### PR DESCRIPTION
## Summary

Fixes two shipped regressions.

**1. Agent tabs read "Shell" even when an agent is active.** A recent commit downgraded a new task's launch to a plain shell whenever base-branch "freshening" reported any warning. But freshen warnings are benign and common (offline, auth hiccup, unpushed local commits on the base branch) — the worktree is still created from the local copy, so the chosen agent should launch. The tab label just mirrors the launch mode, so it read "Shell". Now the agent always launches; the warning is still surfaced via the toast and terminal banner, matching the checkout/resume path which never downgraded.

**2. AI review shows "Request Changes" but renders no finding cards.** `repairLooseJson` misread an inner quote followed by `,`/`}`/`]`/`:` (e.g. `returns "ok", but ...`) as the value's closing quote, corrupting the finding object so the whole-object reparse threw and every finding was dropped in per-object recovery — while the quote-free summary survived, giving a verdict banner with zero cards. The comma case is now disambiguated: a value-terminating comma is followed by the start of a real JSON token; a prose comma is followed by more words.

## Changes

- `main/ipc/tasks.js` — launch the chosen agent regardless of a (non-fatal) freshen warning.
- `renderer/finding-parser.js` — smarter closing-quote heuristic in `repairLooseJson`.

## Test Plan

- `npm run test` — 142 pass, including a new regression test for the inner-quote-before-comma case (fails against old code).
- `npm run lint` — clean.

## Checklist

- [x] Tests pass
- [x] Lint clean
- [x] Regression test added

🤖 Generated with [Claude Code](https://claude.com/claude-code)