### PR TITLE
feat(notifications): read what opencode said from its own store

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,10 @@ jobs:
 
       - uses: actions/setup-node@v5
         with:
-          node-version: '20'
+          # Matches the Node that Electron 41 bundles, which is what the app
+          # actually runs on. The agent stores are read through node:sqlite,
+          # absent before 22 and behind a flag until 23.4.
+          node-version: '24'
           cache: 'npm'
 
       - name: Install dependencies

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,7 +12,7 @@ npm install      # rebuilds node-pty for Electron; patches the menu-bar name
 npm start        # launches the app
 ```
 
-You'll want **Node.js 18+**, the **GitHub CLI** (`gh`), and at least one
+You'll want **Node.js 24+**, the **GitHub CLI** (`gh`), and at least one
 supported agent CLI (Claude Code by default). See the README for per-OS setup.
 
 ## Before you open a PR

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ Prebuilt, signed, and notarized binaries are available for macOS, Windows, and L
 ## 📋 Prerequisites
 
 Klaussy Desktop automatically detects and configures your local environment. It requires:
-1.  **Node.js 18+**
+1.  **Node.js 24+** (the agent stores are read through `node:sqlite`)
 2.  **GitHub CLI (`gh`)** (with active authentication)
 3.  **An Agent CLI or IDE extension** (Claude Code is the default; also supports Codex, Gemini, Antigravity, Copilot, Cursor, Cline, opencode, Kimi Code, and local models via Ollama + Aider)
 

--- a/main/state/instances.js
+++ b/main/state/instances.js
@@ -270,6 +270,12 @@ function transcriptFileFor(inst, providerId) {
     bindAgyConversation(inst);
     return inst.agyConversation;
   }
+  if (providerId === 'opencode') {
+    if (!inst.opencodeSession) {
+      inst.opencodeSession = agentTranscript.findOpencodeSession(inst.worktreePath, inst.spawnTime);
+    }
+    return inst.opencodeSession ? agentTranscript.opencodeSource(inst.opencodeSession) : '';
+  }
   return '';
 }
 

--- a/main/util/agent-transcript.js
+++ b/main/util/agent-transcript.js
@@ -372,7 +372,84 @@ function readAntigravity({ transcriptFile, cursor, fromEnd }) {
   return readAntigravitySqlite(transcriptFile, cursor, fromEnd);
 }
 
-const READERS = { claude: readClaude, codex: readCodex, antigravity: readAntigravity };
+// ---- opencode: <data home>/opencode/opencode.db ----
+//
+// A message row carries the role, its parts carry the text, and `part.rowid` is
+// monotonic, so it doubles as the cursor.
+function opencodeDbPath() {
+  const { authFilePath } = require('../state/opencode-config');
+  return path.join(path.dirname(authFilePath()), 'opencode.db');
+}
+
+// The source is one string so a change of session repoints the cursor the same
+// way a change of file does for the readers backed by one.
+function opencodeSource(sessionId) {
+  return `${opencodeDbPath()}#${sessionId}`;
+}
+
+function findOpencodeSession(worktreePath, sinceMs) {
+  const dbPath = opencodeDbPath();
+  if (!worktreePath || !fs.existsSync(dbPath)) return '';
+  let db;
+  try {
+    db = openDb(dbPath);
+    const row = db.prepare(
+      'select id from session where directory = ? and time_updated >= ? order by time_updated desc limit 1',
+    ).get(worktreePath, Number(sinceMs) || 0);
+    return row ? row.id : '';
+  } catch (err) {
+    console.warn('[agent-transcript] opencode session lookup failed:', err.message);
+    return '';
+  } finally {
+    if (db) try { db.close(); } catch { /* already closed */ }
+  }
+}
+
+function readOpencode({ transcriptFile, cursor, fromEnd }) {
+  const sep = String(transcriptFile || '').lastIndexOf('#');
+  if (sep === -1) return null;
+  const dbPath = transcriptFile.slice(0, sep);
+  const sessionId = transcriptFile.slice(sep + 1);
+  if (!sessionId || !fs.existsSync(dbPath)) return null;
+
+  const from = Number(cursor) || 0;
+  let db;
+  try {
+    db = openDb(dbPath);
+    const rows = db.prepare(
+      `select p.rowid as seq, p.data as part_data, m.data as message_data
+         from part p join message m on m.id = p.message_id
+        where p.session_id = ? and p.rowid > ?
+        order by p.rowid`,
+    ).all(sessionId, from);
+    if (!rows.length) return { text: '', cursor: from };
+
+    let last = from;
+    const parts = [];
+    for (const row of rows) {
+      last = row.seq;
+      if (fromEnd) continue;
+      let message = {};
+      let part = {};
+      try { message = JSON.parse(row.message_data); } catch { continue; }
+      try { part = JSON.parse(row.part_data); } catch { continue; }
+      // A turn of pure tool calls is silence, not a read failure.
+      if (message.role !== 'assistant' || part.type !== 'text') continue;
+      const text = String(part.text || '').trim();
+      if (text && parts[parts.length - 1] !== text) parts.push(text);
+    }
+    return { text: fromEnd ? '' : capFromEnd(parts.join('\n\n')), cursor: last };
+  } catch (err) {
+    console.warn('[agent-transcript] opencode read failed:', err.message);
+    return null;
+  } finally {
+    if (db) try { db.close(); } catch { /* already closed */ }
+  }
+}
+
+const READERS = {
+  claude: readClaude, codex: readCodex, antigravity: readAntigravity, opencode: readOpencode,
+};
 
 function hasReader(providerId) {
   return Object.prototype.hasOwnProperty.call(READERS, providerId);
@@ -397,6 +474,8 @@ module.exports = {
   claudeTranscriptPath,
   findCodexRollout,
   findAntigravityConversation,
+  findOpencodeSession,
+  opencodeSource,
   antigravityWorkspace,
   MAX_TEXT,
 };

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   "license": "SEE LICENSE IN LICENSE",
   "private": true,
   "engines": {
-    "node": ">=18"
+    "node": ">=24"
   },
   "repository": {
     "type": "git",

--- a/test/util/agent-transcript.test.js
+++ b/test/util/agent-transcript.test.js
@@ -234,6 +234,63 @@ test('codex: fromEnd adopts a rollout without posting what it already holds', ()
   assert.equal(t.readNewMessages('codex', { transcriptFile: file, cursor: r.cursor }).text, 'Later.');
 });
 
+function opencodeDb(rows) {
+  const { DatabaseSync } = require('node:sqlite');
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'klaussy-opencode-'));
+  const file = path.join(dir, 'opencode.db');
+  const db = new DatabaseSync(file);
+  db.exec('create table message (id TEXT, session_id TEXT, data TEXT)');
+  db.exec('create table part (id TEXT, message_id TEXT, session_id TEXT, data TEXT)');
+  let n = 0;
+  for (const [role, parts] of rows) {
+    const mid = 'msg_' + (++n);
+    db.prepare('insert into message (id, session_id, data) values (?, ?, ?)')
+      .run(mid, 'ses_x', JSON.stringify({ role }));
+    for (const part of parts) {
+      db.prepare('insert into part (id, message_id, session_id, data) values (?, ?, ?, ?)')
+        .run('prt_' + (++n), mid, 'ses_x', JSON.stringify(part));
+    }
+  }
+  db.close();
+  return file + '#ses_x';
+}
+
+test('opencode: assistant text is read and its reasoning is not', () => {
+  const src = opencodeDb([
+    ['user', [{ type: 'text', text: 'read a.txt' }]],
+    ['assistant', [
+      { type: 'reasoning', text: 'The user wants me to read a file. Let me think.' },
+      { type: 'step-start' },
+      { type: 'text', text: 'The file says hello.' },
+    ]],
+  ]);
+  const r = t.readNewMessages('opencode', { transcriptFile: src, cursor: 0 });
+  assert.equal(r.text, 'The file says hello.');
+  assert.doesNotMatch(r.text, /Let me think/, 'reasoning is the scratchpad, never posted');
+  assert.doesNotMatch(r.text, /read a\.txt/, 'the user is not the agent talking');
+});
+
+test('opencode: the cursor returns only what is new', () => {
+  const src = opencodeDb([['assistant', [{ type: 'text', text: 'First.' }]]]);
+  const first = t.readNewMessages('opencode', { transcriptFile: src, cursor: 0 });
+  assert.equal(first.text, 'First.');
+  assert.equal(t.readNewMessages('opencode', { transcriptFile: src, cursor: first.cursor }).text, '');
+});
+
+test('opencode: a turn with no spoken text is silence, not a failure', () => {
+  const src = opencodeDb([['assistant', [{ type: 'step-start' }, { type: 'step-finish' }]]]);
+  const r = t.readNewMessages('opencode', { transcriptFile: src, cursor: 0 });
+  assert.equal(r.text, '');
+  assert.notEqual(r, null, 'a readable store with nothing said still answers');
+});
+
+test('opencode: fromEnd adopts the session without posting it', () => {
+  const src = opencodeDb([['assistant', [{ type: 'text', text: 'Said before we bound.' }]]]);
+  const r = t.readNewMessages('opencode', { transcriptFile: src, cursor: 0, fromEnd: true });
+  assert.equal(r.text, '');
+  assert.ok(r.cursor > 0, 'but the position is taken');
+});
+
 test('a missing transcript returns null rather than throwing', () => {
   assert.equal(t.readNewMessages('codex', { transcriptFile: '/nope/missing.jsonl', cursor: 0 }), null);
   assert.equal(t.readNewMessages('claude', { worktreePath: '', sessionId: '', cursor: 0 }), null);


### PR DESCRIPTION
## Summary

Adds a transcript reader for opencode, so its chat mirroring posts what the agent actually said instead of a scrape of its repainting terminal. Clean-text coverage goes from 3 agents to 4 (claude, codex, antigravity, opencode).

Kimi is deliberately not included — see below.

## Changes

opencode keeps sessions in SQLite rather than a tailable log:

- `message.data` carries the role, `part.data` carries the text, joined on `message_id`
- `part.rowid` is monotonic, so it is the cursor
- `session.directory` records the worktree a session runs in, so the lookup is exact rather than a newest-file guess

`reasoning` parts are excluded the same way claude `thinking` blocks are.

A turn of pure tool calls extracts no text. That is normal for this store, unlike Antigravity where the speech step is speech-only, so it reports silence and keeps its cursor rather than returning a read failure and suppressing the screen fallback.

## Test Plan

Verified against the real store on the dev machine, not only fixtures:

- reads clean assistant prose from a live session, cursor advances, a second read returns nothing
- run against a session that actually contains `reasoning` parts: 0 snippets leaked into the output
- `fromEnd` takes the position without posting

Plus four unit tests over a temporary SQLite fixture: reasoning excluded, cursor delta, tool-only turn is silence not failure, `fromEnd`.

`npm run test` 438 pass, `npm run lint` clean.

## Why kimi is not here

Kimi's conversation lives in `<sessionDir>/agents/main/wire.jsonl`, and its record shape is `{type: <op type>, ...payload}`. Which op type carries assistant text could not be established:

- every `wire.jsonl` on this machine holds only `metadata` / `config.update` / `tools.set_active_tools`, no conversation
- the installed bundle has readable source, but nothing that writes the log by that name
- `src/wire/record.ts` defines only the generic envelope
- the v1.1 to v1.5 wire migrations enumerate `goal.*` records only

One real kimi conversation on disk makes this a short follow-up. Building it on inference is how the Antigravity reader went wrong.

## Checklist

- [x] Verified against real on-disk data, including the reasoning-leak case
- [x] Unit tests over a fixture store
- [ ] Not exercised end to end through a live Klaussy opencode session

🤖 Generated with [Claude Code](https://claude.com/claude-code)
