### PR TITLE
fix(tabs): keep the agent name on a tab after its CLI exits

### DIFF
--- a/e2e/tab-agent-label.spec.js
+++ b/e2e/tab-agent-label.spec.js
@@ -1,0 +1,96 @@
+// Primary-tab agent labels. When an agent CLI exits, the main process swaps
+// the pty for a login shell and sets mode='shell'; the tab used to follow that
+// and relabel itself "Shell", losing the task's identity. These drive the real
+// render path (TerminalManager.refreshAgentChip, the same entry point app.js
+// calls on conversion) against a hand-built tab DOM, so no pty is spawned.
+
+/* global window, document */
+const { test, expect } = require('./fixtures');
+
+// Pin the model lookup in the main process. Stubbing window.klaus from the page
+// is silently ignored — contextBridge objects are frozen — and the real handler
+// falls back to the machine's configured CLI default, which isn't stable here.
+const MODELS = { claude: 'opus', codex: 'gpt-5', gemini: 'gemini-2.5-pro' };
+
+async function stubModelIpc(electronApp, models) {
+  await electronApp.evaluate(({ ipcMain }, byMode) => {
+    ipcMain.removeHandler('agent-current-model');
+    ipcMain.handle('agent-current-model', (_e, { mode }) => ({ model: byMode[mode] || null }));
+  }, models);
+}
+
+// The DOM here is the minimal shape updatePrimaryAgentTab queries: a sub-tab 0
+// button wrapping a .sub-tab-label span.
+async function seedTask(mainWindow, { id, mode }) {
+  await mainWindow.evaluate((t) => {
+    const container = document.createElement('div');
+    container.id = 'tab-probe-' + t.id;
+    container.innerHTML =
+      '<button class="sub-tab" data-sub-id="0"><span class="sub-tab-label"></span></button>';
+    document.body.appendChild(container);
+    window.AppState.tasks.set(t.id, {
+      id: t.id, mode: t.mode, worktreePath: '/tmp/tab-probe',
+      container, subTerminals: [],
+    });
+    window.TerminalManager.refreshAgentChip(t.id);
+  }, { id, mode });
+  return mainWindow.locator('#tab-probe-' + id + ' .sub-tab-label');
+}
+
+// The mutation app.js performs on 'task-converted-to-shell' (renderer/app.js):
+// remember the agent that exited, then flip mode to shell.
+async function convertToShell(mainWindow, id) {
+  await mainWindow.evaluate((taskId) => {
+    const t = window.AppState.tasks.get(taskId);
+    if (t.mode && t.mode !== 'shell') t.resumeAgent = t.mode;
+    t.mode = 'shell';
+    window.TerminalManager.refreshAgentChip(taskId);
+  }, id);
+}
+
+test.beforeEach(async ({ electronApp, mainWindow }) => {
+  await mainWindow.waitForLoadState('networkidle');
+  await stubModelIpc(electronApp, MODELS);
+});
+
+test('a live agent tab shows the agent and its model', async ({ mainWindow }) => {
+  const label = await seedTask(mainWindow, { id: 9001, mode: 'claude' });
+  await expect(label).toHaveText('Claude Opus');
+});
+
+test('an exited agent keeps its label instead of becoming "Shell"', async ({ mainWindow }) => {
+  const label = await seedTask(mainWindow, { id: 9002, mode: 'claude' });
+  await expect(label).toHaveText('Claude Opus');
+
+  await convertToShell(mainWindow, 9002);
+
+  // The regression: this read "Shell" once the pty converted.
+  await expect(label).toHaveText('Claude Opus');
+});
+
+test('an exited non-Claude agent keeps its own label', async ({ mainWindow }) => {
+  const label = await seedTask(mainWindow, { id: 9003, mode: 'codex' });
+  await convertToShell(mainWindow, 9003);
+  await expect(label).toHaveText('GPT-5');
+});
+
+test('a task started as a shell still reads "Shell"', async ({ mainWindow }) => {
+  // Guards the over-fix: labelling every converted tab with an agent would put
+  // an agent name on a shell the user opened deliberately.
+  const label = await seedTask(mainWindow, { id: 9004, mode: 'shell' });
+  await expect(label).toHaveText('Shell');
+});
+
+test('Resume relabels from the live mode, not the agent that exited', async ({ mainWindow }) => {
+  const label = await seedTask(mainWindow, { id: 9005, mode: 'claude' });
+  await convertToShell(mainWindow, 9005);
+  await expect(label).toHaveText('Claude Opus');
+
+  // Resume sets mode back to an agent but leaves resumeAgent set, so a stale
+  // resumeAgent must not outrank a live mode.
+  await mainWindow.evaluate(() => {
+    window.AppState.tasks.get(9005).mode = 'gemini';
+    window.TerminalManager.refreshAgentChip(9005);
+  });
+  await expect(label).toHaveText('Gemini 2.5 Pro');
+});

--- a/renderer/terminal-manager.js
+++ b/renderer/terminal-manager.js
@@ -497,10 +497,12 @@ window.TerminalManager = (function () {
   }
 
   // The primary tab tracks the task's own mode (it can change: agent exits to
-  // shell, sidebar Resume relaunches an agent).
+  // shell, sidebar Resume relaunches an agent). An agent whose CLI has exited
+  // keeps its name here so the tab stays the task's identity.
   function updatePrimaryAgentTab(taskEntry) {
     var span = taskEntry.container.querySelector('.sub-tab[data-sub-id="0"] .sub-tab-label');
-    applyAgentLabel(span, taskEntry.mode, taskEntry.worktreePath, taskEntry.id);
+    var mode = AppUtils.exitedAgent(taskEntry) || taskEntry.mode;
+    applyAgentLabel(span, mode, taskEntry.worktreePath, taskEntry.id);
   }
 
   // Re-resolve tab labels on tab switches: immediately while unresolved (the
@@ -513,9 +515,8 @@ window.TerminalManager = (function () {
       return Date.now() - Number(span.dataset.modelCheckedAt || 0) > MODEL_RECHECK_MS;
     };
     var primary = taskEntry.container.querySelector('.sub-tab[data-sub-id="0"] .sub-tab-label');
-    if (due(primary)) {
-      applyAgentLabel(primary, taskEntry.mode, taskEntry.worktreePath, taskEntry.id);
-    }
+    // Not applyAgentLabel directly: that would relabel an exited agent "Shell".
+    if (due(primary)) updatePrimaryAgentTab(taskEntry);
     taskEntry.subTerminals.forEach(function (s) {
       var span = s.tab && s.tab.querySelector('.sub-tab-label');
       if (span && span.dataset.agentTab && due(span)) {

--- a/renderer/utils.js
+++ b/renderer/utils.js
@@ -54,6 +54,14 @@ window.AppUtils = (function () {
     return p ? p.displayName : (mode || 'Agent');
   }
 
+  // No default-provider fallback here, unlike the sidebar's Resume target: that
+  // would label a deliberately-opened shell with an agent that never ran.
+  function exitedAgent(task) {
+    if (!task || task.mode !== 'shell') return null;
+    var prior = task.resumeAgent;
+    return (prior && prior !== 'shell') ? prior : null;
+  }
+
   return {
     escHtml: escHtml,
     escAttr: escAttr,
@@ -61,5 +69,6 @@ window.AppUtils = (function () {
     iconColor: iconColor,
     modeShortLabel: modeShortLabel,
     modeDisplayName: modeDisplayName,
+    exitedAgent: exitedAgent,
   };
 })();

--- a/test/util/app-utils.test.js
+++ b/test/util/app-utils.test.js
@@ -1,0 +1,36 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+// utils.js reads the preload bridge only inside functions, so a stub `window`
+// is enough to load it (same approach as finding-parser.test.js).
+global.window = global.window || {};
+require('../../renderer/utils');
+const AppUtils = global.window.AppUtils;
+
+// Regression: when an agent CLI exits, the main process converts the pty in
+// place and sets mode='shell', which relabelled the tab "Shell" and lost the
+// task's identity.
+
+test('exitedAgent: recovers the agent that exited', () => {
+  assert.equal(AppUtils.exitedAgent({ mode: 'shell', resumeAgent: 'claude' }), 'claude');
+  assert.equal(AppUtils.exitedAgent({ mode: 'shell', resumeAgent: 'codex' }), 'codex');
+});
+
+test('exitedAgent: a task started as a shell stays a shell', () => {
+  assert.equal(AppUtils.exitedAgent({ mode: 'shell' }), null);
+  assert.equal(AppUtils.exitedAgent({ mode: 'shell', resumeAgent: null }), null);
+  // 'shell' is never a meaningful resume target, so it must not label the tab.
+  assert.equal(AppUtils.exitedAgent({ mode: 'shell', resumeAgent: 'shell' }), null);
+});
+
+test('exitedAgent: a live agent is not exited', () => {
+  assert.equal(AppUtils.exitedAgent({ mode: 'claude' }), null);
+  // Resume relaunches the agent but leaves resumeAgent set, so a live mode has
+  // to win over it.
+  assert.equal(AppUtils.exitedAgent({ mode: 'claude', resumeAgent: 'claude' }), null);
+});
+
+test('exitedAgent: tolerates a missing task', () => {
+  assert.equal(AppUtils.exitedAgent(null), null);
+  assert.equal(AppUtils.exitedAgent(undefined), null);
+});


### PR DESCRIPTION
## Summary

An agent tab was relabelling itself **"Shell"** whenever the agent's CLI exited, losing which agent had been running the task — even though the conversation is still on screen and Resume relaunches that same agent.

When an agent CLI exits, the main process converts the pty to a login shell in place and sets `mode='shell'`. The primary tab followed that mode and dropped to "Shell". This derives the label from the agent that exited instead.

This is the symptom fix. The *why does the CLI exit* question turned up two separate restart-path bugs (`tasks.js:1237` early `restarting` clear, `tasks.js:1245` unguarded restart `onExit`) and a missing exit-code diagnostic — those are out of scope here and will be a follow-up PR.

## Changes

- **`renderer/utils.js`** — new `AppUtils.exitedAgent(task)` predicate: the agent a task ran before its pty became a shell, recovered from `resumeAgent` (which `app.js` already captures on conversion). Deliberately does *not* fall back to the default provider, unlike the sidebar's Resume target — that would label a deliberately-opened shell with an agent that never ran.
- **`renderer/terminal-manager.js`** — `updatePrimaryAgentTab` labels from `exitedAgent(task) || task.mode`, and the 30s label sweep routes through it so it can't reset to "Shell" on a timer.

Deliberately **no "(exited)" marker**: the converted pty is a live, typable shell, so the tab shouldn't imply the session is gone.

Behaviour:
- Live agent → agent name + model (unchanged).
- Agent exits → tab keeps the agent name (was: "Shell").
- Task started as a shell → still "Shell" (no `resumeAgent`).
- Resumed tab (mode is an agent again) → live mode wins, so a stale `resumeAgent` can't outrank it.

## Test Plan

- `test/util/app-utils.test.js` — unit tests for the predicate (live, exited, shell-origin, resumed, missing-task).
- `e2e/tab-agent-label.spec.js` — drives the real render path (`TerminalManager.refreshAgentChip`, the entry point `app.js` calls on conversion) against a rendered tab; no pty spawned, so it runs locally despite the known worktree/pty e2e flakiness.
- **Confirmed the e2e tests fail without the fix**: reverting `updatePrimaryAgentTab` to the old one-liner fails the 3 regression tests while the 2 controls (live agent, real shell) stay green.
- `npm test` (156 passing) and `npm run lint` clean.

## Checklist

- [x] Tests added and passing
- [x] Lint clean
- [x] Scoped to the tab-label symptom; restart-race causes tracked separately
- [ ] Manual check in the running app (label renders "Claude Opus" after a real exit) — not yet done

🤖 Generated with [Claude Code](https://claude.com/claude-code)
