### PR TITLE
fix(tasks): stop restart from racing an agent pty into a shell

### DIFF
--- a/main/ipc/tasks.js
+++ b/main/ipc/tasks.js
@@ -17,7 +17,7 @@ const { defaultShell, shellLoginArgs, shellRunCmdArgs } = require('../util/platf
 const {
   instances, spawnInWorktree, findLatestSessionId, snapshotSessionIds,
   processIdleDetection, clearIdleTimer, convertInstanceToShell,
-  sendToTerminalSubscribers,
+  sendToTerminalSubscribers, makeAgentExitHandler,
 } = require('../state/instances');
 const { stopCIPolling } = require('../state/ci-poll');
 const { getMainWindow, hardenWindow } = require('../state/windows');
@@ -1166,9 +1166,8 @@ ipcMain.handle('restart-task', (_event, { id, cols, rows }) => {
   const inst = instances.get(id);
   if (!inst) return { error: 'Instance not found' };
 
-  // Mark restarting BEFORE kill(): pty.kill is async and the stale exit handler
-  // would otherwise race with the new-pty assignment below — in particular if
-  // the instance was still in claude mode, the old-pty's onExit would spawn a
+  // Set BEFORE kill(): kill is async, so the old pty can exit before inst.pty is
+  // reassigned below; the identity check in makeAgentExitHandler covers after that.
   inst.restarting = true;
   try { inst.pty.kill(); } catch {}
 
@@ -1241,17 +1240,7 @@ ipcMain.handle('restart-task', (_event, { id, cols, rows }) => {
     sendToTerminalSubscribers(`terminal-data-${id}`, data);
   });
 
-  // When this agent exits, auto-convert to shell again
-  ptyProc.onExit(() => {
-    clearIdleTimer(inst);
-    session.release(); // free the concurrency slot (Codex token-rotation guard)
-    if (isAgentMode(inst.mode)) {
-      convertInstanceToShell(inst);
-    } else {
-      inst.alive = false;
-      sendToTerminalSubscribers(`terminal-exit-${id}`);
-    }
-  });
+  ptyProc.onExit(makeAgentExitHandler(inst, ptyProc, { session }));
 
   return { ok: true };
 });

--- a/main/state/instances.js
+++ b/main/state/instances.js
@@ -23,6 +23,7 @@ const { getProvider, isAgentMode, binFor, displayNameFor } = require('./ai-provi
 const { ensureWorktreeConsentSync } = require('../util/agent-consent');
 const { beginSession } = require('../util/agent-concurrency');
 const { stageInitialPrompt } = require('../util/agent-prompt');
+const { agentExitAction } = require('../util/agent-exit');
 
 const instances = new Map(); // id -> { name, worktreePath, pty, branch }
 let nextId = 1;
@@ -432,23 +433,7 @@ function spawnInWorktree(name, worktreePath, branch, mode, resumeSessionId, extr
     sendToTerminalSubscribers(`terminal-data-${id}`, data);
   });
 
-  ptyProc.onExit(({ exitCode }) => {
-    clearIdleTimer(instance);
-    session.release(); // free the concurrency slot (Codex token-rotation guard)
-    if (promptFile) { try { fs.unlinkSync(promptFile); } catch { /* already gone */ } }
-    // If this was a Claude session, auto-convert to shell in-place — but
-    // only for natural exits. An explicit kill-task sets `killed`, and
-    // restart-task sets `restarting`; neither should spawn a shell we'd
-    // lose track of (kill-task already deleted the instances entry; the
-    // orphan shell would have no Map entry and nothing could kill it).
-    if (isAgentMode(instance.mode) && !_isQuitting()
-        && !instance.killed && !instance.restarting) {
-      convertInstanceToShell(instance);
-      return;
-    }
-    instance.alive = false;
-    sendToTerminalSubscribers(`terminal-exit-${id}`, exitCode);
-  });
+  ptyProc.onExit(makeAgentExitHandler(instance, ptyProc, { session, promptFile }));
 
   // Start CI polling for this task (dep-injected so ci-poll.js can own it
   // in a later phase without a circular import between state modules).
@@ -457,7 +442,35 @@ function spawnInWorktree(name, worktreePath, branch, mode, resumeSessionId, extr
   return { id, name, worktreePath, branch, mode, repoPath };
 }
 
-function convertInstanceToShell(inst) {
+// Shared by spawn and restart: a copy that dropped the quit/kill/restart guards
+// was the original orphaned-shell bug.
+function makeAgentExitHandler(instance, ptyProc, { session, promptFile } = {}) {
+  const id = instance.id;
+  return ({ exitCode } = {}) => {
+    clearIdleTimer(instance);
+    if (session) session.release(); // free the concurrency slot (Codex token-rotation guard)
+    if (promptFile) { try { fs.unlinkSync(promptFile); } catch { /* already gone */ } }
+    const action = agentExitAction({
+      isCurrentPty: !instance.pty || instance.pty === ptyProc,
+      isAgent: isAgentMode(instance.mode),
+      quitting: _isQuitting(),
+      killed: !!instance.killed,
+      restarting: !!instance.restarting,
+    });
+    if (action === 'ignore') return;
+    if (action === 'convert') { convertInstanceToShell(instance, exitCode); return; }
+    instance.alive = false;
+    sendToTerminalSubscribers(`terminal-exit-${id}`, exitCode);
+  };
+}
+
+function convertInstanceToShell(inst, exitCode) {
+  const uptimeS = inst.spawnTime ? Math.round((Date.now() - inst.spawnTime) / 1000) : null;
+  // The CLI's own exit reason isn't captured, so a crash, an auth failure, and
+  // a user typing /exit all look alike here.
+  console.log(`[agent-exit] ${inst.mode} in "${inst.name}" exited`
+    + ` (code=${exitCode == null ? '?' : exitCode}${uptimeS == null ? '' : `, uptime=${uptimeS}s`})`
+    + ' — converting terminal to shell');
   sendIdleNotification(inst, `${displayNameFor(inst.originalMode || inst.mode)} has exited`);
   const id = inst.id;
   const userShell = defaultShell();
@@ -547,6 +560,7 @@ module.exports = {
   clearIdleTimer,
   spawnInWorktree,
   convertInstanceToShell,
+  makeAgentExitHandler,
   sendCIFlipNotification,
   isAnyWindowFocused,
   setDeps,

--- a/main/util/agent-exit.js
+++ b/main/util/agent-exit.js
@@ -1,0 +1,9 @@
+// 'ignore' = a stale pty exited after the instance was reattached to a newer
+// one; acting on it would clobber the live pty.
+function agentExitAction({ isCurrentPty, isAgent, quitting, killed, restarting }) {
+  if (!isCurrentPty) return 'ignore';
+  if (isAgent && !quitting && !killed && !restarting) return 'convert';
+  return 'exit';
+}
+
+module.exports = { agentExitAction };

--- a/test/util/agent-exit.test.js
+++ b/test/util/agent-exit.test.js
@@ -1,0 +1,33 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const { agentExitAction } = require('../../main/util/agent-exit');
+
+const live = { isCurrentPty: true, isAgent: true, quitting: false, killed: false, restarting: false };
+
+test('a natural agent exit converts to shell', () => {
+  assert.equal(agentExitAction(live), 'convert');
+});
+
+test('a stale pty is ignored even when everything else says convert', () => {
+  // The restart race: the old pty exits after inst.pty was reassigned, and
+  // converting here would clobber the just-restarted agent.
+  assert.equal(agentExitAction({ ...live, isCurrentPty: false }), 'ignore');
+});
+
+test('the current pty exiting while a restart is in flight tears down, not convert', () => {
+  // kill() is async, so the old pty can exit before inst.pty is reassigned —
+  // isCurrentPty is still true, and only the restarting flag stops the convert.
+  assert.equal(agentExitAction({ ...live, restarting: true }), 'exit');
+});
+
+test('quitting tears down instead of spawning a shell during shutdown', () => {
+  assert.equal(agentExitAction({ ...live, quitting: true }), 'exit');
+});
+
+test('a killed task tears down instead of orphaning a shell', () => {
+  assert.equal(agentExitAction({ ...live, killed: true }), 'exit');
+});
+
+test('a plain shell (non-agent) exit tears down', () => {
+  assert.equal(agentExitAction({ ...live, isAgent: false }), 'exit');
+});


### PR DESCRIPTION
## Summary

Follow-up to #41. That PR fixed the *label* when an agent tab converts to a shell; this fixes two cases where the conversion happens **when it shouldn't**, and adds the first diagnostic for *why* an agent CLI exits.

Both bugs require the task to have been restarted at least once, so they're an aggravator of the reported "my agent turned into a shell" rather than its sole cause — but restarting is exactly what you'd do after a surprise conversion.

## The bugs

**1. Restart race.** `restart-task` reassigns `inst.pty` to the new pty and clears `inst.restarting` synchronously, but `pty.kill()` on the old pty is async. If the old pty's exit lands *after* that, the spawn handler saw `restarting === false` and converted — clobbering the just-restarted agent with a shell and orphaning the fresh pty. Nothing asserted the exiting pty was still `instance.pty`.

**2. Drifted restart handler.** `restart-task`'s own `onExit` was a hand-copied variant that checked only `isAgentMode(inst.mode)`, missing the `_isQuitting` / `killed` / `restarting` guards the spawn handler has. Consequences for any task restarted once: app-quit spawns a stray shell mid-shutdown; `kill-task` (which deletes the instances entry first) orphans an unkillable shell — the exact leak the code comment claims to prevent.

## Changes

- **`main/util/agent-exit.js`** (new) — pure `agentExitAction(...)` policy returning `ignore` / `convert` / `exit`. Dependency-free so the guard logic is unit-testable without Electron/node-pty.
- **`main/state/instances.js`** — `makeAgentExitHandler(instance, ptyProc, {session, promptFile})`, now used by **both** the initial spawn and restart so they can't drift again. Adds the stale-pty identity check (ignore an exit whose pty is no longer `instance.pty`). `convertInstanceToShell` now logs `[agent-exit] <mode> in "<name>" exited (code=…, uptime=…s)`.
- **`main/ipc/tasks.js`** — `restart-task` uses the shared handler; comment corrected (it was truncated mid-sentence). `restarting` still guards the window *before* the pty reassignment; the identity check guards *after* it — complementary, both kept.

## What this does NOT change

- The label behaviour from #41.
- The root question of *why* the CLI exits — still uncaptured; the new log is the first signal, nothing more.
- The broadcast-bar and popout input paths flagged during triage (a broadcast of `exit` hitting every terminal; popout never unsubscribing) — separate, out of scope here.

## Test Plan

- `test/util/agent-exit.test.js` — covers the policy: natural exit → convert; stale pty → ignore (the race); current-pty-during-restart → exit; quitting → exit; killed → exit; non-agent → exit.
- `npm test` 182 passing, `npm run lint` clean, pre-commit review lenses clean.
- The pty wiring stays under existing e2e. **Not** manually reproduced in the running app — the races are timing-dependent and I haven't driven a real restart to confirm.

## Checklist

- [x] Tests added and passing
- [x] Lint + pre-commit review clean
- [x] Scoped to the restart-conversion bugs; label fix (#41) and input-path issues tracked separately
- [ ] Manual repro of the restart race in the running app — not done (timing-dependent)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
