### PR TITLE
fix(repo): report hook-install failure instead of ok:true

### DIFF
--- a/main/ipc/repo.js
+++ b/main/ipc/repo.js
@@ -219,7 +219,7 @@ ipcMain.handle('repo:install-hook', (_event, { repoPath }) => {
       revert.preCommitReview = false;
       saveConfig(revert);
     }
-    return { ok: true, installed };
+    return { ok: installed, installed, error: installed ? undefined : 'hook install failed' };
   } catch (e) {
     return { ok: false, error: e.message };
   }


### PR DESCRIPTION
## Summary
`repo:install-hook` returned `{ ok: true }` even when `installHookForRepo` failed — it swallows its own errors and no-ops on a non-git path, so a false `installed` is the only signal. A caller checking `ok` alone read that failure as success.

## Changes
- Return `{ ok: installed, installed, error: installed ? undefined : 'hook install failed' }` so a failed install is reported with a reason the "Enable Commit Review Gate" toast can show.

## Test Plan
- Lint clean; `npm run test` (197) passing.
- Surfaced by the pre-push review during PR #37; today's caller checks `installed`, so no behavior regression — this just makes `ok` honest for any caller.

🤖 Generated with [Claude Code](https://claude.com/claude-code)