### PR TITLE
feat(repo-intel): enforce a klaussy-agents version floor + harden upgrades

### DIFF
--- a/main/bootstrap/app-events.js
+++ b/main/bootstrap/app-events.js
@@ -8,6 +8,7 @@ const path = require('path');
 const fs = require('fs');
 const { execSync, execFileSync, execFile } = require('child_process');
 const { whichBinSync } = require('../util/platform');
+const { execToolSync } = require('../util/exec');
 const { app, ipcMain, dialog, BrowserWindow } = require('electron');
 const lspManager = require('../../lsp-manager');
 const { loadConfig, saveConfig, flushSaveConfig, runConfigMigrations } = require('../util/config');
@@ -109,7 +110,10 @@ function fixSpawnPath() {
 // absent or the query fails.
 function pipxBinDir() {
   try {
-    const out = execFileSync('pipx', ['environment', '--value', 'PIPX_BIN_DIR'], {
+    // execToolSync so a Windows scoop-shim pipx (pipx.cmd) resolves + runs —
+    // a bare execFileSync('pipx') would ENOENT on it and silently drop a
+    // custom PIPX_BIN_DIR from the spawn PATH.
+    const out = execToolSync('pipx', ['environment', '--value', 'PIPX_BIN_DIR'], {
       stdio: ['ignore', 'pipe', 'ignore'], timeout: 5000,
     }).toString().trim();
     return out || null;
@@ -355,6 +359,10 @@ function install() {
         Promise.resolve()
           .then(() => repoIntel.ensureReviewTools())
           .then(() => repoIntel.upgradeReviewToolsIfDue())
+          // After install + any daily upgrade, warn (once) if klaussy-agents is
+          // still below the version floor so the user gets a one-click upgrade
+          // instead of silently working against stale skills.
+          .then(() => repoIntel.warnIfKlaussyOutdated())
           .catch((e) => console.warn('[repo-intel] tool install/upgrade at boot failed:', e.message));
       }, 3000);
     }

--- a/main/ipc/tasks.js
+++ b/main/ipc/tasks.js
@@ -771,6 +771,17 @@ ipcMain.handle('get-repo-intel', (_event, { worktreePath, agent }) => {
   }
 });
 
+// Backs the renderer's "Upgrade now" toast — forces an immediate tool upgrade
+// past the daily gate and returns { version, min, ok } for the toast to report
+ipcMain.handle('upgrade-review-tools', async () => {
+  try {
+    return await require('../state/repo-intel').upgradeReviewToolsNow();
+  } catch (e) {
+    console.warn('[upgrade-review-tools]', e.message);
+    return { version: null, ok: false, error: e.message };
+  }
+});
+
 // ---- Current model for the sub-tab agent labels -----------------------------
 // "Claude Fable 5", not "claude code 2.1.172". Resolution order: the pinned
 // per-provider model from Preferences, then (Claude only) the model stamped on

--- a/main/state/repo-intel.js
+++ b/main/state/repo-intel.js
@@ -33,7 +33,10 @@ const path = require('path');
 const crypto = require('crypto');
 const { execFileSync } = require('child_process');
 const { app } = require('electron');
-const { execFileP } = require('../util/exec');
+// execToolP (aliased to execFileP here) hardens every external-tool spawn in
+// this file on Windows — where.exe/PATHEXT resolution + `.cmd`/`.bat` shim
+// support + windowsHide — while staying a pure passthrough on macOS/Linux.
+const { execToolP: execFileP } = require('../util/exec');
 const { baseRepoForWorktree } = require('../util/git-repo');
 const { loadConfig, saveConfig } = require('../util/config');
 
@@ -207,6 +210,32 @@ function getKlaussyCli() {
   return p;
 }
 
+// Lowest klaussy-agents version we treat as current — bump on any release we
+// want every repo to pick up, and the desktop prompts a one-click upgrade when
+// the installed CLI is below this floor (regeneration elsewhere keys on equality)
+const KLAUSSY_AGENTS_MIN_VERSION = '0.19.2';
+
+// Pull the first dotted numeric triple out of a `klaussy --version` string
+// ("klaussy, version 0.15.0" / "0.15.0" / "klaussy-agents 0.15.0" all parse).
+// Returns [major, minor, patch] or null when no version is parseable.
+function parseVersionTriple(s) {
+  const m = String(s || '').match(/(\d+)\.(\d+)\.(\d+)/);
+  return m ? [Number(m[1]), Number(m[2]), Number(m[3])] : null;
+}
+
+// True only when BOTH versions parse AND current < min. Unparseable input
+// returns false, so an odd version string never nags the user forever.
+function versionBelow(current, min) {
+  const c = parseVersionTriple(current);
+  const m = parseVersionTriple(min);
+  if (!c || !m) return false;
+  for (let i = 0; i < 3; i++) {
+    if (c[i] < m[i]) return true;
+    if (c[i] > m[i]) return false;
+  }
+  return false;
+}
+
 // Tell every window what's happening so the renderer can toast it — silent
 // success reads as "nothing ran" and silent failure hides a missing CLI.
 // Lazy require avoids a load-order dependency on state/windows.
@@ -279,6 +308,27 @@ async function pickInstaller() {
       return { kind: 'pip', py: c.py, pyArgs: c.pyArgs };
     } catch { /* try next */ }
   }
+  return null;
+}
+
+// True when a manager's list output has `pkg` as a line's first token — the
+// shape of both `pipx list --short` and `uv tool list` output
+function listHasPkg(stdout, pkg) {
+  return String(stdout || '').split('\n').some((line) => line.trim().split(/\s+/)[0] === pkg);
+}
+
+// Which isolated manager OWNS an already-installed tool (vs pickInstaller's
+// "what CAN install") — needed because a blind `pipx upgrade` on a uv-installed
+// tool silently no-ops. Returns { kind } or null (no owner); never throws
+async function detectToolOwner(pkg) {
+  try {
+    const r = await execFileP('pipx', ['list', '--short'], { timeout: 15000 });
+    if (listHasPkg(r.stdout, pkg)) return { kind: 'pipx' };
+  } catch { /* no pipx, or nothing installed via it */ }
+  try {
+    const r = await execFileP('uv', ['tool', 'list'], { timeout: 15000 });
+    if (listHasPkg(r.stdout, pkg)) return { kind: 'uv' };
+  } catch { /* no uv, or nothing installed via it */ }
   return null;
 }
 
@@ -422,18 +472,22 @@ async function upgradeReviewToolsIfDue() {
     const BIG = { timeout: 5 * 60 * 1000, maxBuffer: 16 * 1024 * 1024 };
     for (const t of TOOLS) {
       const pkg = t.pkg;
+      // Upgrade with the manager that OWNS this tool — a blind `pipx upgrade`
+      // on a uv-installed CLI no-ops (caught below) and strands a stale version.
+      // Fall back to pickInstaller only when neither isolated manager claims it
+      const owner = (await detectToolOwner(pkg)) || installer;
       try {
-        if (installer.kind === 'pipx') {
+        if (owner.kind === 'pipx') {
           await execFileP('pipx', ['upgrade', pkg], BIG);
-        } else if (installer.kind === 'uv') {
+        } else if (owner.kind === 'uv') {
           await execFileP('uv', ['tool', 'upgrade', pkg], BIG);
         } else {
           try {
-            await execFileP(installer.py, [...(installer.pyArgs || []), '-m', 'pip', 'install', '--user', '-U', pkg], BIG);
+            await execFileP(owner.py, [...(owner.pyArgs || []), '-m', 'pip', 'install', '--user', '-U', pkg], BIG);
           } catch (err) {
             const msg = (err && err.stderr ? String(err.stderr) : '') + '\n' + ((err && err.message) || '');
             if (/externally-managed-environment|PEP ?668|break-system-packages/i.test(msg)) {
-              await execFileP(installer.py, [...(installer.pyArgs || []), '-m', 'pip', 'install', '--user', '-U', '--break-system-packages', pkg], BIG);
+              await execFileP(owner.py, [...(owner.pyArgs || []), '-m', 'pip', 'install', '--user', '-U', '--break-system-packages', pkg], BIG);
             }
           }
         }
@@ -453,6 +507,41 @@ async function upgradeReviewToolsIfDue() {
   } catch (e) {
     console.warn('[repo-intel] upgrade check failed:', (e && e.message) || e);
   }
+}
+
+// Has this app run already surfaced the "klaussy-agents is out of date" prompt?
+// One nag per launch — the toast carries a one-click upgrade action, so
+// repeating it on every repo-intel run would just be noise.
+let outdatedNotified = false;
+
+// Emit a `tools-outdated` event when the installed klaussy-agents is below the
+// floor, so the renderer can offer a one-click upgrade — a MISSING CLI isn't
+// "outdated" (owned by the tools-failed toast), so stay quiet with no version
+async function warnIfKlaussyOutdated() {
+  try {
+    if (outdatedNotified) return;
+    const cli = await getKlaussyCli();
+    if (!cli.version) return;
+    if (!versionBelow(cli.version, KLAUSSY_AGENTS_MIN_VERSION)) return;
+    outdatedNotified = true;
+    notifyWindows({ type: 'tools-outdated', current: cli.version, min: KLAUSSY_AGENTS_MIN_VERSION });
+  } catch { /* best-effort — a version probe hiccup shouldn't crash boot */ }
+}
+
+// Force an immediate upgrade (the "Upgrade now" action), bypassing the daily
+// gate — re-probes and reports whether the machine cleared the floor; never throws
+async function upgradeReviewToolsNow() {
+  try {
+    const cfg = loadConfig();
+    cfg.reviewToolsCheckedAt = 0; // clear the daily gate so the upgrade runs now
+    saveConfig(cfg);
+  } catch { /* fall through — the upgrade may still be due */ }
+  outdatedNotified = false; // let a fresh nag fire if the upgrade doesn't take
+  await upgradeReviewToolsIfDue();
+  let version = null;
+  try { version = (await getKlaussyCli()).version; } catch { /* probe failed */ }
+  const ok = version ? !versionBelow(version, KLAUSSY_AGENTS_MIN_VERSION) : false;
+  return { version, min: KLAUSSY_AGENTS_MIN_VERSION, ok };
 }
 
 // Resolve a worktree (or repo) path to its primary checkout — intel belongs
@@ -1192,5 +1281,8 @@ function ensureWorktreeBootstrap(worktreePath) {
 }
 
 module.exports = { ensureRepoIntel, getRepoIntelBlock, syncIntelIntoWorktree, ensureWorktreeBootstrap, ensureEnvLinks, ensureReviewTools, upgradeReviewToolsIfDue,
+  warnIfKlaussyOutdated, upgradeReviewToolsNow,
   // Exported for unit testing of the prompt-minimization logic (Item 4).
-  loadStructuredIntel, ruleMatchesTouchedPaths, filterGraphSummary, assembleBlock };
+  loadStructuredIntel, ruleMatchesTouchedPaths, filterGraphSummary, assembleBlock,
+  // Exported for unit testing of the version-floor comparison.
+  versionBelow, KLAUSSY_AGENTS_MIN_VERSION };

--- a/main/util/exec.js
+++ b/main/util/exec.js
@@ -5,6 +5,44 @@
 
 const { execFile, execFileSync } = require('child_process');
 const execFileP = require('util').promisify(execFile);
+const { whichBinSync } = require('./platform');
+
+const IS_WIN = process.platform === 'win32';
+
+// cmd.exe-safe quoting for execToolP's batch-shim branch: bare tokens pass
+// through; anything with whitespace/metacharacters is double-quoted (no `%`).
+function winShellQuote(s) {
+  s = String(s);
+  if (/^[A-Za-z0-9_.:=+\-\\/]+$/.test(s)) return s;
+  return '"' + s.replace(/"/g, '\\"') + '"';
+}
+
+// Windows-hardened execFile for PATH tools, a plain passthrough on macOS/Linux
+// (on Windows: where+PATHEXT resolution, cmd/bat shims via shell, windowsHide,
+// and batch files that execFile blocks per CVE-2024-27980 run through cmd)
+function execToolP(file, args = [], opts = {}) {
+  if (!IS_WIN) return execFileP(file, args, opts);
+  const resolved = /[\\/]/.test(file) ? file : (whichBinSync(file) || file);
+  if (/\.(cmd|bat)$/i.test(resolved)) {
+    return execFileP(winShellQuote(resolved), args.map(winShellQuote), {
+      ...opts, shell: true, windowsHide: true,
+    });
+  }
+  return execFileP(resolved, args, { ...opts, windowsHide: true });
+}
+
+// Synchronous twin of execToolP for startup PATH-discovery, same Windows
+// hardening, passthrough to execFileSync on macOS/Linux
+function execToolSync(file, args = [], opts = {}) {
+  if (!IS_WIN) return execFileSync(file, args, opts);
+  const resolved = /[\\/]/.test(file) ? file : (whichBinSync(file) || file);
+  if (/\.(cmd|bat)$/i.test(resolved)) {
+    return execFileSync(winShellQuote(resolved), args.map(winShellQuote), {
+      ...opts, shell: true, windowsHide: true,
+    });
+  }
+  return execFileSync(resolved, args, { ...opts, windowsHide: true });
+}
 
 // Cap accumulation of a child process's stderr. Every streaming claude handler
 // buffers stderr unboundedly — a `--verbose` run or a lot of warnings could
@@ -163,6 +201,9 @@ function sanitizeExtraEnv(extraEnv) {
 
 module.exports = {
   execFileP,
+  execToolP,
+  execToolSync,
+  winShellQuote,
   STDERR_CAP_BYTES,
   appendStderr,
   ghEnvForRepo,

--- a/preload.js
+++ b/preload.js
@@ -74,6 +74,7 @@ contextBridge.exposeInMainWorld('klaus', {
     currentModel: (worktreePath, mode, taskId) => ipcRenderer.invoke('agent-current-model', { worktreePath, mode, taskId }),
     deleteSession: (worktreePaths) => ipcRenderer.invoke('delete-session', { worktreePaths }),
     getRepoIntel: (worktreePath, agent) => ipcRenderer.invoke('get-repo-intel', { worktreePath, agent }),
+    upgradeReviewTools: () => ipcRenderer.invoke('upgrade-review-tools'),
     getSessionRepos: (worktreePath) => ipcRenderer.invoke('get-session-repos', { worktreePath }),
     precommitReview: (worktreePath, provider) => ipcRenderer.invoke('precommit-review-run', { worktreePath, provider }),
     precommitReviewCancel: (worktreePath) => ipcRenderer.invoke('precommit-review-cancel', { worktreePath }),

--- a/renderer/app.js
+++ b/renderer/app.js
@@ -196,6 +196,29 @@ window.App = window.App || {};
         window.toast.warn('Repo-analysis tools (' + (ev.missing || []).join(', ') + ') couldn’t be installed automatically (' + (ev.reason || 'unknown') + '). Klaussy will retry in the background.');
         return;
       }
+      if (ev.type === 'tools-outdated') {
+        var msg = 'klaussy-agents is out of date (' + (ev.current || '?') + ' → needs ' + (ev.min || '?')
+          + '). New agent skills won’t appear in your repos until you upgrade.';
+        if (window.klaus.task.upgradeReviewTools) {
+          window.toast.action('warn', msg, 'Upgrade now', function () {
+            window.toast.info('Upgrading klaussy-agents…');
+            window.klaus.task.upgradeReviewTools().then(function (res) {
+              if (res && res.ok) {
+                window.toast.success('klaussy-agents upgraded to ' + res.version + ' — repos pick up new skills on next open');
+              } else {
+                window.toast.warn('Upgrade didn’t complete'
+                  + (res && res.version ? ' (still ' + res.version + ')' : '')
+                  + '. Try manually: pipx upgrade klaussy-agents  (or: uv tool upgrade klaussy-agents)');
+              }
+            }).catch(function (e) {
+              window.toast.warn('Upgrade failed: ' + (e && e.message ? e.message : e));
+            });
+          });
+        } else {
+          window.toast.warn(msg + ' Run: pipx upgrade klaussy-agents');
+        }
+        return;
+      }
       if (!ev.repoPath) return;
       var repoName = ev.repoPath.split('/').filter(Boolean).pop();
       if (ev.type === 'started') {

--- a/renderer/toast.js
+++ b/renderer/toast.js
@@ -69,6 +69,19 @@
       .klaussy-toast.info    { border-left-color: #64b5f6; }
       .klaussy-toast.success { border-left-color: #81c784; }
       .klaussy-toast .msg { white-space: pre-wrap; }
+      .klaussy-toast-action {
+        display: inline-block;
+        margin-top: 8px;
+        padding: 4px 12px;
+        font: inherit;
+        font-weight: 600;
+        color: #e8e8f0;
+        background: rgba(255,255,255,0.12);
+        border: 1px solid rgba(255,255,255,0.18);
+        border-radius: 4px;
+        cursor: pointer;
+      }
+      .klaussy-toast-action:hover { background: rgba(255,255,255,0.2); }
     `;
     document.head.appendChild(style);
 
@@ -84,8 +97,11 @@
   // so users can read + copy the failure message before it disappears.
   const DISMISS_MS = { error: 8000, warn: 6000, info: 4500, success: 4500 };
 
-  function show(level, message) {
+  // opts (optional): { actionLabel, onAction, sticky }. An action toast renders
+  // a button that runs onAction then dismisses; `sticky` disables auto-dismiss.
+  function show(level, message, opts) {
     if (!_installed) install();
+    opts = opts || {};
     const el = document.createElement('div');
     el.className = 'klaussy-toast ' + level;
     const span = document.createElement('span');
@@ -93,23 +109,42 @@
     // Plain text: no innerHTML, so message content can't smuggle markup.
     span.textContent = String(message == null ? '' : message);
     el.appendChild(span);
-    _container.appendChild(el);
 
-    // Next frame so the transition runs from the initial off-screen state.
-    requestAnimationFrame(() => el.classList.add('visible'));
-
-    const timeout = DISMISS_MS[level] || DISMISS_MS.info;
     let dismissed = false;
     const dismiss = () => {
       if (dismissed) return;
       dismissed = true;
+      clearTimeout(timer);
       el.classList.remove('visible');
       el.classList.add('leaving');
       // Wait for the fade-out transition before removing from the DOM.
       setTimeout(() => { try { el.remove(); } catch {} }, 200);
     };
-    const timer = setTimeout(dismiss, timeout);
-    el.addEventListener('click', () => { clearTimeout(timer); dismiss(); });
+
+    if (opts.actionLabel && typeof opts.onAction === 'function') {
+      const btn = document.createElement('button');
+      btn.className = 'klaussy-toast-action';
+      btn.textContent = String(opts.actionLabel);
+      btn.addEventListener('click', (e) => {
+        // Don't let the click bubble to the toast body's dismiss handler before
+        // the action runs.
+        e.stopPropagation();
+        try { opts.onAction(); } finally { dismiss(); }
+      });
+      el.appendChild(document.createElement('br'));
+      el.appendChild(btn);
+    }
+
+    _container.appendChild(el);
+
+    // Next frame so the transition runs from the initial off-screen state.
+    requestAnimationFrame(() => el.classList.add('visible'));
+
+    // Sticky toasts stay until clicked — used for actionable prompts the user
+    // shouldn't miss (a timed-out upgrade nag reads as "nothing to do").
+    const timeout = DISMISS_MS[level] || DISMISS_MS.info;
+    const timer = opts.sticky ? null : setTimeout(dismiss, timeout);
+    el.addEventListener('click', dismiss);
   }
 
   window.toast = {
@@ -117,5 +152,9 @@
     warn:    (msg) => show('warn', msg),
     info:    (msg) => show('info', msg),
     success: (msg) => show('success', msg),
+    // Actionable toast: level + message + a button. Sticky by default so the
+    // action stays available; pass opts.sticky === false to auto-dismiss.
+    action:  (level, msg, actionLabel, onAction, opts) =>
+      show(level, msg, Object.assign({ sticky: true, actionLabel, onAction }, opts)),
   };
 })();

--- a/test/util/exec.test.js
+++ b/test/util/exec.test.js
@@ -2,7 +2,7 @@ require('../setup');
 
 const test = require('node:test');
 const assert = require('node:assert/strict');
-const { appendStderr, sanitizeExtraEnv, runWithConcurrency, STDERR_CAP_BYTES, resolveGhEnv } = require('../../main/util/exec');
+const { appendStderr, sanitizeExtraEnv, runWithConcurrency, STDERR_CAP_BYTES, resolveGhEnv, winShellQuote } = require('../../main/util/exec');
 
 // --- resolveGhEnv ---
 
@@ -153,4 +153,33 @@ test('runWithConcurrency with cap > items runs up to items.length workers', asyn
     active--;
   });
   assert.ok(peak <= 2, 'spawned more workers than items: ' + peak);
+});
+
+// --- winShellQuote (cmd.exe batch-shim arg quoting) ---
+
+test('winShellQuote leaves safe bare tokens untouched', () => {
+  // The fixed tool args we route through the shell branch must not gain quotes.
+  for (const s of ['upgrade', '--short', 'klaussy-agents', '-3', '-m', 'pip',
+                   '--user', '-U', 'C:\\Users\\me\\.local\\bin\\pipx.cmd',
+                   'PIPX_BIN_DIR', '--value']) {
+    assert.equal(winShellQuote(s), s, 'should pass through: ' + s);
+  }
+});
+
+test('winShellQuote double-quotes anything with whitespace or metacharacters', () => {
+  assert.equal(winShellQuote('C:\\Program Files\\pipx\\pipx.cmd'),
+    '"C:\\Program Files\\pipx\\pipx.cmd"');
+  assert.equal(winShellQuote('a b'), '"a b"');
+  // cmd metacharacters that would otherwise break the command line.
+  assert.equal(winShellQuote('a&b'), '"a&b"');
+  assert.equal(winShellQuote('a|b'), '"a|b"');
+  assert.equal(winShellQuote('a>b'), '"a>b"');
+});
+
+test('winShellQuote escapes embedded double quotes', () => {
+  assert.equal(winShellQuote('say "hi"'), '"say \\"hi\\""');
+});
+
+test('winShellQuote coerces non-strings without throwing', () => {
+  assert.equal(winShellQuote(3), '3');
 });

--- a/test/util/repo-intel-version-floor.test.js
+++ b/test/util/repo-intel-version-floor.test.js
@@ -1,0 +1,45 @@
+require('../setup');
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const { versionBelow, KLAUSSY_AGENTS_MIN_VERSION } = require('../../main/state/repo-intel');
+
+// versionBelow gates the "out of date" prompt: parse a triple from whatever
+// `klaussy --version` prints, compare per-component (not lexically), and stay
+// silent on unparseable input so a weird version string never nags forever
+
+test('versionBelow: strictly-older version is below the floor', () => {
+  assert.equal(versionBelow('0.14.9', '0.15.0'), true);
+  assert.equal(versionBelow('0.14.0', '0.15.0'), true);
+  assert.equal(versionBelow('0.0.1', '0.15.0'), true);
+});
+
+test('versionBelow: equal or newer version is NOT below the floor', () => {
+  assert.equal(versionBelow('0.15.0', '0.15.0'), false);
+  assert.equal(versionBelow('0.15.1', '0.15.0'), false);
+  assert.equal(versionBelow('1.0.0', '0.15.0'), false);
+});
+
+test('versionBelow: numeric (not lexical) component comparison', () => {
+  // Numerically 0.9.0 < 0.15.0 (minor 9 < 15), so it IS below the floor — a
+  // naive lexical compare would wrongly say "0.9.0" > "0.15.0" ('9' > '1').
+  assert.equal(versionBelow('0.9.0', '0.15.0'), true);
+  // ...and 0.15.0 is not below 0.9.0 for the same reason.
+  assert.equal(versionBelow('0.15.0', '0.9.0'), false);
+});
+
+test('versionBelow: parses a version out of a decorated --version string', () => {
+  assert.equal(versionBelow('klaussy, version 0.14.0', '0.15.0'), true);
+  assert.equal(versionBelow('klaussy-agents 0.15.0', '0.15.0'), false);
+});
+
+test('versionBelow: unparseable input is never "below" (no false nag)', () => {
+  assert.equal(versionBelow('', '0.15.0'), false);
+  assert.equal(versionBelow(null, '0.15.0'), false);
+  assert.equal(versionBelow('dev', '0.15.0'), false);
+  assert.equal(versionBelow('0.15.0', 'not-a-version'), false);
+});
+
+test('KLAUSSY_AGENTS_MIN_VERSION is a parseable semver triple', () => {
+  assert.match(KLAUSSY_AGENTS_MIN_VERSION, /^\d+\.\d+\.\d+$/);
+});


### PR DESCRIPTION
## Summary

Repos were silently going stale in Klaussy Desktop — missing newly-shipped klaussy agent skills — because the klaussy-agents upgrade path was install-if-missing plus a silent, once-a-day best-effort `pipx upgrade`, with no version floor and no signal when it failed. This enforces a version floor with a visible one-click upgrade, makes the upgrade installer-aware, and hardens the whole tool-spawn layer on Windows.

## Changes

- **Installer-aware upgrade** — `detectToolOwner` probes `pipx list` / `uv tool list` so `upgradeReviewToolsIfDue` upgrades with the manager that actually owns each tool. A blind `pipx upgrade` on a uv-owned install silently no-ops and strands the CLI on a stale version.
- **Version floor + one-click prompt** — `KLAUSSY_AGENTS_MIN_VERSION` (0.19.2) with a numeric-semver `versionBelow`. `warnIfKlaussyOutdated` emits a `tools-outdated` event once at boot; the renderer shows a sticky "Upgrade now" toast wired through a new `upgrade-review-tools` IPC to `upgradeReviewToolsNow` (clears the daily gate, upgrades, re-probes, reports whether the floor was cleared).
- **Windows-hardened spawn layer** — new `execToolP` / `execToolSync` + `winShellQuote` in `util/exec`. Pure passthroughs on macOS/Linux; on Windows they resolve via `where.exe` + PATHEXT, run `.cmd`/`.bat` shims (e.g. scoop-installed pipx/uv) through the shell (Node blocks batch files via execFile post-CVE-2024-27980), and set `windowsHide`. `repo-intel` routes all ~23 tool spawns through it via one aliased import; `pipxBinDir` uses the sync variant.
- **Toast action button** — `window.toast.action(level, msg, label, onAction, opts)` (sticky by default) + button styling.

## Test Plan

- `npm run test` — 152/152 unit tests pass, including new coverage for the `versionBelow` comparator and `winShellQuote` cmd-quoting.
- `npm run lint` — clean.
- Verified against the real CLI (`klaussy 0.19.2`): `versionBelow` parses/compares correctly, `detectToolOwner` resolves `klaussy-agents` to pipx and doesn't false-match uv's script lines, `execToolP` passes through on macOS (ran a real `git --version`).
- Launched the app on the hardened code: boots clean, no errors, `warnIfKlaussyOutdated` correctly stays silent at the floor.

## Checklist

- [x] Tests added/updated
- [x] Lint clean
- [x] Verified in the running app

## Notes

Cross-platform: works and is improved on macOS/Linux. The Windows path is correct-by-construction and now covers the scoop/`.cmd` case, but has **not** been exercised on real Windows hardware yet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
