### PR TITLE
fix(humanize): bring the JS port back in lockstep with klaussy-agents

### DIFF
--- a/main/util/humanize-comment.js
+++ b/main/util/humanize-comment.js
@@ -5,17 +5,24 @@
 // is intentionally conservative: high-confidence, meaning-preserving edits
 // only. Code is never touched.
 //
+// This is a port of klaussy-agents' `src/klaussy/humanize.py`, which owns the
+// rules. Keep the two in lockstep: same patterns, same order, same tests.
+//
 // Returns the humanized string; passes non-strings through unchanged.
 
 const { execFileSync } = require('child_process');
 
-// Sentence-initial filler openers. Stripped only at the start of the text or a
-// line (so we don't cut mid-sentence), and the following word is re-capitalized.
-const OPENERS = '(?:It\'?s worth noting that|It\'?s important to note that'
-  + '|It\'?s worth mentioning that|It\'?s important to remember that'
+// Sentence-initial filler openers, stripped at the start of the text or a line
+// (so we don't cut mid-sentence), and the following word is re-capitalized.
+// Two families: chatbot "note that" scaffolding, and editorializing verdict
+// openers ("Personally", "Honestly", ...) that prime a dismissive read.
+const OPENERS = '(?:It(?:\'?s| is) worth noting that|It(?:\'?s| is) important to note that'
+  + '|It(?:\'?s| is) worth mentioning that|It(?:\'?s| is) important to remember that'
   + '|I noticed that|I wanted to point out that'
   + '|I want to (?:point out|note|mention|flag) that|Please note that'
   + '|Just to (?:note|mention)|Worth noting,?|Note that'
+  + '|Actually|Personally|Honestly|Frankly|Quite frankly|To be honest'
+  + '|In my (?:honest )?opinion|IMO|IMHO|If you ask me'
   + '|At the end of the day|Generally speaking|Now,? more than ever'
   + '|Furthermore|Moreover|Additionally|Consequently|Nevertheless|Indeed)';
 
@@ -40,40 +47,83 @@ const SCAFFOLD = '(?:Let me know if[^\\n]*|Hope (?:this|that) helps[^\\n]*'
   + '|I hope (?:this|that) helps[^\\n]*|Feel free to[^\\n]*'
   + '|Happy to help[^\\n]*|Let me know your thoughts[^\\n]*)';
 
+// Sentence-initial "Actually," is handled by the opener list; these cover the
+// mid-sentence and trailing uses. The adjective is only dropped after a
+// determiner that doesn't inflect, so "an actual bug" is left to the prompt.
+const ACTUALLY_TRAIL = /(?<=\w)[ \t]*,?[ \t]*\bactually\b(?=[ \t]*(?:[.,;:!?)\]]|$|\n))/gi;
+const ACTUALLY_MID = /(?<=\w)[ \t]+actually\b/gi;
+// "... works. Actually it does." — mid-line sentence starts, which the opener
+// list (anchored to the start of a line) never sees.
+const ACTUALLY_SENTENCE = /([.!?][ \t]+)actually\b[ \t,]*(\w)/gi;
+// The word after "actual" must be its noun: a verb, conjunction, or preposition
+// there means "the actual" was the noun ("compare the actual to the expected").
+const ACTUAL_ADJ = /\b(the|this|that|these|those|its|their|our|your|my|no|each|any|every|some|all)[ \t]+actual[ \t]+(?!(?:is|was|are|were|be|been|and|or|to|vs\.?|versus|of|in|on|at|for|with|from|than|but|so|because)\b)(?=\w)/gi;
+
+// Stiff phrasings with one short equivalent that reads the same in every
+// sentence. Anything whose replacement depends on the surrounding clause ("a
+// number of", "in terms of") stays prompt-side, where a model can judge it.
+const PHRASINGS = [
+  [/\butilize\b/gi, 'use'],
+  [/\butilizes\b/gi, 'uses'],
+  [/\butilizing\b/gi, 'using'],
+  [/\bleverage\b/gi, 'use'],
+  [/\bleverages\b/gi, 'uses'],
+  [/\bleveraging\b/gi, 'using'],
+  [/\bin order to\b/gi, 'to'],
+  [/\bcould potentially\b/gi, 'could'],
+  [/\bmay potentially\b/gi, 'may'],
+  [/\bdue to the fact that\b/gi, 'because'],
+  [/\bin the event that\b/gi, 'if'],
+  [/\bprior to\b/gi, 'before'],
+  [/\bsubsequent to\b/gi, 'after'],
+  [/\bat this point in time\b/gi, 'now'],
+  [/\bwith regards? to\b/gi, 'about'],
+  [/\b(?:is|are) able to\b/gi, 'can'],
+  [/\b(?:was|were) able to\b/gi, 'could'],
+  [/\bhas the ability to\b/gi, 'can'],
+  [/\bhave the ability to\b/gi, 'can'],
+];
+
+// Capitalize `replacement` iff `matched` was, so line-initial hits keep their capital.
+function matchCase(matched, replacement) {
+  if (matched[0] === matched[0].toUpperCase() && matched[0] !== matched[0].toLowerCase()) {
+    return replacement[0].toUpperCase() + replacement.slice(1);
+  }
+  return replacement;
+}
+
 function scrubProse(s) {
-  // Em / en dashes — the single strongest tell.
+  // Em / en dashes — the single strongest tell. A dash between two numbers is a
+  // range ("35–50 min"), so it collapses to a plain hyphen; spacing it out would
+  // read as a subtraction or a dropped clause.
+  s = s.replace(/(?<=\d)\s*[–—]\s*(?=\d)/g, '-');
   s = s.replace(/\s*—\s*/g, ', ').replace(/\s*–\s*/g, ' - ');
   // Drop overused AI emojis.
   s = s.replace(/[🚀✨🔑💡🎯😊🙏]/gu, '');
   // Drop trailing scaffolding sentences/lines.
   s = s.replace(new RegExp('(?:^|\\n)\\s*' + SCAFFOLD + '\\s*$', 'gi'), '');
-  // Strip filler openers at the start of the text or a line; recapitalize.
-  s = s.replace(new RegExp('(^|\\n)[ \\t]*' + OPENERS + '[ \\t,]+(\\w)', 'gi'),
-    function (_m, pre, ch) { return pre + ch.toUpperCase(); });
   // Drop standalone praise lines, then strip praise that leads into content.
   s = s.replace(PRAISE_LINE, '$1');
   s = s.replace(PRAISE_LEAD, function (_m, pre, ch) { return pre + ch.toUpperCase(); });
-  // Strip thanking bots followed by text; recapitalize.
+  // Drop standalone bot-thanks, then strip bot-thanks that leads into content.
+  s = s.replace(new RegExp('(^|\\n)[ \\t]*' + THANK_BOT + '[ \\t,!.?]*(?=\\n|$)', 'gi'), '$1');
   s = s.replace(new RegExp('(^|\\n)[ \\t]*' + THANK_BOT + '[ \\t,!.?]*(\\w)', 'gi'),
     function (_m, pre, ch) { return pre + ch.toUpperCase(); });
-  // Strip thanking bots at the end of a line or text.
-  s = s.replace(new RegExp('(^|\\n)[ \\t]*' + THANK_BOT + '[ \\t,!.?]*$', 'gi'), '');
-  // Strip apologies followed by text; recapitalize.
+  // Drop standalone apologies, then strip apologies that lead into content.
+  s = s.replace(new RegExp('(^|\\n)[ \\t]*' + APOLOGIES + '[ \\t,!.?]*(?=\\n|$)', 'gi'), '$1');
   s = s.replace(new RegExp('(^|\\n)[ \\t]*' + APOLOGIES + '[ \\t,!.?]*(\\w)', 'gi'),
     function (_m, pre, ch) { return pre + ch.toUpperCase(); });
-  // Strip apologies at the end of a line or text.
-  s = s.replace(new RegExp('(^|\\n)[ \\t]*' + APOLOGIES + '[ \\t,!.?]*$', 'gi'), '');
-  // Safe lexicon replacements: leverage/utilize -> use.
-  s = s.replace(/\butilize\b/gi, 'use')
-       .replace(/\butilizes\b/gi, 'uses')
-       .replace(/\butilizing\b/gi, 'using')
-       .replace(/\bleverage\b/gi, 'use')
-       .replace(/\bleverages\b/gi, 'uses')
-       .replace(/\bleveraging\b/gi, 'using');
-  // A few safe, unambiguous tightenings.
-  s = s.replace(/\bin order to\b/gi, 'to')
-    .replace(/\bcould potentially\b/gi, 'could')
-    .replace(/\bmay potentially\b/gi, 'may');
+  // Strip filler openers at the start of the text or a line; recapitalize.
+  s = s.replace(new RegExp('(^|\\n)[ \\t]*' + OPENERS + '[ \\t,]+(\\w)', 'gi'),
+    function (_m, pre, ch) { return pre + ch.toUpperCase(); });
+  // Drop "actually" (trailing first, so its comma goes with it) and "actual".
+  s = s.replace(ACTUALLY_SENTENCE, function (_m, pre, ch) { return pre + ch.toUpperCase(); });
+  s = s.replace(ACTUALLY_TRAIL, '');
+  s = s.replace(ACTUALLY_MID, '');
+  s = s.replace(ACTUAL_ADJ, function (_m, det) { return det + ' '; });
+  for (const [pattern, replacement] of PHRASINGS) {
+    s = s.replace(pattern, function (m) { return matchCase(m, replacement); });
+  }
   // Tidy whitespace introduced by the removals.
   s = s.replace(/[ \t]{2,}/g, ' ').replace(/[ \t]+(\n)/g, '$1');
   return s;

--- a/test/util/humanize-comment.test.js
+++ b/test/util/humanize-comment.test.js
@@ -7,7 +7,14 @@ const { humanizeCommentJs: humanizeComment } = require('../../main/util/humanize
 
 test('normalizes em and en dashes in prose', () => {
   assert.equal(humanizeComment('Leaks a connection — wrap it.'), 'Leaks a connection, wrap it.');
-  assert.equal(humanizeComment('range 1–5 here'), 'range 1 - 5 here');
+  assert.equal(humanizeComment('the fix – finally – landed'), 'the fix - finally - landed');
+});
+
+test('keeps numeric ranges tight', () => {
+  // A dash between digits is a range, not a clause break: "35 - 50 min" reads as
+  // a subtraction or a dropped clause.
+  assert.equal(humanizeComment('parses take 35–50 min'), 'parses take 35-50 min');
+  assert.equal(humanizeComment('pages 3—4 are wrong'), 'pages 3-4 are wrong');
 });
 
 test('strips a leading filler opener and recapitalizes', () => {
@@ -85,6 +92,30 @@ test('strips apologetic throat-clearing at start of line/text or when standalone
 test('replaces leverage and utilize with use', () => {
   assert.equal(humanizeComment('We should utilize the new function.'), 'We should use the new function.');
   assert.equal(humanizeComment('This will leverage caches.'), 'This will use caches.');
+});
+
+test('swaps stiff phrasings for their short equivalent, keeping the capital', () => {
+  assert.equal(humanizeComment('Prior to the retry, flush the buffer.'), 'Before the retry, flush the buffer.');
+  assert.equal(humanizeComment('The client has the ability to refresh it.'), 'The client can refresh it.');
+  assert.equal(humanizeComment('Due to the fact that it expires, we refresh.'), 'Because it expires, we refresh.');
+  assert.equal(humanizeComment('The worker was able to recover.'), 'The worker could recover.');
+});
+
+test('drops empty "actual" and "actually"', () => {
+  assert.equal(humanizeComment('This actually works.'), 'This works.');
+  assert.equal(humanizeComment('It fails, actually.'), 'It fails.');
+  assert.equal(humanizeComment('The actual value is wrong.'), 'The value is wrong.');
+  // "the actual" as a noun keeps its word.
+  assert.equal(
+    humanizeComment('Compare the actual to the expected.'),
+    'Compare the actual to the expected.',
+  );
+});
+
+test('strips editorializing verdict openers', () => {
+  assert.equal(humanizeComment('Personally, I would rethrow here.'), 'I would rethrow here.');
+  assert.equal(humanizeComment('Honestly, this leaks.'), 'This leaks.');
+  assert.equal(humanizeComment('IMO, the lock is too broad.'), 'The lock is too broad.');
 });
 
 test('passes non-strings through unchanged', () => {


### PR DESCRIPTION
## Summary

`main/util/humanize-comment.js` is a port of klaussy-agents' `humanize.py`, and it had drifted. This brings it back to byte-for-byte agreement: same patterns, same order, same tests.

## Changes

- **Ported the rules the JS never had**: the `actual` / `actually` removals, and the editorializing verdict openers (`Personally`, `Honestly`, `Frankly`, `IMO`, `IMHO`, `If you ask me`). Both have been in the Python for a while.
- **Fixed the rule order** — the JS applied filler openers before praise, the Python applies them after.
- **Ported what landed with klaussy-agents 0.25.0**: the stiff-phrasing table (`prior to` → `before`, `is able to` → `can`, `due to the fact that` → `because` and friends) with the first letter's case preserved, uncontracted filler openers (`It is worth noting that` alongside `It's worth noting that`), and tight numeric ranges.
- `35–50 min` now becomes `35-50 min` instead of `35 - 50 min`, which read as a subtraction. This is a deliberate behavior change; the test that asserted the old output was replaced with one documenting why.

## Test Plan

- [x] Tests pass locally — `node --test test/util/humanize-comment.test.js`, 18/18 (was 14)
- [x] Manually verified

New cases cover numeric ranges, the phrasing table with capitalization, `actual`/`actually` including the `compare the actual to the expected` case that must survive, and the verdict openers.

Parity is verified rather than assumed: both implementations were run over a 66-case corpus covering every rule plus the cases built to trip them — `an actual bug` survives, `` `prior to` `` inside backticks is untouched, code fences pass through. **0 of 66 differ.**

Why it matters: `humanizeComment()` prefers the `klaussy humanize` CLI and falls back to this port when it isn't on PATH. While they disagreed, the same comment came out scrubbed differently depending on whether klaussy was installed.

## Checklist

- [x] Code follows project conventions (see CLAUDE.md)
- [x] No unrelated changes
- [x] Tests added/updated for new functionality
- [x] Documentation updated if needed

Companion to steph-dove/klaussy-agents#45, which owns the rules.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
