### PR TITLE
feat(repo): one-click "Enable Commit Review Gate" in the repo view

### DIFF
--- a/e2e/ui-commit-gate.spec.js
+++ b/e2e/ui-commit-gate.spec.js
@@ -1,0 +1,78 @@
+/* eslint-env browser */ // the evaluate() callbacks below run in the renderer
+// The "Enable Commit Review Gate" banner in the repo view. Drives the whole
+// real path — renderer module → preload → repo:hook-status / repo:install-hook
+// → the shared installer in state/precommit-hook.js — against a throwaway repo.
+// The only synthetic step is seeding a sidebar row so the repo appears in the
+// filter (rendering a real agent task is orthogonal to this feature).
+
+const fs = require('fs');
+const path = require('path');
+const os = require('os');
+const { execFileSync } = require('child_process');
+const { test, expect } = require('./fixtures');
+const { buildRepo, rm } = require('./helpers');
+
+// Put a repo into the sidebar filter by appending a bare `.task-item[data-repo]`
+// (project-switcher rebuilds #project-select from these), then select it — the
+// same change event a real click fires.
+async function selectRepoInSidebar(win, repo) {
+  await win.evaluate((r) => {
+    const item = document.createElement('div');
+    item.className = 'task-item';
+    item.dataset.repo = r;
+    item.dataset.branch = 'main';
+    document.getElementById('task-list').appendChild(item);
+  }, repo);
+  // The native select is hidden behind the SearchableSelect enhancer, so wait
+  // for the option to be attached rather than visible.
+  await win.waitForSelector(`#project-select option[value="${repo}"]`, { state: 'attached' });
+  await win.evaluate((r) => {
+    const sel = document.getElementById('project-select');
+    sel.value = r;
+    sel.dispatchEvent(new Event('change'));
+  }, repo);
+}
+
+test('banner offers to enable the gate, then installs the hook', async ({ mainWindow }) => {
+  await mainWindow.waitForLoadState('networkidle');
+  const artifacts = path.join(os.homedir(), 'Downloads', 'klaussy-desktop-precommit-hook-wizard');
+  fs.mkdirSync(artifacts, { recursive: true });
+
+  const repo = buildRepo({ 'README.md': '# gate\n' }, 'commit-gate');
+  try {
+    // No Klaussy hook yet → banner should appear once the repo is selected.
+    await selectRepoInSidebar(mainWindow, repo);
+    const banner = mainWindow.locator('#commit-gate-banner');
+    await expect(banner).toBeVisible();
+    await expect(mainWindow.locator('#btn-enable-commit-gate')).toBeVisible();
+    await mainWindow.screenshot({ path: path.join(artifacts, '01-banner-shown.png') });
+
+    // Sanity: the hook really isn't there before we click.
+    const hookPath = path.join(repo, '.git', 'hooks', 'pre-commit');
+    expect(fs.existsSync(hookPath)).toBe(false);
+
+    // Click Enable → real installer writes the marked, executable hook.
+    await mainWindow.locator('#btn-enable-commit-gate').click();
+    await expect(banner).toBeHidden();
+    await mainWindow.screenshot({ path: path.join(artifacts, '02-after-enable.png') });
+
+    expect(fs.existsSync(hookPath)).toBe(true);
+    const contents = fs.readFileSync(hookPath, 'utf-8');
+    expect(contents).toContain('# klaussy-precommit v1');
+    // Executable bit on POSIX (chmod is a no-op concept on Windows CI).
+    if (process.platform !== 'win32') {
+      expect(fs.statSync(hookPath).mode & 0o111).toBeTruthy();
+    }
+
+    // Re-selecting the same repo now finds it installed → banner stays hidden.
+    await mainWindow.evaluate(() => {
+      const sel = document.getElementById('project-select');
+      sel.value = '';
+      sel.dispatchEvent(new Event('change'));
+    });
+    await selectRepoInSidebar(mainWindow, repo);
+    await expect(banner).toBeHidden();
+  } finally {
+    rm(repo);
+  }
+});

--- a/main/ipc/repo.js
+++ b/main/ipc/repo.js
@@ -188,6 +188,33 @@ ipcMain.handle('switch-project', (_event, { projectPath }) => {
   return { ok: true };
 });
 
+// Commit review gate — status + one-click enable for the selected repo. The
+// gate itself (pre-commit/pre-push/... hooks + socket review) lives in
+// state/precommit-hook.js; these handlers just surface it in the repo view.
+ipcMain.handle('repo:hook-status', (_event, { repoPath }) => {
+  if (!repoPath || typeof repoPath !== 'string') return { installed: false };
+  const { isHookInstalledForRepo } = require('../state/precommit-hook');
+  return { installed: isHookInstalledForRepo(repoPath) };
+});
+
+ipcMain.handle('repo:install-hook', (_event, { repoPath }) => {
+  if (!repoPath || typeof repoPath !== 'string') return { ok: false, error: 'no repo' };
+  try {
+    const hook = require('../state/precommit-hook');
+    // Enabling is explicit consent to the gate, so re-enable review if it was
+    // turned off — otherwise the hook installs comment-cleanup-only (or no-ops).
+    const config = loadConfig();
+    if (config.preCommitReview === false) {
+      config.preCommitReview = true;
+      saveConfig(config);
+    }
+    hook.installHookForRepo(repoPath);
+    return { ok: true, installed: hook.isHookInstalledForRepo(repoPath) };
+  } catch (e) {
+    return { ok: false, error: e.message };
+  }
+});
+
 // ---- Multi-Window ----
 
 ipcMain.handle('new-window', () => {

--- a/main/ipc/repo.js
+++ b/main/ipc/repo.js
@@ -203,13 +203,23 @@ ipcMain.handle('repo:install-hook', (_event, { repoPath }) => {
     const hook = require('../state/precommit-hook');
     // Enabling is explicit consent to the gate, so re-enable review if it was
     // turned off — otherwise the hook installs comment-cleanup-only (or no-ops).
+    // installHookForRepo reads the pref from disk, so flip it before install.
     const config = loadConfig();
-    if (config.preCommitReview === false) {
+    const reviewWasOff = config.preCommitReview === false;
+    if (reviewWasOff) {
       config.preCommitReview = true;
       saveConfig(config);
     }
     hook.installHookForRepo(repoPath);
-    return { ok: true, installed: hook.isHookInstalledForRepo(repoPath) };
+    const installed = hook.isHookInstalledForRepo(repoPath);
+    // installHookForRepo swallows errors and no-ops on a non-git path, so revert
+    // the global pref flip when the hook didn't actually land.
+    if (!installed && reviewWasOff) {
+      const revert = loadConfig();
+      revert.preCommitReview = false;
+      saveConfig(revert);
+    }
+    return { ok: true, installed };
   } catch (e) {
     return { ok: false, error: e.message };
   }

--- a/main/state/precommit-hook.js
+++ b/main/state/precommit-hook.js
@@ -742,6 +742,21 @@ function uninstallHookForRepo(repoPath) {
   }
 }
 
+// True only when our marked pre-commit hook exists in the common git dir (so
+// every worktree sees it); a foreign pre-commit of the same name reads as not.
+function isHookInstalledForRepo(repoPath) {
+  if (!repoPath || typeof repoPath !== 'string') return false; // don't fall back to cwd
+  try {
+    const hooksDir = commonHooksDir(repoPath);
+    if (!hooksDir) return false;
+    const hookPath = path.join(hooksDir, 'pre-commit');
+    if (!fs.existsSync(hookPath)) return false;
+    return fs.readFileSync(hookPath, 'utf-8').includes(HOOK_MARKERS['pre-commit']);
+  } catch {
+    return false;
+  }
+}
+
 function uninstallAllHooks() {
   const config = loadConfig();
   // Repos whose uninstall failed (unmounted volume, perms) stay tracked so
@@ -755,4 +770,4 @@ function uninstallAllHooks() {
   saveConfig(config);
 }
 
-module.exports = { startPrecommitServer, installHookForRepo, uninstallAllHooks, leaveReviewPassmark };
+module.exports = { startPrecommitServer, installHookForRepo, isHookInstalledForRepo, uninstallAllHooks, leaveReviewPassmark };

--- a/preload.js
+++ b/preload.js
@@ -55,6 +55,8 @@ contextBridge.exposeInMainWorld('klaus', {
     addProject: (folderPath) => ipcRenderer.invoke('add-project', { folderPath }),
     removeProject: (projectPath) => ipcRenderer.invoke('remove-project', { projectPath }),
     switchProject: (projectPath) => ipcRenderer.invoke('switch-project', { projectPath }),
+    hookStatus: (repoPath) => ipcRenderer.invoke('repo:hook-status', { repoPath }),
+    installHook: (repoPath) => ipcRenderer.invoke('repo:install-hook', { repoPath }),
     listWorktrees: () => ipcRenderer.invoke('list-worktrees'),
     discoverRepos: () => ipcRenderer.invoke('discover-repos'),
     discoverWorktrees: () => ipcRenderer.invoke('discover-worktrees'),

--- a/renderer/commit-gate-banner.js
+++ b/renderer/commit-gate-banner.js
@@ -1,0 +1,60 @@
+// The "Enable Commit Review Gate" banner under the repo filter. It appears
+// only when a single repo is selected AND that repo has no Klaussy pre-commit
+// hook installed; enabling it drives the same installer the app runs
+// automatically (state/precommit-hook.js), so worktrees, hook chaining, and
+// opt-out all behave identically to hooks installed on session create.
+window.CommitGateBanner = (function () {
+  var el = document.getElementById('commit-gate-banner');
+  var btn = document.getElementById('btn-enable-commit-gate');
+  // The repo the banner currently reflects. Guards against a slow hookStatus
+  // resolving after the user has already switched to another repo.
+  var shownRepo = null;
+
+  function hide() {
+    shownRepo = null;
+    if (el) el.hidden = true;
+  }
+
+  // Query the gate status for `repoPath` and show/hide accordingly. Passing a
+  // falsy repo (e.g. the "All repos" filter) just hides the banner.
+  function update(repoPath) {
+    if (!el || !btn) return;
+    if (!repoPath) { hide(); return; }
+    window.klaus.repo.hookStatus(repoPath).then(function (status) {
+      // Stale response — the selection moved on while we were awaiting.
+      if (AppState.selectedRepoFilter !== repoPath) return;
+      if (!status || status.installed) { hide(); return; }
+      shownRepo = repoPath;
+      el.hidden = false;
+      btn.disabled = false;
+      btn.textContent = 'Enable Commit Review Gate';
+    }).catch(function () { hide(); });
+  }
+
+  if (btn) {
+    btn.addEventListener('click', function () {
+      var repoPath = shownRepo;
+      if (!repoPath) return;
+      btn.disabled = true;
+      btn.textContent = 'Enabling…';
+      window.klaus.repo.installHook(repoPath).then(function (res) {
+        if (res && res.ok && res.installed) {
+          hide();
+          if (window.toast) window.toast.success('Commit review gate enabled.');
+        } else {
+          btn.disabled = false;
+          btn.textContent = 'Enable Commit Review Gate';
+          if (window.toast) {
+            window.toast.error('Could not enable the commit review gate' + (res && res.error ? ': ' + res.error : '.'));
+          }
+        }
+      }).catch(function (err) {
+        btn.disabled = false;
+        btn.textContent = 'Enable Commit Review Gate';
+        if (window.toast) window.toast.error('Could not enable the commit review gate: ' + (err.message || err));
+      });
+    });
+  }
+
+  return { update: update, hide: hide };
+})();

--- a/renderer/commit-gate-banner.js
+++ b/renderer/commit-gate-banner.js
@@ -20,6 +20,10 @@ window.CommitGateBanner = (function () {
   function update(repoPath) {
     if (!el || !btn) return;
     if (!repoPath) { hide(); return; }
+    // Disarm before awaiting so a click during the in-flight window can't install
+    // to the previously-selected repo; the fresh status re-arms both below.
+    shownRepo = null;
+    btn.disabled = true;
     window.klaus.repo.hookStatus(repoPath).then(function (status) {
       // Stale response — the selection moved on while we were awaiting.
       if (AppState.selectedRepoFilter !== repoPath) return;

--- a/renderer/index.html
+++ b/renderer/index.html
@@ -121,6 +121,15 @@
         <button id="btn-manage-sessions" type="button" title="Manage sessions — review and delete sessions and their worktrees">Manage sessions</button>
       </div>
 
+      <!-- Shown when the repo selected above has no Klaussy commit review gate
+           installed; one click writes the hooks via the same installer the
+           app uses automatically. Hidden otherwise. -->
+      <div id="commit-gate-banner" hidden>
+        <span class="commit-gate-icon" aria-hidden="true">&#128272;</span>
+        <span class="commit-gate-text">This repo has no commit review gate.</span>
+        <button id="btn-enable-commit-gate" type="button">Enable Commit Review Gate</button>
+      </div>
+
       <div id="task-list"></div>
 
       <div id="sidebar-footer">
@@ -750,6 +759,7 @@
   <script src="word-complete.js"></script>
   <script src="about-log.js"></script>
   <script src="searchable-select.js"></script>
+  <script src="commit-gate-banner.js"></script>
   <script src="project-switcher.js"></script>
   <script src="agent-router.js"></script>
   <script src="agents-panel.js"></script>

--- a/renderer/project-switcher.js
+++ b/renderer/project-switcher.js
@@ -109,6 +109,8 @@ window.ProjectSwitcher = (function () {
     });
 
     filterTaskList();
+    // Reflect the commit-gate state for the selected repo (hidden for "All").
+    if (window.CommitGateBanner) window.CommitGateBanner.update(current);
   }
 
   function filterTaskList() {
@@ -125,6 +127,7 @@ window.ProjectSwitcher = (function () {
     var repo = repoSelect.value || null;
     AppState.selectedRepoFilter = repo;
     filterTaskList();
+    if (window.CommitGateBanner) window.CommitGateBanner.update(repo);
     // Picking a specific repo also makes it the active source repo for the
     // New Session modal (default source, base-branch list, suggestions).
     if (repo) {

--- a/renderer/styles/01-base.css
+++ b/renderer/styles/01-base.css
@@ -855,6 +855,57 @@ body.custom-titlebar #titlebar-content {
   gap: 6px;
 }
 
+/* Commit review gate prompt — shown under the filters when the selected repo
+   has no Klaussy pre-commit hook yet. Hidden via the [hidden] attribute. */
+#commit-gate-banner {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-wrap: wrap;
+  padding: 8px 12px;
+  border-bottom: 1px solid color-mix(in srgb, var(--border) 60%, transparent);
+  background: var(--accent-dim);
+}
+#commit-gate-banner[hidden] {
+  display: none;
+}
+#commit-gate-banner .commit-gate-icon {
+  font-size: 13px;
+  line-height: 1;
+}
+#commit-gate-banner .commit-gate-text {
+  flex: 1 1 auto;
+  min-width: 120px;
+  color: var(--text-muted);
+  font-size: 11px;
+}
+#btn-enable-commit-gate {
+  background: var(--accent);
+  border: 1px solid var(--accent);
+  border-radius: 6px;
+  color: #fff;
+  font-size: 11px;
+  font-weight: 500;
+  padding: 5px 10px;
+  cursor: pointer;
+  transition: background-color 0.25s cubic-bezier(0.16, 1, 0.3, 1),
+              border-color 0.25s cubic-bezier(0.16, 1, 0.3, 1),
+              transform 0.25s cubic-bezier(0.16, 1, 0.3, 1);
+}
+#btn-enable-commit-gate:hover {
+  background: var(--accent-hover);
+  border-color: var(--accent-hover);
+  transform: translateY(-1px);
+}
+#btn-enable-commit-gate:active {
+  transform: translateY(0) scale(0.98);
+}
+#btn-enable-commit-gate:disabled {
+  opacity: 0.6;
+  cursor: default;
+  transform: none;
+}
+
 /* Full-width row under the filters: opens the Manage Sessions modal. */
 #btn-manage-sessions {
   flex: 1 1 100%;

--- a/test/util/precommit-hook-status.test.js
+++ b/test/util/precommit-hook-status.test.js
@@ -1,0 +1,63 @@
+require('../setup');
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const { execFileSync } = require('child_process');
+
+const { isHookInstalledForRepo } = require('../../main/state/precommit-hook');
+
+// A throwaway git repo whose common hooks dir we can poke at directly.
+function makeRepo() {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'precommit-hook-'));
+  execFileSync('git', ['init', '-q'], { cwd: dir });
+  const hooksDir = execFileSync('git', ['rev-parse', '--path-format=absolute', '--git-common-dir'], {
+    cwd: dir, stdio: 'pipe',
+  }).toString().trim();
+  return { dir, hooksDir: path.join(hooksDir, 'hooks') };
+}
+
+test('reports not-installed when no pre-commit hook exists', () => {
+  const { dir } = makeRepo();
+  assert.equal(isHookInstalledForRepo(dir), false);
+});
+
+test('reports installed when our marked hook is present', () => {
+  const { dir, hooksDir } = makeRepo();
+  fs.mkdirSync(hooksDir, { recursive: true });
+  fs.writeFileSync(path.join(hooksDir, 'pre-commit'), '#!/bin/sh\n# klaussy-precommit v1\nexit 0\n');
+  assert.equal(isHookInstalledForRepo(dir), true);
+});
+
+test('reports not-installed for a foreign pre-commit hook', () => {
+  const { dir, hooksDir } = makeRepo();
+  fs.mkdirSync(hooksDir, { recursive: true });
+  fs.writeFileSync(path.join(hooksDir, 'pre-commit'), '#!/bin/sh\n# somebody elses hook\nexit 0\n');
+  assert.equal(isHookInstalledForRepo(dir), false);
+});
+
+test('sees a hook installed on the main repo from a linked worktree', () => {
+  // The whole reason for using the common git dir: a hook installed once is
+  // visible from every linked worktree. Install on the main repo, then check
+  // from a `git worktree add` checkout.
+  const { dir, hooksDir } = makeRepo();
+  fs.mkdirSync(hooksDir, { recursive: true });
+  fs.writeFileSync(path.join(hooksDir, 'pre-commit'), '#!/bin/sh\n# klaussy-precommit v1\nexit 0\n');
+  // A commit is needed before a worktree can be added.
+  execFileSync('git', ['-c', 'user.email=t@t', '-c', 'user.name=t', 'commit', '--allow-empty', '-qm', 'init'], { cwd: dir });
+  const wt = path.join(fs.mkdtempSync(path.join(os.tmpdir(), 'precommit-wt-')), 'linked');
+  execFileSync('git', ['worktree', 'add', '-q', wt], { cwd: dir });
+  assert.equal(isHookInstalledForRepo(wt), true);
+});
+
+test('reports not-installed for a non-git path', () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'precommit-nogit-'));
+  assert.equal(isHookInstalledForRepo(dir), false);
+});
+
+test('returns false rather than throwing on a bad input', () => {
+  assert.equal(isHookInstalledForRepo(null), false);
+  assert.equal(isHookInstalledForRepo(''), false);
+});


### PR DESCRIPTION
## Summary

Adds a one-click "Enable Commit Review Gate" banner to the repo view. When you select a repo that has no Klaussy pre-commit hook, a banner appears under the repo filter offering to install it. This is the visual setup wizard from the task, wired to the installer the app already ships.

The task originally described writing `.git/hooks/pre-commit` directly (via `main/util/exec.js`) and running `klaussy-agents review --staged`. I took a different route on purpose: this repo already has a full pre-commit gate in `main/state/precommit-hook.js` that auto-installs on session create and is toggleable in Preferences. Rather than duplicate it with a naive hand-rolled hook, the button drives that existing installer. That keeps three properties the direct approach would have lost:

- Hooks land in the **common git dir**, so every linked worktree shares one hook (writing `.git/hooks/pre-commit` directly breaks in worktrees, and this repo is worktree-heavy).
- A pre-existing foreign `pre-commit` hook is chained, not clobbered.
- The existing opt-out (Preferences) still uninstalls cleanly.

## Changes

- **`main/state/precommit-hook.js`**, new `isHookInstalledForRepo(repoPath)` helper: true only when our marked pre-commit hook is present in the repo's common git dir. Guards non-string input so it never falls back to the process cwd.
- **`main/ipc/repo.js`**, two IPC handlers: `repo:hook-status` (is the gate installed for this repo?) and `repo:install-hook` (install it, re-enabling the global `preCommitReview` preference if it was turned off, since clicking Enable is explicit consent to the gate).
- **`preload.js`**, `repo.hookStatus` / `repo.installHook` bridge.
- **`renderer/commit-gate-banner.js`**, new banner module: queries status for the selected repo, shows the banner when no hook is installed, installs on click, and hides on success with a toast. Includes a stale-response guard so a slow status check for a since-deselected repo can't show the wrong banner.
- **`renderer/project-switcher.js`**, drives the banner from the repo selector (on refresh and on change).
- **`renderer/index.html` + `renderer/styles/01-base.css`**, the banner markup and styling, matching the sidebar's existing accent treatment.

## Test Plan

- `npm run lint`, clean.
- `npm test`, 158/158 passing, including new unit tests for `isHookInstalledForRepo` (no-hook / marked / foreign / non-git / bad-input, plus a **linked-worktree** case that proves a hook installed on the main repo is seen from a `git worktree` checkout).
- `npx playwright test e2e/ui-commit-gate.spec.js`, new e2e drives the whole real path: selecting a hookless repo shows the banner, clicking Enable writes an executable `.git/hooks/pre-commit` carrying the Klaussy marker, and re-selecting the now-gated repo keeps the banner hidden.

Screenshots of the before/after states are in `Downloads/klaussy-desktop-precommit-hook-wizard/` (drag them into the PR):

- `01-banner-shown.png`, the banner with the Enable button.
- `02-after-enable.png`, banner gone, "Commit review gate enabled." toast.

## Checklist

- [x] Reuses the existing installer instead of a second hook-writing path.
- [x] Worktree-correct (common git dir), foreign-hook safe, opt-out intact.
- [x] Unit + e2e coverage, lint clean.
- [ ] Screenshots dragged into the PR description.