### PR TITLE
fix(notifications): stop offering a button that cannot answer the prompt

### DIFF
--- a/main/util/chat-reply.js
+++ b/main/util/chat-reply.js
@@ -116,14 +116,20 @@ function parseRegion(region) {
   return { options: all.slice(0, MAX_OPTIONS), truncated: all.length > MAX_OPTIONS };
 }
 
-// Scoped to the menu itself: "I'll select all the failing tests" is the agent
-// talking, and reading it as a multi-select strips the Approve/Reject buttons
-// off whatever prompt is really waiting.
-const MULTI_SELECT_IDIOM = /(space to (toggle|select)|select (one or more|all that apply|multiple|one or several)|separated by (spaces?|commas?)|multi-select)/i;
+// Both wear the same "pick several" wording, but only a typed list — numbers on
+// one line — can be answered from chat; a checkbox menu needs keystrokes.
+const MULTI_SELECT_TYPED = /separated by (spaces?|commas?)/i;
+const MULTI_SELECT_TOGGLE = /(space to (toggle|select)|select (one or more|all that apply|multiple|one or several)|multi-select)/i;
 
-function isMultiSelect(tail) {
-  return menusWithFooter(tail).some(({ region, footer }) => MULTI_SELECT_IDIOM.test(footer)
-    || region.some((l) => MULTI_SELECT_IDIOM.test(l)));
+// Returns 'typed', 'toggle', or '' for one answer; scoped to the menu itself
+// because "I'll select all the failing tests" is the agent talking, not a prompt.
+function multiSelectStyle(tail) {
+  for (const { region, footer } of menusWithFooter(tail)) {
+    const lines = [footer, ...region];
+    if (lines.some((l) => MULTI_SELECT_TYPED.test(l))) return 'typed';
+    if (lines.some((l) => MULTI_SELECT_TOGGLE.test(l))) return 'toggle';
+  }
+  return '';
 }
 
 // Claude Code draws a numbered menu where 'y' does nothing, while other agents
@@ -282,6 +288,6 @@ function applyText({ taskId, text, userId, allowList }) {
 
 module.exports = {
   applyDecision, applyChoice, applyText,
-  isAllowed, sanitizeForPaste, keysForPrompt, parsePromptOptions, isMultiSelect,
+  isAllowed, sanitizeForPaste, keysForPrompt, parsePromptOptions, multiSelectStyle,
   hasSelectionFooter, parsePromptQuestion, approvalTail, MAX_OPTIONS,
 };

--- a/main/util/notification-gateway.js
+++ b/main/util/notification-gateway.js
@@ -92,7 +92,7 @@ async function dispatchEvent(event, cfg) {
   let promptOptions = [];
   let optionsTruncated = false;
   let menuPrompt = false;
-  let isMultiSelect = false;
+  let multiSelect = '';
   let promptQuestion = '';
   const wantsButtons = event.type === EVENT_TYPES.APPROVAL_REQUIRED
     && (cfg.slackInteractive || cfg.discordInteractive)
@@ -102,12 +102,14 @@ async function dispatchEvent(event, cfg) {
     // are read here and stored with the token rather than guessed at click time.
     const reply = require('./chat-reply');
     const parsed = reply.parsePromptOptions(event.logsTail);
-    promptOptions = parsed.options;
-    optionsTruncated = parsed.truncated;
-    isMultiSelect = reply.isMultiSelect(event.logsTail);
+    multiSelect = reply.multiSelectStyle(event.logsTail);
+    // A button carries one key, which can't answer a prompt that takes several,
+    // so those get told how to answer instead of a button pressing a wrong key.
+    promptOptions = multiSelect ? [] : parsed.options;
+    optionsTruncated = multiSelect ? false : parsed.truncated;
     // A menu ignores y/n, so Approve/Reject for one would be dead buttons; none
     // is better, since the mirrored turn still shows the choices.
-    menuPrompt = reply.hasSelectionFooter(event.logsTail) || promptOptions.length > 0 || isMultiSelect;
+    menuPrompt = reply.hasSelectionFooter(event.logsTail) || promptOptions.length > 0 || !!multiSelect;
     // A hook said what it wants in the agent's own words; the screen is only
     // guessed at when nothing authoritative came with the event.
     promptQuestion = event.promptQuestion || reply.parsePromptQuestion(event.logsTail);
@@ -127,7 +129,7 @@ async function dispatchEvent(event, cfg) {
     );
   }
   const decorated = approvalToken
-    ? { ...event, approvalToken, options: promptOptions, optionsTruncated, menuPrompt, promptQuestion, isMultiSelect }
+    ? { ...event, approvalToken, options: promptOptions, optionsTruncated, menuPrompt, promptQuestion, multiSelect }
     : event;
 
   const jobs = [];

--- a/main/util/webhook-format.js
+++ b/main/util/webhook-format.js
@@ -104,6 +104,15 @@ function headline(event, p) {
   return `${agentLabel(event)} ${p.verb}`;
 }
 
+// A typed list is answerable from chat because the reply is pasted as one line,
+// while a checkbox menu needs keystrokes only the terminal can send.
+function answerHint(event, bold) {
+  if (event.multiSelect === 'typed') return 'Reply in chat with the option numbers, e.g. `1, 3`.';
+  if (event.multiSelect) return 'Picking several options needs the terminal — answer in Klaussy.';
+  if (event.menuPrompt) return 'Reply in chat with your option choice(s).';
+  return `Respond in Klaussy to ${bold}Approve${bold} or ${bold}Reject${bold} this step.`;
+}
+
 function formatSlack(event) {
   // A mirrored turn is the agent talking, not an alert about it.
   if (event.type === EVENT_TYPES.MESSAGE) {
@@ -149,13 +158,8 @@ function formatSlack(event) {
           type: 'context',
           elements: [{ type: 'mrkdwn', text: '_More options exist — answer in Klaussy to see them all._' }],
         });
-      } else if (event.isMultiSelect) {
-        blocks.push({
-          type: 'context',
-          elements: [{ type: 'mrkdwn', text: '_Select choices by clicking buttons or reply with option numbers (e.g. 1, 2)._' }],
-        });
       }
-    } else if (event.approvalToken && !event.menuPrompt && !event.isMultiSelect) {
+    } else if (event.approvalToken && !event.menuPrompt && !event.multiSelect) {
       blocks.push({
         type: 'actions',
         block_id: 'klaussy_approval',
@@ -175,7 +179,7 @@ function formatSlack(event) {
     } else {
       blocks.push({
         type: 'context',
-        elements: [{ type: 'mrkdwn', text: (event.menuPrompt || event.isMultiSelect) ? 'Reply in chat with your option choice(s).' : 'Respond in Klaussy to *Approve* or *Reject* this step.' }],
+        elements: [{ type: 'mrkdwn', text: answerHint(event, '*') }],
       });
     }
   }
@@ -219,11 +223,8 @@ function formatDiscord(event) {
 
   const parts = [];
   const interactive = event.type === EVENT_TYPES.APPROVAL_REQUIRED && event.approvalToken;
-  if (event.type === EVENT_TYPES.APPROVAL_REQUIRED && !interactive) {
-    parts.push((event.menuPrompt || event.isMultiSelect) ? 'Reply in chat with your option choice(s).' : 'Respond in Klaussy to **Approve** or **Reject** this step.');
-  }
-  if (interactive && event.isMultiSelect) {
-    parts.push('_Select choices below or reply in chat with option numbers (e.g. 1 2)._');
+  if (event.type === EVENT_TYPES.APPROVAL_REQUIRED && (!interactive || event.multiSelect)) {
+    parts.push(answerHint(event, '**'));
   }
   if (event.promptQuestion) parts.push(fenceSafe(event.promptQuestion));
   const logs = screenExcerpt(event);
@@ -250,7 +251,7 @@ function formatDiscord(event) {
         label: `${o.key}. ${o.label}`.slice(0, 80),
         custom_id: `klaussy_choice:${event.approvalToken}:${o.key}`,
       }))
-      : ((event.menuPrompt || event.isMultiSelect) ? [] : [
+      : ((event.menuPrompt || event.multiSelect) ? [] : [
         { type: 2, style: 3, label: 'Approve', custom_id: 'klaussy_approve:' + event.approvalToken },
         { type: 2, style: 4, label: 'Reject', custom_id: 'klaussy_reject:' + event.approvalToken },
       ]);

--- a/test/util/chat-reply.test.js
+++ b/test/util/chat-reply.test.js
@@ -269,10 +269,15 @@ test('long menus are capped so the message stays readable', () => {
   assert.equal(parsePromptOptions(exact).truncated, false);
 });
 
-test('a toggle prompt offers no buttons rather than pressing one key', () => {
-  const { isMultiSelect } = require('../../main/util/chat-reply');
-  assert.equal(isMultiSelect('Pick files\n 1. a\n 2. b\nSpace to toggle · Enter to confirm'), true);
-  assert.equal(isMultiSelect(HOTDOG_PROMPT), false);
+test('the two multi-select shapes are told apart', () => {
+  const { multiSelectStyle } = require('../../main/util/chat-reply');
+  assert.equal(multiSelectStyle('Pick files\n 1. a\n 2. b\nSpace to toggle · Enter to confirm'), 'toggle');
+  assert.equal(multiSelectStyle('Which features?\n 1. a\n 2. b\nSelect all that apply · Enter to confirm'), 'toggle');
+  assert.equal(multiSelectStyle('Which features?\n 1. a\n 2. b\nEnter to select, separated by commas'), 'typed');
+  assert.equal(multiSelectStyle(HOTDOG_PROMPT), '', 'a single-answer prompt is neither');
+
+  // The agent saying it will select things is not a prompt asking anyone to.
+  assert.equal(multiSelectStyle('I will select all that apply once the tests pass.'), '');
 });
 
 test('a choice can only press an option that was offered', () => {

--- a/test/util/notification-gateway.test.js
+++ b/test/util/notification-gateway.test.js
@@ -265,6 +265,34 @@ test('buttons only go to the platform that can hear them', async () => {
   }
 });
 
+test('a checkbox menu is dispatched with no options to press', async () => {
+  const srv = makeCaptureServer();
+  const base = await srv.start();
+  threads._reset();
+  const realFetch = global.fetch;
+  const botPosts = [];
+  global.fetch = async (url, opts) => {
+    botPosts.push({ url: String(url), body: JSON.parse(opts.body) });
+    return { ok: true, json: async () => ({ ok: true, ts: '1.1' }) };
+  };
+  try {
+    await gateway.dispatchEvent({
+      ...APPROVAL,
+      logsTail: 'Which features?\n 1. Auth\n 2. Billing\nSpace to toggle · Enter to confirm',
+    }, cfg(base, {
+      slackInteractive: true, slackBotToken: 'xoxb-x', slackChannel: 'C1',
+      slackWebhookUrl: '', discordInteractive: false,
+    }));
+    const alert = botPosts.filter((p) => p.url.includes('chat.postMessage')).pop();
+    assert.ok(!alert.body.blocks.some((b) => b.type === 'actions'),
+      'no button can express this answer, so none is drawn');
+    assert.match(JSON.stringify(alert.body), /needs the terminal/);
+  } finally {
+    global.fetch = realFetch;
+    await srv.close();
+  }
+});
+
 // A webhook cannot post into a thread and its posts carry no id to reply to, so
 // anything it sends is unanswerable. With a bot configured, a webhook url on the
 // side used to take every non-approval message down that dead end.

--- a/test/util/webhook-format.test.js
+++ b/test/util/webhook-format.test.js
@@ -252,26 +252,26 @@ test('an unreadable screen is not pasted into the alert', () => {
   assert.match(flat, /waiting for approval/, 'it still says what happened');
 });
 
-test('a multi-select prompt renders choice buttons and hints without approve/reject fallback', () => {
-  const evt = {
-    ...APPROVAL,
-    approvalToken: 'tok',
-    options: [
-      { key: '1', label: 'Feature A' },
-      { key: '2', label: 'Feature B' },
-    ],
-    menuPrompt: true,
-    isMultiSelect: true,
-  };
+// The gateway offers no options for these, so neither platform has a button to draw.
+test('a checkbox menu sends people to the terminal rather than to a button', () => {
+  const evt = { ...APPROVAL, approvalToken: 'tok', options: [], menuPrompt: true, multiSelect: 'toggle' };
+
   const slack = formatSlack(evt);
-  const actions = slack.blocks.find((b) => b.type === 'actions');
-  assert.equal(actions.elements.length, 2);
-  assert.equal(actions.elements[0].text.text, '1. Feature A');
-  assert.match(JSON.stringify(slack), /Select choices by clicking buttons/);
+  assert.equal(slack.blocks.find((b) => b.type === 'actions'), undefined, 'no buttons at all');
+  assert.match(JSON.stringify(slack), /needs the terminal/);
 
   const discord = formatDiscord(evt);
-  assert.equal(discord.components[0].components.length, 2);
-  assert.match(JSON.stringify(discord), /Select choices below or reply in chat/);
+  assert.equal(discord.components, undefined);
+  assert.match(JSON.stringify(discord), /needs the terminal/);
+});
+
+test('a typed list asks for the numbers in chat', () => {
+  const evt = { ...APPROVAL, approvalToken: 'tok', options: [], menuPrompt: true, multiSelect: 'typed' };
+
+  assert.match(JSON.stringify(formatSlack(evt)), /option numbers/);
+  const discord = formatDiscord(evt);
+  assert.equal(discord.components, undefined);
+  assert.match(JSON.stringify(discord), /option numbers/);
 });
 
 test('a screen with real prose is still worth showing', () => {


### PR DESCRIPTION
A click carries one key. That answers a menu taking one option, but a prompt taking several was getting the same row of buttons, and pressing one sent a lone digit a checkbox menu ignores.

The hint under them was worse than the dead buttons. It invited a reply in chat, and a chat reply is pasted and submitted (`pastePromptInto` writes the text then `\r`), so the numbers landed as characters the menu ignored and the Enter confirmed whatever happened to be toggled — a wrong answer sent on the user's behalf.

## What changed

Two shapes wear the same "pick several" wording and take opposite input, so they are now told apart:

| shape | recognised by | how it is answered |
| --- | --- | --- |
| typed list | "separated by commas/spaces" | reply in chat with the numbers — a line plus a newline is exactly what it wants |
| checkbox menu | "space to toggle", "select all that apply" | at the terminal; arrow keys and a confirm are not something a click can carry |

- `chat-reply.multiSelectStyle()` returns `'typed' | 'toggle' | ''`, replacing the yes/no `isMultiSelect` (removed — nothing outside its own test still asked that question).
- The gateway offers no options for either shape, so no dead choice buttons are drawn.
- `webhook-format.answerHint()` gives Slack and Discord the same guidance with each one's bold syntax.

## Notes for review

- A webhook-only Discord target still gets the generic "answer in Klaussy". That path is handed the undecorated event on purpose, since a webhook rejects components — and it has no inbound socket to reply on anyway.
- The classifier only runs when interactivity is on (`wantsButtons`), which is the only case that could have drawn a button.

## Testing

`npm test` — 435 pass, 0 fail. New coverage: the two shapes are told apart (including the agent merely *saying* "select all that apply", which is not a prompt), a checkbox menu renders no buttons on either platform, and a dispatch of one carries no options to press.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
