### PR TITLE
feat(pr-review): humanize findings in-app, and fix four review-pane bugs

### DIFF
--- a/main/ipc/claude-stream-ipc.js
+++ b/main/ipc/claude-stream-ipc.js
@@ -20,8 +20,10 @@ const {
   spawnClaudeStream, makeClaudeCancelHandler,
   debugCheckProcs, fixCheckProcs, inlineEditProcs, inlineCompleteProcs, reviewSurfaceAiProcs,
   explainStreamProcs, aiReviewProcs, commitMsgProcs, reviewChatProcs,
-  investigateProcs,
+  investigateProcs, humanizeProcs,
 } = require('../state/claude-streaming');
+const { loadRules, cutPrompt, voicePrompt, checkPrompt } = require('../state/humanize-prompts');
+const { humanizeComment } = require('../util/humanize-comment');
 const {
   startImplementPty, writeImplementPty, resizeImplementPty, cancelImplementPty,
   getImplementSnapshot, getActiveImplementByWorktree,
@@ -764,4 +766,41 @@ SUGGESTED REPLY:
   const win = promptGoesOnStdin(claudeBin);
   return execHeadlessAgent(claudeBin, win ? ['-p'] : ['-p', prompt], { cwd: worktreePath, timeout: 60000 }, win ? prompt : null)
     .then((res) => (res.error ? { error: res.error } : { review: res.stdout.trim() }));
+});
+
+
+// --- Humanize: the model-driven passes of klaussy's humanize skill ------------
+//
+// One handler per pass; the renderer chains them, since main's done payload
+// carries no text. Rules come from the repo's scaffolded humanize skill when it
+// has one, so a repo that upgrades klaussy gets new rules without an app release.
+ipcMain.handle('humanize-pass-start', (event, { requestId, worktreePath, pass, text, question, original, provider } = {}) => {
+  if (!requestId) return { error: 'Missing requestId' };
+  if (!text || !text.trim()) return { error: 'Nothing to humanize' };
+  if (humanizeProcs.has(requestId)) return { error: 'Already running for ' + requestId };
+
+  const rules = loadRules(worktreePath);
+  let instructions;
+  if (pass === 'cut') instructions = cutPrompt(rules, { question });
+  else if (pass === 'voice') instructions = voicePrompt(rules);
+  else if (pass === 'check') instructions = checkPrompt(original || text);
+  else return { error: 'Unknown pass: ' + pass };
+
+  spawnClaudeStream({
+    requestId, procMap: humanizeProcs, channelPrefix: 'humanize-pass',
+    sender: event.sender,
+    cwd: worktreePath || process.cwd(),
+    prompt: instructions + '\n\n--- TEXT ---\n' + text,
+    provider: pickProvider(provider, defaultAgentProvider()),
+  });
+  return { ok: true };
+});
+
+ipcMain.handle('humanize-pass-cancel', makeClaudeCancelHandler(humanizeProcs));
+
+// Pass 4: the same deterministic scrubber the outbound-comment path uses, and
+// the one pass that always runs.
+ipcMain.handle('humanize-scrub', (_event, { text } = {}) => {
+  if (typeof text !== 'string') return { error: 'Nothing to scrub' };
+  return { text: humanizeComment(text) };
 });

--- a/main/state/claude-streaming.js
+++ b/main/state/claude-streaming.js
@@ -40,6 +40,7 @@ const aiReviewProcs = new Map();
 const commitMsgProcs = new Map();
 const reviewChatProcs = new Map();
 const investigateProcs = new Map();
+const humanizeProcs = new Map();
 
 // Lazy require to avoid a circular import between this module and windows.js
 // (windows.js doesn't import this today, but defer anyway for robustness).
@@ -311,4 +312,5 @@ module.exports = {
   commitMsgProcs,
   reviewChatProcs,
   investigateProcs,
+  humanizeProcs,
 };

--- a/main/state/humanize-prompts.js
+++ b/main/state/humanize-prompts.js
@@ -1,0 +1,136 @@
+// Prompts for the multi-pass humanize flow; the deterministic scrubber
+// (humanize-comment.js) is the last pass and runs in-process.
+//
+// Separate passes because with every rule in play at once only the safe
+// mechanical ones survive, and voice and length lose. Rules come from the repo's
+// scaffolded humanize skill when there is one; the fallback below mirrors
+// klaussy 0.25.0's block, so keep it in sync with `klaussy humanize --rules`.
+
+const fs = require('fs');
+const path = require('path');
+
+// Section headers in klaussy's HUMANIZE_BLOCK. Each pass takes only its own
+// sections; slicing by header keeps this working as the block's wording changes.
+const SECTIONS = {
+  voice: '**Voice: say it out loud.**',
+  shape: '**Shape: the smallest thing that carries the point.**',
+  answer: '**Answer what was asked, then stop.**',
+  mechanical: "**Don't (mechanical tells).**",
+  civil: '**Stay civil while you cut.**',
+};
+
+const FALLBACK_RULES = `**Voice: say it out loud.** The target is a competent engineer typing this once, in a hurry, who isn't going to read it back.
+
+- Write what you'd say standing at their desk.
+- Use contractions.
+- Verbs, not noun phrases: "this validates the token", not "this performs validation of the token".
+- Name the thing doing the work: "the retry loop eats the 429", not "error handling may result in suppression of the status".
+- Short common words: before not prior to, if not in the event that, can not is able to, use not utilize.
+- Fragments are fine. One idea per sentence.
+- Type it once and don't polish it. The last tell is evenness: every sentence complete, every paragraph the same shape. Let it be uneven.
+- Have a stance. First person and an opinion read as a person; a neutral summary reads as generated.
+- No em-dashes or en-dashes in prose. Use a comma or rewrite.
+
+**Shape: the smallest thing that carries the point.**
+
+- A thread reply is one sentence. A single review comment is one to three.
+- Lead with the change, not the discovery. Someone who reads one sentence should already be able to act.
+- Prose by default. No headings, tables, or bold field labels.
+- Three sentences to a paragraph.
+- No bookends. Don't restate the request, don't summarize what you just said.
+- Keep the concrete parts: a suggested diff, a command, a file:line, a version number.
+
+**Answer what was asked, then stop.**
+
+- No closing principle. Don't end by restating your decision as a general rule.
+- No mechanism they didn't ask for. If a paragraph doesn't change what the reader does next, cut it.
+- Grant a point in four words, or not at all. Never manufacture the agreement.
+
+**Stay civil while you cut.**
+
+- Critique the work, never the person.
+- Don't mirror the thread's tone. Answer as if it had been phrased civilly.`;
+
+// Pull one section out of a rules blob: from its header to the next header.
+function section(rules, key) {
+  const header = SECTIONS[key];
+  const start = rules.indexOf(header);
+  if (start === -1) return '';
+  const rest = Object.values(SECTIONS)
+    .map((h) => rules.indexOf(h, start + header.length))
+    .filter((i) => i !== -1);
+  const end = rest.length ? Math.min(...rest) : rules.length;
+  return rules.slice(start, end).trim();
+}
+
+// The repo's own humanize skill, if klaussy scaffolded one. Same lookup shape as
+// findRepoReviewSkill: match the `-humanize` suffix rather than rebuilding the
+// sanitized repo name.
+function findRepoHumanizeSkill(worktreePath) {
+  if (!worktreePath) return null;
+  try {
+    const skillsDir = path.join(worktreePath, '.claude', 'skills');
+    for (const e of fs.readdirSync(skillsDir, { withFileTypes: true })) {
+      if (!e.isDirectory() || !e.name.endsWith('-humanize')) continue;
+      const p = path.join(skillsDir, e.name, 'SKILL.md');
+      if (fs.existsSync(p)) return p;
+    }
+  } catch { /* no .claude/skills — use the built-in rules */ }
+  return null;
+}
+
+function loadRules(worktreePath) {
+  const skillPath = findRepoHumanizeSkill(worktreePath);
+  if (skillPath) {
+    try {
+      const text = fs.readFileSync(skillPath, 'utf-8');
+      // Only trust it if the sections we slice are actually present.
+      if (text.includes(SECTIONS.voice) && text.includes(SECTIONS.shape)) return text;
+    } catch { /* unreadable — fall through */ }
+  }
+  return FALLBACK_RULES;
+}
+
+// Pass 1: content only. Deleting, never restyling — a pass that rewrites here
+// spends its attention on wording and stops cutting.
+function cutPrompt(rules, { question } = {}) {
+  const asked = question
+    ? `The text answers this:\n${question}\n\nCut anything that doesn't answer it.\n\n`
+    : 'There is no explicit question. Cut anything that does not carry a decision, a fact the reader needs, or a concrete next step.\n\n';
+  return `Cut this text down to what earns its place. Delete whole sentences and paragraphs. `
+    + `Keep every sentence you keep WORD FOR WORD: this pass does not improve wording, and rewriting here means you stop cutting. `
+    + `Never touch code, identifiers, or anything inside backticks or fences. Output only the kept text.\n\n`
+    + asked
+    + section(rules, 'answer') + '\n\n' + section(rules, 'shape');
+}
+
+// Pass 2: register only. Facts are frozen so the cut pass's decisions stand.
+function voicePrompt(rules) {
+  return `Rewrite this in the voice below. Every fact that goes in comes out: add no claims, drop none, `
+    + `soften or strengthen none. If a sentence looks worth deleting, leave it, that decision was already made. `
+    + `Never reword code, identifiers, or anything inside backticks or fences. Output only the rewritten text.\n\n`
+    + section(rules, 'voice') + '\n\n' + section(rules, 'civil');
+}
+
+// Pass 3: the guard. The pass that changed the meaning can't be the one grading
+// it, so this compares against the original the user started from.
+function checkPrompt(original) {
+  return `Compare the rewrite against the original below, claim by claim, and fix any drift. Look for:\n\n`
+    + `- ADDED: anything asserted the original didn't say, a hedge that became a certainty, or agreement the author never gave.\n`
+    + `- DROPPED: a load-bearing noun, number, identifier, file path, or version. "We invalidated on every write" losing "the cache" is a failure even though it reads fine.\n`
+    + `- REVERSED: a concession that became a refusal, "may race" that became "races", a point that changed sides.\n\n`
+    + `Restore the original's meaning in the rewrite's voice. Do not re-expand it: fixing drift means putting back meaning, not words. `
+    + `Output only the corrected text, nothing else.\n\n`
+    + `--- ORIGINAL ---\n${original}\n--- END ORIGINAL ---`;
+}
+
+module.exports = {
+  FALLBACK_RULES,
+  SECTIONS,
+  section,
+  findRepoHumanizeSkill,
+  loadRules,
+  cutPrompt,
+  voicePrompt,
+  checkPrompt,
+};

--- a/main/state/review-prompts.js
+++ b/main/state/review-prompts.js
@@ -48,10 +48,12 @@ Structure the final response EXACTLY like this. Emit the review as a SINGLE JSON
 Rules for the JSON (follow exactly, the parser is strict):
 
 - It must be valid JSON: double-quoted keys and string values, no trailing commas, no comments. Escape any newline or double-quote that appears inside a string value so the JSON stays parseable. You may wrap the object in a json code fence; the parser accepts it with or without one.
-- path and line place the inline comment on GitHub, so they must be accurate. line is the line number in the file CURRENT (post-change) state that the comment attaches to. If you are not confident of the exact line, set line to null and the comment posts as a general PR comment instead of an inline one. side is "RIGHT" for added or existing code, "LEFT" only for a removed line.
+- path and line place the inline comment on GitHub, so they must be accurate. line is the line number in the file CURRENT (post-change) state that the comment attaches to. It must be a line the diff above actually touches (an added line, or a context line inside a hunk) — GitHub rejects an anchor outside the diff and the finding degrades to a floating comment. When the problem is on an unchanged line, anchor to the nearest line inside the hunk and say where the real problem sits in the body. If you are not confident of the exact line, set line to null and the comment posts as a general PR comment instead of an inline one. side is "RIGHT" for added or existing code, "LEFT" only for a removed line.
 - title is a short label shown on the card header. Do NOT repeat the severity or location in it.
 - body is the ONLY field posted to GitHub as the comment. Do NOT prefix it with the severity, location, category, or any bracketed header; those render from their own fields. Apply every Voice and style rule to it (no em dashes, no AI tells, terse, opinionated, first person where natural). Write it as if you are the human reviewer leaving the comment.
 - code is the original snippet the comment is about, quoted verbatim. Do NOT put your suggested fix in code; that goes in suggestion.
+- body must open with the reason the change is needed, in one or two sentences, since it is what leads the posted comment above the suggested change. Say what breaks and when, not what the suggestion does — the reader can see that from the diff.
+- suggestion is the change itself: a fenced \`\`\`suggestion block GitHub can apply, or prose when the fix isn't a literal replacement. Do NOT restate the rationale here; it already leads the comment.
 - Sort findings by severity: Blocker, then High, Medium, Low, Warn, Nit.
 - If there are zero findings, emit an empty findings array and still fill in summary.
 - Output nothing after the closing marker.`;

--- a/preload.js
+++ b/preload.js
@@ -405,6 +405,24 @@ contextBridge.exposeInMainWorld('klaus', {
       ipcRenderer.once(channel, handler);
       return () => ipcRenderer.removeListener(channel, handler);
     },
+    // The renderer chains cut -> voice -> check, then humanizeScrub for pass 4.
+    humanizePassStart: (requestId, opts) =>
+      ipcRenderer.invoke('humanize-pass-start', { requestId, ...opts }),
+    humanizePassCancel: (requestId) =>
+      ipcRenderer.invoke('humanize-pass-cancel', { requestId }),
+    onHumanizePassData: (requestId, callback) => {
+      const channel = 'humanize-pass-chunk-' + requestId;
+      const handler = (_e, chunk) => callback(chunk);
+      ipcRenderer.on(channel, handler);
+      return () => ipcRenderer.removeListener(channel, handler);
+    },
+    onHumanizePassDone: (requestId, callback) => {
+      const channel = 'humanize-pass-done-' + requestId;
+      const handler = (_e, data) => callback(data);
+      ipcRenderer.once(channel, handler);
+      return () => ipcRenderer.removeListener(channel, handler);
+    },
+    humanizeScrub: (text) => ipcRenderer.invoke('humanize-scrub', { text }),
     reviewInvestigateStart: (requestId, findingBody, provider) =>
       ipcRenderer.invoke('pr-review-investigate-start', { requestId, findingBody, provider }),
     reviewInvestigateCancel: (requestId) =>

--- a/renderer/finding-parser.js
+++ b/renderer/finding-parser.js
@@ -188,14 +188,21 @@ window.FindingParser = (function () {
   function looksLikeCode(s) {
     if (!s) return false;
     if (/```/.test(s)) return true;                 // agent already fenced it
-    if (/[{}]|=>|===|!==/.test(s)) return true;     // braces, arrows, strict-eq
+    // A sentence that quotes code inline ("use `[\p{L}\p{N}_]` with the `u`
+    // flag") is prose, so run the signal checks with those spans removed and
+    // punctuation inside them can't box an English sentence. Only when real
+    // words remain outside them, so an all-inline-code suggestion is still
+    // judged on its own text.
+    var stripped = s.replace(/`[^`\n]*`/g, ' ');
+    var probe = (stripped.match(/[A-Za-z]{2,}/g) || []).length >= 3 ? stripped : s;
+    if (/[{}]|=>|===|!==/.test(probe)) return true; // braces, arrows, strict-eq
     // A declaration or assignment line: `const x = …`, `foo.bar = …`.
-    if (/^\s*(const|let|var|function|class|import|export)\s/m.test(s)) return true;
-    if (/^\s*[\w$][\w$.[\]]*\s*=\s*\S/m.test(s)) return true;
+    if (/^\s*(const|let|var|function|class|import|export)\s/m.test(probe)) return true;
+    if (/^\s*[\w$][\w$.[\]]*\s*=\s*\S/m.test(probe)) return true;
     // A control-flow statement line — caught only when the line also carries
     // code punctuation before any sentence punctuation, so "If x is null,
     // return early." stays prose while "if (!user) return null;" is code.
-    if (/^\s*(if|for|while|switch|else|return|throw|await)\b[^.!?\n]*[(){};=]/m.test(s)) return true;
+    if (/^\s*(if|for|while|switch|else|return|throw|await)\b[^.!?\n]*[(){};=]/m.test(probe)) return true;
     return false;
   }
 
@@ -207,9 +214,19 @@ window.FindingParser = (function () {
     var body = String(obj.body == null ? '' : obj.body).trim();
     var suggestion = String(obj.suggestion == null ? '' : obj.suggestion).trim();
     if (!suggestion) return body;
-    var block = looksLikeCode(suggestion)
-      ? '```\n' + suggestion.replace(/^```[a-zA-Z0-9_-]*\n?/, '').replace(/\n?```$/, '') + '\n```'
-      : suggestion;
+    var block;
+    if (/```/.test(suggestion)) {
+      // Already fenced, possibly as prose wrapped around a code block ("Add to
+      // the same block:" then ```js …); another fence would let the inner one
+      // close it early and leak the markers as text. An unbalanced fence gets
+      // closed, since the renderer only matches complete pairs.
+      block = suggestion;
+      if ((suggestion.match(/```/g) || []).length % 2 === 1) block += '\n```';
+    } else if (looksLikeCode(suggestion)) {
+      block = '```\n' + suggestion + '\n```';
+    } else {
+      block = suggestion;
+    }
     return (body ? body + '\n\n' : '') + 'Suggested change:\n\n' + block;
   }
 

--- a/renderer/index.html
+++ b/renderer/index.html
@@ -781,6 +781,7 @@
   <script src="pr-review-findings.js"></script>
   <script src="pr-review-terminal.js"></script>
   <script src="pr-review-implement.js"></script>
+  <script src="pr-review-humanize.js"></script>
   <script src="pr-review-conversation.js"></script>
   <script src="pr-review-checks.js"></script>
   <script src="window-color.js"></script>

--- a/renderer/pr-review-findings.js
+++ b/renderer/pr-review-findings.js
@@ -233,19 +233,23 @@
   // override the hint and post the comment on the wrong line).
   //
   // Returns { line } if a confident match is found, null otherwise.
-  PR.findSnippetLineAcrossCandidates = function(fileContent, hintLine, candidates) {
+  PR.findSnippetLineAcrossCandidates = function(fileContent, hintLine, candidates, prefer) {
     var lines = fileContent.split('\n');
     var validCandidates = candidates
       .map(function (s) { return PR.normalizeLine(s); })
       .filter(function (s) { return s && s.length >= 4; });
     if (validCandidates.length === 0) return null;
 
-    // Direct hit: any candidate's text appears on the hint line itself.
-    if (hintLine && lines[hintLine - 1] != null) {
+    // Direct hit: any candidate's text appears on the hint line itself. When a
+    // preference is given and the hint line fails it (not part of the diff, so
+    // GitHub won't take it), keep looking — the scan below still ranks the hint
+    // line first among equals, so an unacceptable hit costs nothing.
+    if (hintLine && lines[hintLine - 1] != null
+        && (typeof prefer !== 'function' || prefer(hintLine))) {
       var hintLineContent = PR.normalizeLine(lines[hintLine - 1]);
       for (var c = 0; c < validCandidates.length; c++) {
         if (hintLineContent.indexOf(validCandidates[c]) !== -1) {
-          return { line: hintLine };
+          return { line: hintLine, preferred: true };
         }
       }
     }
@@ -268,7 +272,16 @@
     if (near.length === 0) return null;
     if (!hintLine) return { line: near[0] };
     near.sort(function (a, b) { return Math.abs(a - hintLine) - Math.abs(b - hintLine); });
-    return { line: near[0] };
+    // `prefer` (optional) marks which lines are usable anchors. Candidates come
+    // from every line of the finding's code block, so the closest match is often
+    // a neighbour sitting outside the diff, which costs the finding its inline
+    // anchor; take the closest match the caller accepts, else the closest overall.
+    if (typeof prefer === 'function') {
+      for (var pi = 0; pi < near.length; pi++) {
+        if (prefer(near[pi])) return { line: near[pi], preferred: true };
+      }
+    }
+    return { line: near[0], preferred: false };
   };
 
   // Verify each finding's line number by reading the file inside the
@@ -328,12 +341,25 @@
           return s && s.length >= 4 && !/^[\/*#\-]+$/.test(s);
         });
         if (f.locationRaw && f.locationRaw.snippet) candidates.push(f.locationRaw.snippet);
-        var match = PR.findSnippetLineAcrossCandidates(r.content, f.line, candidates);
+        var side = f.side || 'RIGHT';
+        var anchorable = function (ln) { return PR.isLineInDiff(diffText, f.path, ln, side); };
+        // The line the review cited, before any snippet match moves it. When
+        // it's already a valid anchor, no snippet match may cost us inline mode.
+        var citedLine = f.line;
+        var citedInDiff = !!diffText && anchorable(citedLine);
+        var match = PR.findSnippetLineAcrossCandidates(r.content, f.line, candidates, anchorable);
         // A snippet match only proves the line exists in the *current file*;
         // GitHub rejects inline anchors that aren't part of the PR diff (422
         // "line must be part of the diff"). Gate inline mode on the line
         // actually being in the diff and fall back to an issue comment otherwise.
-        var inDiff = match && PR.isLineInDiff(diffText, f.path, match.line, f.side || 'RIGHT');
+        var inDiff = match && PR.isLineInDiff(diffText, f.path, match.line, side);
+        if (match && !inDiff && citedInDiff) {
+          // The snippet resolved off the diff, but the cited line anchors fine.
+          // Keep it: an anchored comment on the reviewed line beats a floating
+          // one on a line GitHub won't take.
+          match = { line: citedLine };
+          inDiff = true;
+        }
         if (match && inDiff) {
           f.line = match.line;
           f.locationVerified = true;
@@ -373,10 +399,21 @@
             endLine: nStart + nLines.length - 1,
             text: nLines.join('\n'),
           };
+        } else if (citedInDiff) {
+          // No snippet match, but the cited line is part of the diff. The
+          // worktree can differ from the PR head (dirty tree, another branch
+          // checked out), so a failed text match isn't proof the location is
+          // wrong; anchor it, without a verified snippet.
+          f.line = citedLine;
+          f.locationVerified = true;
+          f.lineNotInDiff = false;
+          f.postMode = 'inline';
+          f.verifiedSnippet = null;
         } else {
-          // No match anywhere in the file — Claude probably hallucinated
-          // the location. Fall back to issue-comment mode so "Add to PR"
-          // still posts *something* useful rather than a broken inline.
+          // No match anywhere in the file and no anchorable cited line —
+          // Claude probably hallucinated the location. Fall back to
+          // issue-comment mode so "Add to PR" still posts something useful
+          // rather than a broken inline.
           f.locationVerified = false;
           f.lineNotInDiff = false;
           f.postMode = 'issue';

--- a/renderer/pr-review-humanize.js
+++ b/renderer/pr-review-humanize.js
@@ -1,0 +1,125 @@
+// Part of the PrReview surface (window.PrReview); see pr-review.js for the
+// core. Drives klaussy's multi-pass humanize over a finding's text: cut
+// (content), voice (register), check (did the meaning survive), scrub
+// (in-process regex, always runs). Separate model calls because one prompt
+// carrying every rule applies the safe mechanical ones and drops voice and
+// length. The chain lives here because the renderer already accumulates
+// streamed text (see startChat); main's done payload carries none.
+
+(function (PR) {
+
+  PR.HUMANIZE_PASSES = ['cut', 'voice', 'check'];
+
+  // Rejects on error so the chain stops and leaves the draft untouched.
+  PR.runHumanizePass = function(pass, text, opts) {
+    opts = opts || {};
+    return new Promise(function (resolve, reject) {
+      var requestId = 'hz-' + pass + '-' + Date.now() + '-' + Math.random().toString(36).slice(2, 8);
+      if (opts.onStart) opts.onStart(requestId);
+      var acc = '';
+      var unsubData = window.klaus.pr.onHumanizePassData(requestId, function (chunk) {
+        acc += chunk;
+      });
+      window.klaus.pr.onHumanizePassDone(requestId, function (result) {
+        if (unsubData) unsubData();
+        if (result && result.error) return reject(new Error(result.error));
+        if (result && result.cancelled) return reject(new Error('cancelled'));
+        var out = acc.trim();
+        if (!out) return reject(new Error(pass + ' pass returned nothing'));
+        resolve(out);
+      });
+      window.klaus.pr.humanizePassStart(requestId, {
+        worktreePath: PR.aiReview && PR.aiReview.worktreePath,
+        pass: pass,
+        text: text,
+        question: opts.question || null,
+        original: opts.original || null,
+      }).then(function (r) {
+        if (r && r.error) { if (unsubData) unsubData(); reject(new Error(r.error)); }
+      });
+    });
+  };
+
+  // `onProgress(pass, index)` drives the button label so a 3-call chain doesn't
+  // look like a hang.
+  PR.runHumanizeChain = async function(text, opts) {
+    opts = opts || {};
+    var original = text;
+    var current = text;
+    for (var i = 0; i < PR.HUMANIZE_PASSES.length; i++) {
+      var pass = PR.HUMANIZE_PASSES[i];
+      if (opts.onProgress) opts.onProgress(pass, i + 1);
+      current = await PR.runHumanizePass(pass, current, {
+        question: opts.question,
+        original: original,
+        onStart: opts.onStart,
+      });
+    }
+    if (opts.onProgress) opts.onProgress('scrub', 4);
+    var scrubbed = await window.klaus.pr.humanizeScrub(current);
+    if (scrubbed && scrubbed.text) current = scrubbed.text;
+    return { before: original, after: current };
+  };
+
+  // Keeps the original text so the card can offer Revert.
+  PR.humanizeFinding = function(f) {
+    if (f.humanizeBusy) return;
+    f.humanizeBusy = 'starting';
+    f.humanizeError = null;
+    PR.repaintAiReviewTab();
+
+    PR.runHumanizeChain(f.text, {
+      question: PR.humanizeQuestionFor(f),
+      onStart: function (requestId) { f.humanizeRequestId = requestId; },
+      onProgress: function (pass, n) {
+        f.humanizeBusy = pass + ' (' + n + '/4)';
+        PR.repaintAiReviewTab();
+      },
+    }).then(function (r) {
+      f.humanizeBefore = r.before;
+      f.text = r.after;
+      f.humanizeBusy = null;
+      f.humanizeRequestId = null;
+      PR.repaintAiReviewTab();
+      PR.saveAiReviewCache();
+      // Reshaping the text can move the quoted snippet, so the anchor has to be
+      // re-verified exactly as it is after a manual ✎ edit.
+      PR.verifyFindingLocations();
+    }).catch(function (err) {
+      f.humanizeBusy = null;
+      f.humanizeRequestId = null;
+      var msg = err && err.message ? err.message : String(err);
+      // Cancelling is a choice, not a failure — don't leave a red box behind.
+      f.humanizeError = msg === 'cancelled' ? null : msg;
+      PR.repaintAiReviewTab();
+    });
+  };
+
+  // The finding keeps whatever text it had, since nothing is written until all
+  // four passes finish.
+  PR.cancelHumanize = function(f) {
+    if (f.humanizeRequestId) window.klaus.pr.humanizePassCancel(f.humanizeRequestId);
+    f.humanizeBusy = null;
+    f.humanizeRequestId = null;
+    PR.repaintAiReviewTab();
+  };
+
+  // What the text is answering, which pass 1 cuts against: a finding answers
+  // "what's wrong at this location", so hand over the title and location.
+  PR.humanizeQuestionFor = function(f) {
+    var bits = [];
+    if (f.title) bits.push(f.title);
+    if (f.path) bits.push('at ' + f.path + (f.line ? ':' + f.line : ''));
+    return bits.length ? 'A code review comment about: ' + bits.join(' ') : null;
+  };
+
+  PR.revertHumanize = function(f) {
+    if (f.humanizeBefore == null) return;
+    f.text = f.humanizeBefore;
+    f.humanizeBefore = null;
+    PR.repaintAiReviewTab();
+    PR.saveAiReviewCache();
+    PR.verifyFindingLocations();
+  };
+
+})(window.PrReview);

--- a/renderer/pr-review-implement.js
+++ b/renderer/pr-review-implement.js
@@ -325,6 +325,33 @@
     return m ? text.slice(m.index + m[0].length).trim() : text.trim();
   };
 
+  // The prose above the "Suggested change:" label, capped at two sentences: the
+  // "why" that leads the posted comment, not the whole finding.
+  PR.findingWhyText = function(f) {
+    var text = (f && f.text) || '';
+    var m = text.match(/(?:^|\n)[ \t]*Suggested change:[ \t]*\n*/i);
+    var prose = (m ? text.slice(0, m.index) : text)
+      .replace(/```[\s\S]*?```/g, '')                 // fenced code
+      .replace(/^[ \t]*\*\*[^\n]*\*\*[ \t]*$/gm, '')  // severity/category/location line
+      .trim();
+    if (!prose) return '';
+    var sentences = prose.split(/(?<=[.!?])\s+/).filter(function (s) { return s.trim(); });
+    return sentences.slice(0, 2).join(' ').trim();
+  };
+
+  // What gets posted to GitHub: the why leads, because a reviewer reading the
+  // comment cold needs the reason before the diff.
+  PR.findingCommentBody = function(f) {
+    var why = PR.findingWhyText(f);
+    var suggestion = PR.findingSuggestionText(f);
+    if (!suggestion) return why;
+    // No label in the text at all means findingSuggestionText returned the
+    // whole body, which the why would duplicate.
+    if (!/(?:^|\n)[ \t]*Suggested change:/i.test((f && f.text) || '')) return suggestion;
+    if (!why) return suggestion;
+    return why + '\n\nSuggested change:\n' + suggestion;
+  };
+
   // Add a finding to the pending review. Both paths STAGE into pendingComments
   // (nothing posts until Submit review): verified findings draft inline,
   // unverified ones as an issueComment draft posted after the review.
@@ -341,9 +368,9 @@
       return;
     }
 
-    // Just the suggested change, staged as the reviewer's own words (no bot
-    // attribution). Body/severity/location stay on the card as reference.
-    var attributedBody = PR.findingSuggestionText(f);
+    // The why plus the suggested change, staged as the reviewer's own words
+    // (no bot attribution). Severity/location stay on the card as reference.
+    var attributedBody = PR.findingCommentBody(f);
     var entry = {
       id: 'pending-' + Date.now() + '-' + Math.random().toString(36).slice(2, 8),
       fromFindingId: f.id,
@@ -412,10 +439,10 @@
     if (PR.lastState) PR.render(PR.lastState);
   };
 
-  // Copy the same suggested-change text Add-to-PR posts, so paste matches send.
+  // Copy the same text Add-to-PR posts, so paste matches send.
   PR.copyFindingAsMarkdown = async function(f) {
     try {
-      await navigator.clipboard.writeText(PR.findingSuggestionText(f));
+      await navigator.clipboard.writeText(PR.findingCommentBody(f));
       f.copyStatus = 'copied';
       PR.repaintAiReviewTab();
       setTimeout(function () {
@@ -462,7 +489,10 @@
           }
         } catch (_) {}
       }
-      PR.repaintAiReviewTab();
+      // Patch just the streaming bubble. A full repaint here would rebuild the
+      // tab's HTML on every chunk, destroying the composer the user is typing
+      // in (losing text, caret, and selection mid-paste).
+      PR.updateChatStreamingBubble(f);
     });
     window.klaus.pr.onReviewChatDone(requestId, function (result) {
       if (unsubData) unsubData();
@@ -547,7 +577,8 @@
           }
         } catch (_) {}
       }
-      PR.repaintAiReviewTab();
+      // Same reason as startChat: patch the bubble, don't rebuild the tab.
+      PR.updateChatStreamingBubble(f);
     });
     window.klaus.pr.onReviewChatDone(agent.id, function (result) {
       if (unsubData) unsubData();

--- a/renderer/pr-review-terminal.js
+++ b/renderer/pr-review-terminal.js
@@ -462,6 +462,17 @@
       + (f.copyStatus === 'copied' ? '✓ Copied' : 'Copy')
     + '</button>';
 
+    // Humanize runs klaussy's four passes over the finding text. Three are
+    // model calls, so the label carries the pass number rather than a bare
+    // spinner.
+    var humanizeBtn = f.humanizeBusy
+      ? '<button class="pr-ai-finding-humanize" type="button" disabled>' + PR.escHtml(f.humanizeBusy) + '</button>'
+        + '<button class="pr-ai-finding-humanize-cancel" type="button">Cancel</button>'
+      : '<button class="pr-ai-finding-humanize" type="button" title="Cut, rewrite in a human voice, check nothing changed meaning, then scrub">Humanize</button>'
+        + (f.humanizeBefore != null
+            ? '<button class="pr-ai-finding-humanize-revert" type="button" title="Restore the text from before humanizing">Revert</button>'
+            : '');
+
     // Ask-Claude button. Toggles the inline chat panel so reviewers can
     // discuss the finding without leaving the card (e.g., "is this
     // actually a bug?", "what's the simplest fix?").
@@ -490,6 +501,13 @@
           + '<div class="pr-ai-finding-comment-error-body">' + PR.escHtml(f.commentError) + '</div>'
         + '</div>'
       : '';
+    // A failed pass leaves the text untouched, so this reports rather than warns.
+    if (f.humanizeError) {
+      errorBlock += '<div class="pr-ai-finding-comment-error">'
+          + '<div class="pr-ai-finding-comment-error-head">Humanize stopped, text unchanged</div>'
+          + '<div class="pr-ai-finding-comment-error-body">' + PR.escHtml(f.humanizeError) + '</div>'
+        + '</div>';
+    }
 
     var actions;
     if (f.ignored) {
@@ -498,11 +516,11 @@
       actions = commentBadge + copyBtn + '<button class="pr-ai-finding-cancel" type="button">Cancel</button>';
     } else if (f.status === 'implemented') {
       actions = '<span class="pr-ai-finding-status">\u2713 Implemented</span>'
-        + commentBadge + editedBadge + copyBtn + investigateBtn + discussBtn + editCommentBtn
+        + commentBadge + editedBadge + copyBtn + humanizeBtn + investigateBtn + discussBtn + editCommentBtn
         + commentBtn
         + '<button class="pr-ai-finding-redo" type="button" title="Run implement again">Implement again</button>';
     } else {
-      actions = commentBadge + editedBadge + copyBtn + investigateBtn + discussBtn + editCommentBtn
+      actions = commentBadge + editedBadge + copyBtn + humanizeBtn + investigateBtn + discussBtn + editCommentBtn
         + '<button class="pr-ai-finding-ignore" type="button">Ignore</button>'
         + commentBtn
         + '<button class="pr-ai-finding-implement" type="button" title="The agent updates the file and drafts a follow-up PR comment for your approval">Implement</button>';
@@ -798,6 +816,19 @@
       var copyBtnEl = card.querySelector('.pr-ai-finding-copy');
       if (copyBtnEl) copyBtnEl.addEventListener('click', function () { PR.copyFindingAsMarkdown(f); });
 
+      var humanizeBtnEl = card.querySelector('.pr-ai-finding-humanize');
+      if (humanizeBtnEl && !f.humanizeBusy) {
+        humanizeBtnEl.addEventListener('click', function () { PR.humanizeFinding(f); });
+      }
+      var humanizeRevertEl = card.querySelector('.pr-ai-finding-humanize-revert');
+      if (humanizeRevertEl) {
+        humanizeRevertEl.addEventListener('click', function () { PR.revertHumanize(f); });
+      }
+      var humanizeCancelEl = card.querySelector('.pr-ai-finding-humanize-cancel');
+      if (humanizeCancelEl) {
+        humanizeCancelEl.addEventListener('click', function () { PR.cancelHumanize(f); });
+      }
+
       // "Ask Claude" button toggles the inline chat panel.
       var discussBtnEl = card.querySelector('.pr-ai-finding-discuss');
       if (discussBtnEl) discussBtnEl.addEventListener('click', function () {
@@ -930,11 +961,82 @@
     if (PR.activeTab !== 'ai-review') return;
     var tab = PR.hostEl.querySelector('.pr-review-ai-tab');
     if (!tab) return;
+    // A repaint replaces the tab's HTML, including any chat composer the user
+    // is mid-sentence in. Carry the focused one's text and caret across.
+    var draft = PR.captureChatComposer(tab);
     tab.innerHTML = PR.renderAiReviewTab();
     PR.bindAiReviewTab();
+    PR.restoreChatComposer(tab, draft);
     // Update tab count badge as findings change.
     var tabBtn = PR.hostEl.querySelector('.pr-review-tab[data-tab="ai-review"]');
     if (tabBtn) tabBtn.innerHTML = 'AI Review' + PR.renderAiReviewTabCount();
+  };
+
+  // Read the focused chat composer's unsent text + caret, keyed by finding so
+  // it can be put back on the matching card after the repaint.
+  PR.captureChatComposer = function(tab) {
+    var el = tab.querySelector('.pr-ai-finding-chat-input');
+    var active = document.activeElement;
+    var focused = tab.contains(active) && active.classList
+      && active.classList.contains('pr-ai-finding-chat-input') ? active : null;
+    var target = focused || (el && el.value ? el : null);
+    if (!target) return null;
+    var card = target.closest('.pr-ai-finding');
+    return {
+      findingId: card && card.getAttribute('data-finding-id'),
+      value: target.value,
+      start: target.selectionStart,
+      end: target.selectionEnd,
+      focused: !!focused,
+    };
+  };
+
+  PR.restoreChatComposer = function(tab, draft) {
+    if (!draft || !draft.findingId || !draft.value) return;
+    var card = tab.querySelector('.pr-ai-finding[data-finding-id="' + draft.findingId + '"]');
+    var input = card && card.querySelector('.pr-ai-finding-chat-input');
+    if (!input) return;
+    input.value = draft.value;
+    if (draft.focused) {
+      input.focus();
+      try { input.setSelectionRange(draft.start, draft.end); } catch (_) {}
+    }
+  };
+
+  // Update only the streaming assistant bubble for one finding. Called per
+  // stream chunk instead of repaintAiReviewTab, which would rebuild the tab
+  // (and the composer) many times a second while the agent is talking.
+  PR.updateChatStreamingBubble = function(f) {
+    if (PR.activeTab !== 'ai-review' || !PR.hostEl) return;
+    var card = PR.hostEl.querySelector('.pr-ai-finding[data-finding-id="' + f.id + '"]');
+    var chat = card && card.querySelector('.pr-ai-finding-chat');
+    if (!chat) return; // panel isn't open; the done-handler's repaint will catch up
+    var list = chat.querySelector('.pr-ai-finding-chat-messages');
+    if (!list) {
+      var hint = chat.querySelector('.pr-ai-finding-chat-hint');
+      list = document.createElement('div');
+      list.className = 'pr-ai-finding-chat-messages';
+      if (hint) chat.replaceChild(list, hint);
+      else chat.insertBefore(list, chat.firstChild);
+    }
+    // Measure before mutating: only keep following the stream if the user
+    // hasn't scrolled up to re-read something.
+    var nearBottom = list.scrollHeight - list.scrollTop - list.clientHeight < 40;
+    var bubble = list.querySelector('.pr-ai-finding-chat-msg.assistant.streaming');
+    if (!bubble) {
+      bubble = document.createElement('div');
+      bubble.className = 'pr-ai-finding-chat-msg assistant streaming';
+      list.appendChild(bubble);
+    }
+    var text = (f.chatStreaming || '').trim();
+    if (text) {
+      bubble.classList.remove('status-pulse');
+      bubble.innerHTML = PR.renderMarkdown(f.chatStreaming);
+    } else {
+      bubble.classList.add('status-pulse');
+      bubble.textContent = 'Thinking…';
+    }
+    if (nearBottom) list.scrollTop = list.scrollHeight;
   };
 
   // Repaint just the Terminal tab body — used while the implement run's

--- a/test/util/finding-parser.test.js
+++ b/test/util/finding-parser.test.js
@@ -125,3 +125,56 @@ test('a backtick-wrapped JSON path is de-wrapped so it can anchor inline', () =>
   assert.equal(r.findings.length, 1);
   assert.equal(r.findings[0].path, 'src/server/index.js');
 });
+
+// A suggestion that quotes code inline inside a sentence used to be fenced as a
+// code block, because the braces in `[\p{L}\p{N}_]` matched the code heuristic.
+// The result rendered monospace and scrolled sideways instead of wrapping.
+function suggestionText(suggestion) {
+  const inner = JSON.stringify({
+    findings: [{ severity: 'Low', category: 'Readability', path: 'a.js', line: 1, side: 'RIGHT', title: 'T', code: 'x', body: 'Because it breaks on unicode.', suggestion }],
+    summary: { verdict: 'Comment', highestRisk: [], testCoverage: 'n/a' },
+  });
+  return FP.parseReviewFindings(wrap(inner)).findings[0].text;
+}
+
+test('a sentence quoting code inline stays prose', () => {
+  const text = suggestionText('Use `[\\p{L}\\p{N}_]` with the `u` flag in place of `\\w` for the lookbehinds here.');
+  assert.doesNotMatch(text, /```/, 'prose must not be fenced');
+  assert.match(text, /Use `\[/);
+});
+
+test('real code with braces is still fenced', () => {
+  const text = suggestionText('if (!user) {\n  return null;\n}');
+  assert.match(text, /```/);
+});
+
+test('a bare inline-code suggestion is judged on its own text', () => {
+  // Almost no words outside the span, so the span itself decides.
+  const text = suggestionText('`const cfg = { retries: 3 };`');
+  assert.match(text, /```/);
+});
+
+test('a plain sentence with no code stays prose', () => {
+  const text = suggestionText('Guard the null case before dereferencing.');
+  assert.doesNotMatch(text, /```/);
+});
+
+test('prose wrapped around a fenced block passes through intact', () => {
+  // Wrapping this in another fence made the inner ```js close the outer one,
+  // leaking "js" and a trailing ``` as literal text in the card.
+  const text = suggestionText("Add to the same block:\n```js\nassert.equal(f('a'), 'b');\n```");
+  assert.match(text, /Add to the same block:/);
+  assert.match(text, /```js\n/, 'inner fence keeps its language tag');
+  assert.equal((text.match(/```/g) || []).length, 2, 'exactly one fence pair');
+});
+
+test('an already-fenced suggestion is not double-fenced', () => {
+  const text = suggestionText('```\nconst x = 1;\n```');
+  assert.equal((text.match(/```/g) || []).length, 2);
+});
+
+test('an unbalanced fence is closed so the renderer can match it', () => {
+  const text = suggestionText('```js\nconst x = 1;');
+  assert.equal((text.match(/```/g) || []).length, 2);
+  assert.match(text, /```$/);
+});

--- a/test/util/humanize-prompts.test.js
+++ b/test/util/humanize-prompts.test.js
@@ -1,0 +1,82 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+const {
+  FALLBACK_RULES, SECTIONS, section, findRepoHumanizeSkill, loadRules,
+  cutPrompt, voicePrompt, checkPrompt,
+} = require('../../main/state/humanize-prompts');
+
+test('each pass gets only its own sections', () => {
+  const cut = cutPrompt(FALLBACK_RULES, {});
+  const voice = voicePrompt(FALLBACK_RULES);
+
+  // The whole point of the split: voice rules must not reach the cut pass, or
+  // it spends its attention rewriting instead of deleting.
+  assert.ok(cut.includes(SECTIONS.answer), 'cut pass keeps the answer rules');
+  assert.ok(cut.includes(SECTIONS.shape), 'cut pass keeps the shape rules');
+  assert.ok(!cut.includes(SECTIONS.voice), 'cut pass must not carry voice rules');
+
+  assert.ok(voice.includes(SECTIONS.voice), 'voice pass keeps the voice rules');
+  assert.ok(!voice.includes(SECTIONS.answer), 'voice pass must not carry cut rules');
+});
+
+test('section() stops at the next header', () => {
+  const voice = section(FALLBACK_RULES, 'voice');
+  assert.ok(voice.startsWith(SECTIONS.voice));
+  assert.ok(!voice.includes(SECTIONS.shape), 'ran past its own section');
+});
+
+test('section() returns empty for a header that is not there', () => {
+  assert.equal(section('no headers at all', 'voice'), '');
+});
+
+test('the cut pass is told what the text answers when we know', () => {
+  const withQ = cutPrompt(FALLBACK_RULES, { question: 'Why not use Shadow DOM?' });
+  assert.match(withQ, /Why not use Shadow DOM\?/);
+  const withoutQ = cutPrompt(FALLBACK_RULES, {});
+  assert.match(withoutQ, /no explicit question/i);
+});
+
+test('both rewriting passes are told to leave code alone', () => {
+  assert.match(cutPrompt(FALLBACK_RULES, {}), /backticks or fences/);
+  assert.match(voicePrompt(FALLBACK_RULES), /backticks or fences/);
+});
+
+test('the check pass carries the original to compare against', () => {
+  const p = checkPrompt('the original text here');
+  assert.match(p, /--- ORIGINAL ---/);
+  assert.match(p, /the original text here/);
+  assert.match(p, /ADDED/);
+  assert.match(p, /DROPPED/);
+  assert.match(p, /REVERSED/);
+  // Restoring meaning must not become an excuse to undo the cut pass.
+  assert.match(p, /Do not re-expand/);
+});
+
+test('the repo skill wins over the built-in rules when it has the sections', () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'hz-'));
+  const skill = path.join(dir, '.claude', 'skills', 'myrepo-humanize');
+  fs.mkdirSync(skill, { recursive: true });
+  const body = `${SECTIONS.voice} repo voice rules\n\n${SECTIONS.shape} repo shape rules`;
+  fs.writeFileSync(path.join(skill, 'SKILL.md'), body);
+
+  assert.ok(findRepoHumanizeSkill(dir), 'found the scaffolded skill');
+  assert.equal(loadRules(dir), body);
+});
+
+test('a skill missing the sections falls back rather than yielding empty passes', () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'hz-'));
+  const skill = path.join(dir, '.claude', 'skills', 'myrepo-humanize');
+  fs.mkdirSync(skill, { recursive: true });
+  fs.writeFileSync(path.join(skill, 'SKILL.md'), 'a skill from some older klaussy');
+
+  assert.equal(loadRules(dir), FALLBACK_RULES);
+});
+
+test('no worktree and no skill still produces usable prompts', () => {
+  assert.equal(loadRules(null), FALLBACK_RULES);
+  assert.ok(cutPrompt(loadRules(null), {}).length > 100);
+});

--- a/test/util/pr-review-anchoring.test.js
+++ b/test/util/pr-review-anchoring.test.js
@@ -1,0 +1,93 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+// pr-review-findings.js and pr-review-implement.js are renderer IIFEs that hang
+// their functions off the shared window.PrReview object. The pieces under test
+// (snippet matching, comment-body composition) touch no DOM, so a stub object is
+// enough to load them, the same trick finding-parser.test.js uses.
+global.window = global.window || {};
+window.PrReview = window.PrReview || {};
+window.PrReview._FP = {
+  sanitizeAiTone: (s) => s,
+  parseReviewFindings: () => ({}),
+  severityOf: () => 'low',
+  cleanPath: (p) => p,
+};
+require('../../renderer/pr-review-findings');
+require('../../renderer/pr-review-implement');
+const PR = window.PrReview;
+
+const FILE = [
+  'function retry(attempts) {',        // 1
+  '  for (let i = 0; i < attempts; i++) {', // 2
+  '    try {',                         // 3
+  '      return send();',              // 4
+  '    } catch (err) {',               // 5
+  '      log(err);',                   // 6
+  '    }',                             // 7
+  '  }',                               // 8
+  '}',                                 // 9
+].join('\n');
+
+test('snippet match prefers a line the caller accepts as an anchor', () => {
+  // Both line 3 ("try {") and line 7 ("}") are plausible matches for a code
+  // block; only line 6 is in the diff. Without a preference the matcher takes
+  // the closest, which here is the wrong, unanchorable one.
+  const inDiff = (ln) => ln === 6;
+  const m = PR.findSnippetLineAcrossCandidates(FILE, 5, ['log(err);', '} catch (err) {'], inDiff);
+  assert.equal(m.line, 6);
+  assert.equal(m.preferred, true);
+});
+
+test('falls back to the closest match when nothing is acceptable', () => {
+  const m = PR.findSnippetLineAcrossCandidates(FILE, 5, ['log(err);'], () => false);
+  assert.equal(m.line, 6);
+  assert.equal(m.preferred, false);
+});
+
+test('no preference function keeps the closest-match behaviour', () => {
+  const m = PR.findSnippetLineAcrossCandidates(FILE, 4, ['return send();']);
+  assert.equal(m.line, 4);
+});
+
+// --- posted comment body -----------------------------------------------------
+
+const FINDING = {
+  text: [
+    '**High · Correctness · `src/api.js:88`**',
+    '',
+    'The retry loop eats the 429, so a rate-limited call comes back looking fine.',
+    'It only shows up under load.',
+    '',
+    'Suggested change:',
+    '```suggestion',
+    '    if (attempt === last) throw err;',
+    '```',
+  ].join('\n'),
+};
+
+test('posted body leads with the why, then the suggested change', () => {
+  const body = PR.findingCommentBody(FINDING);
+  assert.match(body, /^The retry loop eats the 429/);
+  assert.ok(body.indexOf('Suggested change:') > 0, 'suggestion follows the why');
+  assert.ok(body.indexOf('```suggestion') > body.indexOf('Suggested change:'));
+  // The metadata line renders from its own fields; it must not be repeated.
+  assert.doesNotMatch(body, /High · Correctness/);
+});
+
+test('why is capped at two sentences', () => {
+  const wordy = {
+    text: 'One. Two. Three. Four.\n\nSuggested change:\nrename it',
+  };
+  assert.equal(PR.findingWhyText(wordy), 'One. Two.');
+});
+
+test('a finding with no suggestion label posts its text unchanged', () => {
+  const noLabel = { text: 'Rename `foo` to `bar`.' };
+  assert.equal(PR.findingCommentBody(noLabel), 'Rename `foo` to `bar`.');
+});
+
+test('a suggestion with no prose above it posts just the suggestion', () => {
+  const bare = { text: 'Suggested change:\n```suggestion\nx = 1;\n```' };
+  assert.equal(PR.findingCommentBody(bare), '```suggestion\nx = 1;\n```');
+});


### PR DESCRIPTION
## Summary

Adds a Humanize button to each AI-review finding, and fixes four things the review pane got wrong. All four bugs came out of actually using the pane, not from reading the code.

## Changes

**Humanize in-app.** A button on each finding runs klaussy's four passes: cut (content), voice (register), check (did the meaning survive), scrub (deterministic). They're separate model calls on purpose — one prompt carrying every rule reliably applies the safe mechanical ones and drops voice and length, which is why review prose still read as generated even after the rules improved. Each pass gets only its own sections, sliced out of the repo's own scaffolded `<repo>-humanize/SKILL.md` when it has one, so a repo that upgrades klaussy picks up new rules without an app release. Nothing is written until all four finish: a cancel or a failure leaves the text untouched, and Revert restores the pre-humanize version.

**Findings stopped floating.** The verifier searched the worktree for a finding's code snippet and, when the match landed on a different line within 50, overwrote the cited line with it — then demoted the finding to a general comment if that new line fell outside the diff. The cited line, which was often a perfectly good anchor, never got a second look. The matcher now takes a predicate and prefers the closest match that's actually in the diff, the direct-hit shortcut no longer skips that check, and a cited line that anchors fine survives both an off-diff snippet match and no match at all.

**Suggestions explain themselves.** Add-to-PR posted only the text under `Suggested change:`, so the reasoning never reached GitHub. The posted body now leads with the why; Copy sends the same text, since it's documented to match what posts.

**Chat stopped eating what you type.** The per-finding chat rebuilt the whole tab on every stream chunk, destroying the composer mid-sentence. Chunks now patch just the streaming bubble, and repaints triggered elsewhere save and restore the focused composer's text, caret and selection.

**Two suggestion-rendering bugs**, both from one heuristic. A sentence quoting code inline got boxed as a code block, because the braces in `` `[\p{L}\p{N}_]` `` matched the code test — prose rendered monospace and scrolled sideways. And a suggestion that already contained a fence got wrapped in another one, so the inner fence closed the outer early and leaked its markers as text.

Also nudged the review prompt: `line` must be part of the diff, `body` opens with the reason, `suggestion` doesn't restate it.

## Test Plan

- [x] Tests pass locally — 456, up from 437
- [x] Manually verified

16 new tests. `pr-review-anchoring.test.js` covers the matcher's preference behaviour and the composed comment body; one of them caught a gap in my first attempt at the anchoring fix (the direct-hit shortcut) that would otherwise have shipped. `humanize-prompts.test.js` asserts the pass separation directly — voice rules must never reach the cut pass, since that's what made it rewrite instead of delete — plus repo-skill discovery and the fallback when a skill predates the section headers.

Both fence bugs were reproduced from real screenshots and verified against the exact failing input.

## Checklist

- [x] Code follows project conventions (see CLAUDE.md)
- [x] No unrelated changes
- [x] Tests added/updated for new functionality
- [x] Documentation updated if needed

## Notes

One commit rather than two: the chat-repaint fix and the new Humanize button both live in `pr-review-terminal.js`, so they can't be split without interactive staging. Happy to split into two PRs if you'd rather review them separately.

The Humanize button costs three model calls per click and uses your default agent provider. It's wired to finding cards, which also covers what posts (Add-to-PR composes from the finding text). Chat replies and the PR-description / commit-message flows aren't wired yet — `PR.runHumanizeChain` takes any text, so those are button-and-handler work, not new plumbing.

The pre-commit review timed out and was skipped on this commit, so this diff hasn't been through that gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
