### PR TITLE
feat(diff): inline comments on diff lines, batched to the agent

### DIFF
--- a/e2e/terminal-dedupe.spec.js
+++ b/e2e/terminal-dedupe.spec.js
@@ -1,0 +1,26 @@
+// Several callers can fire addTaskToUI twice for one id; guard must re-focus, not render a second pane.
+
+/* global window, document */
+
+const { test, expect } = require('./fixtures');
+
+test('addTaskToUI twice for one id renders a single terminal pane', async ({ mainWindow }) => {
+  await mainWindow.waitForFunction(() => !!(window.TerminalManager && window.TerminalManager.addTaskToUI));
+
+  const count = await mainWindow.evaluate(() => {
+    const id = 990001;
+    const task = {
+      id, name: 'dedupe', worktreePath: '/tmp/dedupe', branch: 'dedupe',
+      repoPath: '/tmp/repo', mode: 'shell', alive: true,
+    };
+    try {
+      window.TerminalManager.addTaskToUI(task);
+      window.TerminalManager.addTaskToUI(task);
+      return document.querySelectorAll('.terminal-container[data-id="' + id + '"]').length;
+    } finally {
+      try { window.TerminalManager.removeTaskFromUI(id); } catch {}
+    }
+  });
+
+  expect(count).toBe(1);
+});

--- a/e2e/ui-diff-annotations.spec.js
+++ b/e2e/ui-diff-annotations.spec.js
@@ -1,0 +1,119 @@
+// Inline diff annotations end-to-end against a live worktree: the comment
+// callback is swapped for a capturing stub so we can assert the exact prompt
+// without spawning an agent. Step screenshots land in QA_SHOT_DIR (default: tmp).
+
+const fs = require('fs');
+const path = require('path');
+const os = require('os');
+const { execFileSync } = require('child_process');
+const { test, expect } = require('./fixtures');
+
+const SHOT_DIR = process.env.QA_SHOT_DIR || path.join(os.tmpdir(), 'klaussy-qa-diff-annotations');
+
+function shot(mainWindow, name) {
+  fs.mkdirSync(SHOT_DIR, { recursive: true });
+  return mainWindow.screenshot({ path: path.join(SHOT_DIR, name) });
+}
+
+function buildBaseRepo() {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'klaussy-e2e-annot-'));
+  const git = (...args) => execFileSync('git', args, { cwd: dir, stdio: 'pipe' });
+  git('init', '-q', '-b', 'main');
+  git('config', 'user.email', 'e2e@klaussy.test');
+  git('config', 'user.name', 'e2e');
+  fs.writeFileSync(path.join(dir, 'sample.js'), 'function a() {\n  return 1;\n}\n');
+  git('add', '.');
+  git('commit', '-q', '-m', 'init');
+  return dir;
+}
+
+test('inline diff annotations: hover → comment → aggregate → send', async ({ mainWindow }) => {
+  await mainWindow.waitForLoadState('networkidle');
+  await expect(mainWindow.locator('#btn-new-task')).toBeVisible();
+
+  const repo = buildBaseRepo();
+  const taskName = `annot-${process.pid}-${Date.now()}`;
+
+  let taskId = null;
+  try {
+    const result = await mainWindow.evaluate(
+      ({ name, repoPath }) => window.klaus.task.create(name, repoPath, 'shell'),
+      { name: taskName, repoPath: repo },
+    );
+    expect(result.error, `create-task error: ${result.error}`).toBeFalsy();
+    taskId = result.id;
+    const worktree = result.worktreePath;
+
+    // Produce a diff with several added lines to comment on.
+    fs.writeFileSync(
+      path.join(worktree, 'sample.js'),
+      'function a() {\n  const x = 1;\n  const y = 2;\n  return x + y;\n}\n',
+    );
+
+    // Open the panel on the worktree and render the file's diff.
+    await mainWindow.evaluate((wt) => window.DiffPanel.show(wt), worktree);
+    await expect(mainWindow.locator('#diff-panel')).toBeVisible();
+    await mainWindow.evaluate(() => window.DiffPanel.refresh());
+    await mainWindow.locator('#diff-file-list .diff-file[data-file="sample.js"]').click();
+
+    const addLines = mainWindow.locator('#diff-view .diff-line.diff-add');
+    await expect(addLines.first()).toBeVisible();
+
+    // --- Step 1: hover a line reveals "+", clicking it opens the editor ---
+    const firstLine = addLines.nth(0);
+    await firstLine.hover();
+    const firstPlus = firstLine.locator('.diff-comment-add');
+    await expect(firstPlus).toBeVisible();
+    await firstPlus.click();
+    await expect(mainWindow.locator('#diff-view .diff-annotation-editor')).toBeVisible();
+    await shot(mainWindow, '1-editor-open.png');
+
+    // --- Step 2: type + save → persistent marker + floating bar shows 1 ---
+    await mainWindow.locator('.diff-annotation-editor .diff-annotation-input').fill('rename x to something clearer');
+    await mainWindow.locator('.diff-annotation-editor .diff-annotation-save').click();
+    await expect(mainWindow.locator('#diff-view .diff-annotation')).toHaveCount(1);
+    await expect(mainWindow.locator('#diff-annotations-bar')).toBeVisible();
+    await expect(mainWindow.locator('#diff-annotations-bar .diff-annotations-count')).toHaveText('1 comment');
+    await shot(mainWindow, '2-one-comment.png');
+
+    // --- Step 3: a second comment on another line → count becomes 2 ---
+    const secondLine = addLines.nth(1);
+    await secondLine.hover();
+    const secondPlus = secondLine.locator('.diff-comment-add');
+    await expect(secondPlus).toBeVisible();
+    await secondPlus.click();
+    await mainWindow.locator('.diff-annotation-editor .diff-annotation-input').fill('is y used anywhere else?');
+    await mainWindow.locator('.diff-annotation-editor .diff-annotation-save').click();
+    await expect(mainWindow.locator('#diff-view .diff-annotation')).toHaveCount(2);
+    await expect(mainWindow.locator('#diff-annotations-bar .diff-annotations-count')).toHaveText('2 comments');
+    await shot(mainWindow, '3-two-comments.png');
+
+    // --- Step 4: Send formats one prompt through the comment callback ---
+    // Swap the callback for a capturing stub and pin an active task so the
+    // send guard passes deterministically.
+    await mainWindow.evaluate((id) => {
+      window.__annotSent = null;
+      window.DiffPanel.setCommentCallback((text) => { window.__annotSent = text; });
+      if (typeof AppState !== 'undefined') AppState.activeTaskId = id;
+    }, taskId);
+
+    await mainWindow.locator('#diff-annotations-bar .diff-annotations-send').click();
+
+    const sent = await mainWindow.evaluate(() => window.__annotSent);
+    expect(sent, 'comment callback received the formatted prompt').toBeTruthy();
+    expect(sent).toContain('Review feedback on the current diff:');
+    expect(sent).toContain('sample.js:');
+    expect(sent).toContain('rename x to something clearer');
+    expect(sent).toContain('is y used anywhere else?');
+    expect(sent).toContain('Please address this feedback.');
+
+    // Sending clears the bar and the inline markers.
+    await expect(mainWindow.locator('#diff-annotations-bar')).toHaveCount(0);
+    await expect(mainWindow.locator('#diff-view .diff-annotation')).toHaveCount(0);
+    await shot(mainWindow, '4-sent-cleared.png');
+  } finally {
+    if (taskId != null) {
+      await mainWindow.evaluate((id) => window.klaus.task.kill(id), taskId).catch(() => {});
+    }
+  }
+});

--- a/renderer/diff-annotations.js
+++ b/renderer/diff-annotations.js
@@ -1,0 +1,57 @@
+// Aggregation + prompt-formatting helpers for inline diff annotations.
+// Deliberately free of DOM/Electron access so it can be unit-tested from Node
+// by stubbing `window`, the same pattern finding-parser.js uses.
+(function () {
+
+  // Re-commenting the same file+side+line edits in place rather than stacking.
+  function keyFor(a) {
+    return a.filePath + '::' + a.side + '::' + a.line;
+  }
+
+  // Returns a new array (callers reassign) so state is never mutated in place.
+  function upsert(list, annotation) {
+    var key = keyFor(annotation);
+    var next = list.filter(function (a) { return keyFor(a) !== key; });
+    next.push(annotation);
+    return next;
+  }
+
+  function removeById(list, id) {
+    return list.filter(function (a) { return a.id !== id; });
+  }
+
+  // Groups by file in insertion order so the agent reads one tidy block
+  // instead of one message per line.
+  function formatPrompt(list) {
+    if (!list || list.length === 0) return '';
+    var groups = [];
+    var indexByFile = {};
+    list.forEach(function (a) {
+      if (!(a.filePath in indexByFile)) {
+        indexByFile[a.filePath] = groups.length;
+        groups.push({ file: a.filePath, items: [] });
+      }
+      groups[indexByFile[a.filePath]].items.push(a);
+    });
+
+    var out = ['Review feedback on the current diff:', ''];
+    groups.forEach(function (group) {
+      out.push(group.file + ':');
+      group.items.forEach(function (a) {
+        var loc = (a.line != null && a.line !== '') ? 'line ' + a.line : 'general';
+        out.push('  - ' + loc + ': ' + String(a.text).trim());
+      });
+      out.push('');
+    });
+    out.push('Please address this feedback.');
+    return out.join('\n');
+  }
+
+  window.DiffAnnotations = {
+    keyFor: keyFor,
+    upsert: upsert,
+    removeById: removeById,
+    formatPrompt: formatPrompt,
+  };
+
+})();

--- a/renderer/diff-panel-filelist.js
+++ b/renderer/diff-panel-filelist.js
@@ -310,34 +310,145 @@
     }
   };
 
-  DP.bindInlineComments = function(file) {
-    DP.diffViewEl.querySelectorAll('.diff-line.diff-add, .diff-line.diff-del, .diff-line.diff-context').forEach(function (lineEl) {
-      lineEl.addEventListener('click', function () {
-        // Don't trigger comment if user is selecting text
-        var sel = window.getSelection();
-        if (sel && !sel.isCollapsed) return;
-        if (!DP.commentCallback) return;
-        // Remove any existing inline comment
-        var existing = DP.diffViewEl.querySelector('.inline-comment');
-        if (existing) existing.remove();
+  // Prefer the new-side number (what the user reads on the right); deleted
+  // lines only carry the old one.
+  function annotationLineIdentity(lineEl) {
+    var side = lineEl.dataset.side || (lineEl.classList.contains('diff-del') ? 'LEFT' : 'RIGHT');
+    var raw = side === 'LEFT' ? lineEl.dataset.oldLn : (lineEl.dataset.newLn || lineEl.dataset.oldLn);
+    return { side: side, line: (raw != null && raw !== '') ? parseInt(raw, 10) : null };
+  }
 
-        var wrap = document.createElement('div');
-        wrap.className = 'inline-comment';
-        wrap.innerHTML = '<input type="text" placeholder="Comment for the agent..." class="inline-comment-input" />';
-        lineEl.after(wrap);
+  function cssId(id) {
+    return (window.CSS && CSS.escape) ? CSS.escape(id) : id;
+  }
 
-        var inp = wrap.querySelector('input');
-        inp.focus();
-        inp.addEventListener('keydown', function (e) {
-          if (e.key === 'Enter') {
-            var text = inp.value.trim();
-            if (text && DP.commentCallback) DP.commentCallback('Regarding ' + file + ': ' + text);
-            wrap.remove();
-          }
-          if (e.key === 'Escape') wrap.remove();
-        });
-      });
+  // Returns null if the line isn't on screen (e.g. a collapsed hunk) — the
+  // annotation stays in state regardless.
+  function findAnnotationLineEl(side, line) {
+    if (side === 'LEFT') {
+      return DP.diffViewEl.querySelector('.diff-line.diff-del[data-old-ln="' + line + '"]');
+    }
+    return DP.diffViewEl.querySelector('.diff-line[data-side="RIGHT"][data-new-ln="' + line + '"]');
+  }
+
+  // A full-width insert must land on a split-view row boundary: anchor after
+  // the paired right cell, since inserting between the pair would bump it to
+  // the next row and shift the whole grid.
+  function annotationAnchor(lineEl) {
+    if (lineEl.classList.contains('diff-split-left')) {
+      var right = lineEl.nextElementSibling;
+      if (right && right.classList.contains('diff-split-right')) return right;
+    }
+    return lineEl;
+  }
+
+  // Persistent chip under a commented line; clicking the text re-opens the editor.
+  DP.renderAnnotationMarker = function(lineEl, file, annotation) {
+    var prev = DP.diffViewEl.querySelector('.diff-annotation[data-annotation-id="' + cssId(annotation.id) + '"]');
+    if (prev) prev.remove();
+
+    var marker = document.createElement('div');
+    marker.className = 'diff-annotation';
+    marker.dataset.annotationId = annotation.id;
+
+    var text = document.createElement('span');
+    text.className = 'diff-annotation-text';
+    text.textContent = annotation.text;
+    text.title = 'Edit comment';
+    text.addEventListener('click', function () {
+      openAnnotationEditor(lineEl, file, { side: annotation.side, line: annotation.line }, annotation);
     });
+
+    var remove = document.createElement('button');
+    remove.type = 'button';
+    remove.className = 'diff-annotation-remove';
+    remove.textContent = '×';
+    remove.title = 'Remove comment';
+    remove.addEventListener('click', function () { DP.removeAnnotation(annotation.id); });
+
+    marker.appendChild(text);
+    marker.appendChild(remove);
+    annotationAnchor(lineEl).after(marker);
+  };
+
+  // Non-blocking: several editors can be open at once across lines and files.
+  function openAnnotationEditor(lineEl, file, identity, existing) {
+    var anchor = annotationAnchor(lineEl);
+    var sibling = anchor.nextElementSibling;
+    if (sibling && sibling.classList.contains('diff-annotation-editor')) {
+      sibling.querySelector('textarea').focus();
+      return;
+    }
+    // Editing: hide the marker while its editor is open, restore on cancel.
+    var marker = existing
+      ? DP.diffViewEl.querySelector('.diff-annotation[data-annotation-id="' + cssId(existing.id) + '"]')
+      : null;
+    if (marker) marker.remove();
+
+    var wrap = document.createElement('div');
+    wrap.className = 'diff-annotation-editor';
+    wrap.innerHTML =
+      '<textarea class="diff-annotation-input" rows="2" placeholder="Comment for the agent…"></textarea>' +
+      '<div class="diff-annotation-actions">' +
+        '<button type="button" class="diff-annotation-cancel">Cancel</button>' +
+        '<button type="button" class="diff-annotation-save">Save</button>' +
+      '</div>';
+    anchor.after(wrap);
+
+    var ta = wrap.querySelector('textarea');
+    ta.value = existing ? existing.text : '';
+    ta.focus();
+
+    function restore() { if (existing) DP.renderAnnotationMarker(lineEl, file, existing); }
+    function cancel() { wrap.remove(); restore(); }
+    function save() {
+      var text = ta.value.trim();
+      if (!text) { cancel(); return; }
+      var annotation = DP.addAnnotation({ filePath: file, side: identity.side, line: identity.line, text: text });
+      wrap.remove();
+      DP.renderAnnotationMarker(lineEl, file, annotation);
+    }
+
+    wrap.querySelector('.diff-annotation-save').addEventListener('click', save);
+    wrap.querySelector('.diff-annotation-cancel').addEventListener('click', cancel);
+    ta.addEventListener('keydown', function (e) {
+      // Plain Enter stays a newline so multi-line comments are possible.
+      if ((e.metaKey || e.ctrlKey) && e.key === 'Enter') { e.preventDefault(); save(); }
+      else if (e.key === 'Escape') { e.preventDefault(); cancel(); }
+    });
+  }
+
+  // Re-attach markers so comments survive a file switch or unified/split re-render.
+  DP.renderFileAnnotations = function(file) {
+    DP.activeAnnotations
+      .filter(function (a) { return a.filePath === file; })
+      .forEach(function (a) {
+        var lineEl = findAnnotationLineEl(a.side, a.line);
+        if (lineEl) DP.renderAnnotationMarker(lineEl, file, a);
+      });
+  };
+
+  DP.bindInlineComments = function(file) {
+    // Only offer the "+" when there's somewhere to send comments; without a
+    // callback the affordance would click to nothing.
+    if (DP.commentCallback) {
+      DP.diffViewEl.querySelectorAll('.diff-line.diff-add, .diff-line.diff-del, .diff-line.diff-context').forEach(function (lineEl) {
+        // Split view shows context lines in both panes; skip the left copy, which
+        // lacks data-side — the right pane's copy has the correct identity.
+        if (lineEl.classList.contains('diff-split-left') && lineEl.classList.contains('diff-context')) return;
+        var addBtn = document.createElement('button');
+        addBtn.type = 'button';
+        addBtn.className = 'diff-comment-add';
+        addBtn.textContent = '+';
+        addBtn.title = 'Add a comment on this line';
+        addBtn.addEventListener('click', function (e) {
+          e.stopPropagation();
+          openAnnotationEditor(lineEl, file, annotationLineIdentity(lineEl), null);
+        });
+        lineEl.appendChild(addBtn);
+      });
+    }
+    DP.renderFileAnnotations(file);
   };
 
   DP.bindExplainButtons = function(file) {
@@ -471,7 +582,7 @@
     // Checkbox selection
     DP.diffViewEl.querySelectorAll('.diff-stage-check').forEach(function (cb) {
       cb.addEventListener('click', function (e) {
-        e.stopPropagation(); // don't trigger bindInlineComments click-to-comment
+        e.stopPropagation();
       });
       cb.addEventListener('change', function () {
         var key = cb.dataset.lineKey;

--- a/renderer/diff-panel.js
+++ b/renderer/diff-panel.js
@@ -18,6 +18,9 @@ window.DiffPanel = window.DiffPanel || {};
   DP.currentRawDiff = '';
   DP.currentDiffStaged = false;
   DP.selectedLineKeys = new Set();
+  // Pending annotations, each { id, filePath, side, line, text }. Persists
+  // across file switches so comments can span files before one batched send.
+  DP.activeAnnotations = [];
   DP.refreshPaused = false;
   DP.diffViewMode = (typeof localStorage !== 'undefined' && localStorage.getItem('diffViewMode')) || 'unified';
 
@@ -877,6 +880,76 @@ window.DiffPanel = window.DiffPanel || {};
     if (s.startsWith('D')) return 'deleted';
     if (s.startsWith('R')) return 'renamed';
     return '';
+  };
+
+  // ---- Inline diff annotations ----
+  // Pure aggregation/formatting lives in window.DiffAnnotations; this half owns
+  // the state + floating bar, and sends one batched prompt to the active agent.
+
+  DP.addAnnotation = function(annotation) {
+    annotation.id = window.DiffAnnotations.keyFor(annotation);
+    DP.activeAnnotations = window.DiffAnnotations.upsert(DP.activeAnnotations, annotation);
+    DP.renderAnnotationsBar();
+    return annotation;
+  };
+
+  DP.removeAnnotation = function(id) {
+    DP.activeAnnotations = window.DiffAnnotations.removeById(DP.activeAnnotations, id);
+    var marker = DP.diffViewEl && DP.diffViewEl.querySelector('.diff-annotation[data-annotation-id="' + (window.CSS && CSS.escape ? CSS.escape(id) : id) + '"]');
+    if (marker) marker.remove();
+    DP.renderAnnotationsBar();
+  };
+
+  DP.clearAnnotations = function() {
+    DP.activeAnnotations = [];
+    if (DP.diffViewEl) {
+      DP.diffViewEl.querySelectorAll('.diff-annotation').forEach(function (el) { el.remove(); });
+    }
+    DP.renderAnnotationsBar();
+  };
+
+  // The bar lives on the panel, not the per-file diff view, so the count
+  // survives file switches.
+  DP.renderAnnotationsBar = function() {
+    if (!DP.panelEl) return;
+    var bar = document.getElementById('diff-annotations-bar');
+    var count = DP.activeAnnotations.length;
+    if (count === 0) {
+      if (bar) bar.remove();
+      return;
+    }
+    if (!bar) {
+      bar = document.createElement('div');
+      bar.id = 'diff-annotations-bar';
+      bar.innerHTML =
+        '<span class="diff-annotations-count"></span>' +
+        '<button type="button" class="diff-annotations-clear">Clear</button>' +
+        '<button type="button" class="diff-annotations-send">Send to Agent</button>';
+      bar.querySelector('.diff-annotations-clear').addEventListener('click', DP.clearAnnotations);
+      bar.querySelector('.diff-annotations-send').addEventListener('click', DP.sendAnnotations);
+      DP.panelEl.appendChild(bar);
+    }
+    bar.querySelector('.diff-annotations-count').textContent =
+      count + ' comment' + (count === 1 ? '' : 's');
+  };
+
+  // Injects one formatted prompt via the comment callback — the same seam the
+  // Cmd+Shift+E "send selection" keybind uses — then clears.
+  DP.sendAnnotations = function() {
+    if (DP.activeAnnotations.length === 0) return;
+    if (typeof AppState !== 'undefined' && !AppState.activeTaskId) {
+      window.toast.warn('No active agent terminal — open a task to send comments to');
+      return;
+    }
+    if (!DP.commentCallback) {
+      window.toast.warn('No agent connection available for comments');
+      return;
+    }
+    var prompt = window.DiffAnnotations.formatPrompt(DP.activeAnnotations);
+    DP.commentCallback(prompt);
+    var count = DP.activeAnnotations.length;
+    DP.clearAnnotations();
+    window.toast.success('Sent ' + count + ' comment' + (count === 1 ? '' : 's') + ' to the agent');
   };
 
 })(window.DiffPanel);

--- a/renderer/index.html
+++ b/renderer/index.html
@@ -732,6 +732,7 @@
   <script src="events.js"></script>
   <script src="theme.js"></script>
   <script src="finding-parser.js"></script>
+  <script src="diff-annotations.js"></script>
   <script src="diff-panel.js"></script>
   <script src="diff-panel-filelist.js"></script>
   <script src="diff-panel-diff.js"></script>

--- a/renderer/styles/02-toolbar-diff.css
+++ b/renderer/styles/02-toolbar-diff.css
@@ -1083,7 +1083,8 @@
 
 .diff-split-grid > .diff-split-hunk-header,
 .diff-split-grid > .diff-split-meta,
-.diff-split-grid > .inline-comment,
+.diff-split-grid > .diff-annotation,
+.diff-split-grid > .diff-annotation-editor,
 .diff-split-grid > .diff-explanation {
   grid-column: 1 / -1;
 }
@@ -1313,14 +1314,58 @@
   color: #fff;
 }
 
-/* Inline commenting (Phase 6) */
-.inline-comment {
-  padding: 4px 12px;
-  background: var(--surface);
-  border-left: 2px solid var(--accent);
+/* Inline diff annotations */
+/* Anchor for the hover "+" button on each commentable line. */
+.diff-line.diff-add,
+.diff-line.diff-del,
+.diff-line.diff-context {
+  position: relative;
 }
 
-.inline-comment-input {
+.diff-comment-add {
+  position: absolute;
+  right: 6px;
+  top: 50%;
+  transform: translateY(-50%);
+  display: none;
+  align-items: center;
+  justify-content: center;
+  width: 16px;
+  height: 16px;
+  padding: 0;
+  font-size: 13px;
+  line-height: 1;
+  white-space: normal;
+  color: #fff;
+  background: var(--accent);
+  border: none;
+  border-radius: 4px;
+  cursor: pointer;
+  opacity: 0.9;
+  z-index: 2;
+}
+
+.diff-line.diff-add:hover .diff-comment-add,
+.diff-line.diff-del:hover .diff-comment-add,
+.diff-line.diff-context:hover .diff-comment-add {
+  display: flex;
+}
+
+.diff-comment-add:hover {
+  opacity: 1;
+}
+
+.diff-annotation-editor {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  padding: 6px 12px;
+  background: var(--surface);
+  border-left: 2px solid var(--accent);
+  white-space: normal;
+}
+
+.diff-annotation-input {
   width: 100%;
   padding: 4px 8px;
   background: var(--input-bg);
@@ -1329,11 +1374,112 @@
   color: var(--text);
   font-size: 12px;
   font-family: inherit;
+  resize: vertical;
   outline: none;
 }
 
-.inline-comment-input:focus {
+.diff-annotation-input:focus {
   border-color: var(--accent);
+}
+
+.diff-annotation-actions {
+  display: flex;
+  gap: 6px;
+  justify-content: flex-end;
+}
+
+.diff-annotation-actions button {
+  padding: 3px 10px;
+  font-size: 11px;
+  border-radius: 4px;
+  border: 1px solid var(--border);
+  cursor: pointer;
+}
+
+.diff-annotation-save {
+  background: var(--accent);
+  color: #fff;
+  border-color: var(--accent);
+}
+
+.diff-annotation-cancel {
+  background: transparent;
+  color: var(--text-dim);
+}
+
+.diff-annotation {
+  display: flex;
+  align-items: flex-start;
+  gap: 8px;
+  padding: 4px 12px;
+  background: var(--surface);
+  border-left: 2px solid var(--accent);
+  white-space: normal;
+}
+
+.diff-annotation-text {
+  flex: 1;
+  font-size: 12px;
+  color: var(--text);
+  cursor: text;
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+
+.diff-annotation-remove {
+  flex-shrink: 0;
+  padding: 0 2px;
+  background: transparent;
+  border: none;
+  color: var(--text-dim);
+  font-size: 14px;
+  line-height: 1;
+  cursor: pointer;
+}
+
+.diff-annotation-remove:hover {
+  color: var(--danger, #e5534b);
+}
+
+/* Floating batch-send bar, anchored to the diff panel so its count survives
+   file switches. */
+#diff-annotations-bar {
+  position: absolute;
+  right: 16px;
+  bottom: 16px;
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 8px 12px;
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.3);
+  z-index: 20;
+}
+
+.diff-annotations-count {
+  font-size: 12px;
+  color: var(--text);
+}
+
+#diff-annotations-bar button {
+  padding: 4px 10px;
+  font-size: 12px;
+  border-radius: 6px;
+  cursor: pointer;
+}
+
+.diff-annotations-clear {
+  background: transparent;
+  color: var(--text-dim);
+  border: 1px solid var(--border);
+}
+
+.diff-annotations-send {
+  background: var(--accent);
+  color: #fff;
+  border: 1px solid var(--accent);
 }
 
 /* Commit area & footer */

--- a/renderer/terminal-manager.js
+++ b/renderer/terminal-manager.js
@@ -35,6 +35,7 @@ window.TerminalManager = (function () {
 
   function addTaskToUI(task) {
     var id = task.id;
+    if (tasks.has(id)) { switchToTask(id); return; }
     var name = task.name;
     var worktreePath = task.worktreePath;
     var branch = task.branch;

--- a/test/util/diff-annotations.test.js
+++ b/test/util/diff-annotations.test.js
@@ -1,0 +1,87 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+// diff-annotations.js is a renderer IIFE assigning to window.DiffAnnotations and
+// touches no Electron/DOM API, so we stub `window` and require it (same approach
+// as finding-parser.test.js).
+global.window = global.window || {};
+require('../../renderer/diff-annotations');
+const DA = global.window.DiffAnnotations;
+
+test('upsert adds a new annotation and replaces one on the same line', () => {
+  let list = [];
+  list = DA.upsert(list, { filePath: 'a.js', side: 'RIGHT', line: 10, text: 'first' });
+  assert.equal(list.length, 1);
+
+  // Same file/side/line → edit in place, no duplicate.
+  list = DA.upsert(list, { filePath: 'a.js', side: 'RIGHT', line: 10, text: 'edited' });
+  assert.equal(list.length, 1);
+  assert.equal(list[0].text, 'edited');
+
+  // Different line → new entry.
+  list = DA.upsert(list, { filePath: 'a.js', side: 'RIGHT', line: 11, text: 'second' });
+  assert.equal(list.length, 2);
+});
+
+test('upsert distinguishes sides on the same line number', () => {
+  let list = [];
+  list = DA.upsert(list, { filePath: 'a.js', side: 'LEFT', line: 5, text: 'old side' });
+  list = DA.upsert(list, { filePath: 'a.js', side: 'RIGHT', line: 5, text: 'new side' });
+  assert.equal(list.length, 2);
+});
+
+test('upsert does not mutate the input array', () => {
+  const original = [];
+  const next = DA.upsert(original, { filePath: 'a.js', side: 'RIGHT', line: 1, text: 'x' });
+  assert.equal(original.length, 0);
+  assert.equal(next.length, 1);
+});
+
+test('removeById drops the matching annotation only', () => {
+  let list = [];
+  list = DA.upsert(list, { filePath: 'a.js', side: 'RIGHT', line: 1, text: 'x' });
+  list = DA.upsert(list, { filePath: 'a.js', side: 'RIGHT', line: 2, text: 'y' });
+  list = list.map((a) => ({ ...a, id: DA.keyFor(a) }));
+
+  const target = DA.keyFor({ filePath: 'a.js', side: 'RIGHT', line: 1 });
+  const after = DA.removeById(list, target);
+  assert.equal(after.length, 1);
+  assert.equal(after[0].text, 'y');
+});
+
+test('formatPrompt returns empty string for no annotations', () => {
+  assert.equal(DA.formatPrompt([]), '');
+  assert.equal(DA.formatPrompt(null), '');
+});
+
+test('formatPrompt groups comments by file in insertion order', () => {
+  const list = [
+    { filePath: 'a.js', side: 'RIGHT', line: 10, text: 'rename this' },
+    { filePath: 'b.js', side: 'RIGHT', line: 3, text: 'extract a helper' },
+    { filePath: 'a.js', side: 'LEFT', line: 4, text: 'why remove?' },
+  ];
+  const out = DA.formatPrompt(list);
+
+  assert.match(out, /^Review feedback on the current diff:/);
+  assert.match(out, /a\.js:/);
+  assert.match(out, /- line 10: rename this/);
+  assert.match(out, /- line 4: why remove\?/);
+  assert.match(out, /b\.js:/);
+  assert.match(out, /- line 3: extract a helper/);
+  assert.match(out, /Please address this feedback\.$/);
+
+  // Both a.js comments sit under a single a.js heading (grouped, not repeated).
+  assert.equal(out.match(/a\.js:/g).length, 1);
+  // a.js is emitted before b.js (insertion order).
+  assert.ok(out.indexOf('a.js:') < out.indexOf('b.js:'));
+});
+
+test('formatPrompt labels a missing line number as general', () => {
+  const out = DA.formatPrompt([{ filePath: 'a.js', side: 'RIGHT', line: null, text: 'overall note' }]);
+  assert.match(out, /- general: overall note/);
+});
+
+test('formatPrompt trims whitespace around comment text', () => {
+  const out = DA.formatPrompt([{ filePath: 'a.js', side: 'RIGHT', line: 1, text: '  spaced  ' }]);
+  assert.match(out, /- line 1: spaced\n/);
+});


### PR DESCRIPTION
## Summary

The diff panel already let you drop a one-off comment on a line and fire it straight at the agent. That works for a single note, but not for reading a whole diff and leaving five remarks you want to send together. This turns that one-shot control into a review pass: comment on as many lines as you want, across files, then send them all at once as a single prompt.

Hover a line, click the "+", and a small editor opens right under it. It's non-blocking, so you keep reading. Each saved comment leaves a marker on its line and bumps a floating counter. When you're done, "Send to Agent" formats everything into one structured prompt and drops it into the active agent's terminal.

## Changes

- `renderer/diff-annotations.js` (new): the pure part. Keying, upsert/remove, and the prompt formatter. No DOM, so it's unit-tested directly.
- `renderer/diff-panel.js`: the `activeAnnotations` state, plus the floating bar (count, Clear, Send) and the send path.
- `renderer/diff-panel-filelist.js`: the per-line hover "+", the inline editor, persistent markers, and re-attaching markers when you switch files or flip unified/split.
- `renderer/styles/02-toolbar-diff.css`: styling for all of the above, replacing the old single-comment styles.
- `e2e/ui-diff-annotations.spec.js` (new) and `test/util/diff-annotations.test.js` (new): coverage.

Sending reuses the existing comment callback, the same seam `Cmd+Shift+E` (send selection) already uses, so nothing new was added to the terminal layer.

For reviewers: the diff panel is a hand-rolled HTML renderer, not Monaco, so the hover and editor hooks hang off the rendered `.diff-line` elements rather than editor view zones.

## Test Plan

- `npm run lint`: clean
- `npm test`: 160 pass, 8 of them new for the formatter
- `npm run test:e2e -- e2e/ui-diff-annotations.spec.js`: drives hover to comment to a second comment to send against the real app, asserting the formatted prompt lands and the bar clears
- Screenshots of each step captured during the e2e run (editor open, one comment, two comments, sent and cleared)

Split view needed two fixes on the way: full-width comment cards were shifting the grid when attached to a left-column line, and left-pane context lines were picking up the wrong line number. Both are fixed and covered.