### PR TITLE
fix(repo-intel): keep klaussy tooling current, and regenerate when either CLI moves

### DIFF
--- a/main/state/repo-intel.js
+++ b/main/state/repo-intel.js
@@ -210,10 +210,34 @@ function getKlaussyCli() {
   return p;
 }
 
-// Lowest klaussy-agents version we treat as current — bump on any release we
-// want every repo to pick up, and the desktop prompts a one-click upgrade when
-// the installed CLI is below this floor (regeneration elsewhere keys on equality)
-const KLAUSSY_AGENTS_MIN_VERSION = '0.19.2';
+// "Current" comes from PyPI, not a pinned constant — a constant only moves when
+// the desktop ships, so it sat eight releases behind without telling anyone.
+const PYPI_LATEST_URL = 'https://pypi.org/pypi/klaussy-agents/json';
+const LATEST_TTL_MS = 6 * 60 * 60 * 1000;
+const LATEST_TIMEOUT_MS = 8000;
+let latestCache = { version: '', at: 0 };
+
+// '' when PyPI can't be reached — every caller reads that as "no reason to think
+// they're behind", so an offline launch doesn't nag.
+async function latestKlaussyVersion() {
+  if (latestCache.version && Date.now() - latestCache.at < LATEST_TTL_MS) return latestCache.version;
+  try {
+    const res = await fetch(PYPI_LATEST_URL, { signal: AbortSignal.timeout(LATEST_TIMEOUT_MS) });
+    if (!res.ok) return '';
+    const body = await res.json();
+    const version = (body && body.info && body.info.version) || '';
+    if (!version) return '';
+    latestCache = { version, at: Date.now() };
+    return version;
+  } catch {
+    return '';
+  }
+}
+
+// Tests only: the cache is process-wide and would carry one case into the next.
+function _resetLatestCache() {
+  latestCache = { version: '', at: 0 };
+}
 
 // Pull the first dotted numeric triple out of a `klaussy --version` string
 // ("klaussy, version 0.15.0" / "0.15.0" / "klaussy-agents 0.15.0" all parse).
@@ -470,6 +494,7 @@ async function upgradeReviewToolsIfDue() {
     const installer = await pickInstaller();
     if (!installer) return;
     const BIG = { timeout: 5 * 60 * 1000, maxBuffer: 16 * 1024 * 1024 };
+    let upgradeFailed = false;
     for (const t of TOOLS) {
       const pkg = t.pkg;
       // Upgrade with the manager that OWNS this tool — a blind `pipx upgrade`
@@ -492,13 +517,17 @@ async function upgradeReviewToolsIfDue() {
           }
         }
       } catch (e) {
-        // A single tool failing to upgrade (already latest, offline, etc.) is fine.
+        upgradeFailed = true;
         console.warn('[repo-intel] upgrade skipped for', pkg + ':', (e && e.message) || e);
       }
     }
-    const c2 = loadConfig();
-    c2.reviewToolsCheckedAt = Date.now();
-    saveConfig(c2);
+    // Stamping regardless would let a failed upgrade read as done and sit out
+    // another day, silently — the failures above are only warnings.
+    if (!upgradeFailed) {
+      const c2 = loadConfig();
+      c2.reviewToolsCheckedAt = Date.now();
+      saveConfig(c2);
+    }
     // A new CLI version invalidates the cached intel — bust the version cache so
     // the next ensureRepoIntel regenerates skills with the upgraded templates.
     klaussyCli = { bin: null, version: null, at: 0, promise: null };
@@ -514,17 +543,18 @@ async function upgradeReviewToolsIfDue() {
 // repeating it on every repo-intel run would just be noise.
 let outdatedNotified = false;
 
-// Emit a `tools-outdated` event when the installed klaussy-agents is below the
-// floor, so the renderer can offer a one-click upgrade — a MISSING CLI isn't
-// "outdated" (owned by the tools-failed toast), so stay quiet with no version
+// Offers a one-click upgrade when the install is behind what PyPI publishes. A
+// MISSING CLI isn't "outdated" (the tools-failed toast owns that), so with no
+// version it stays quiet.
 async function warnIfKlaussyOutdated() {
   try {
     if (outdatedNotified) return;
     const cli = await getKlaussyCli();
     if (!cli.version) return;
-    if (!versionBelow(cli.version, KLAUSSY_AGENTS_MIN_VERSION)) return;
+    const latest = await latestKlaussyVersion();
+    if (!latest || !versionBelow(cli.version, latest)) return;
     outdatedNotified = true;
-    notifyWindows({ type: 'tools-outdated', current: cli.version, min: KLAUSSY_AGENTS_MIN_VERSION });
+    notifyWindows({ type: 'tools-outdated', current: cli.version, min: latest });
   } catch { /* best-effort — a version probe hiccup shouldn't crash boot */ }
 }
 
@@ -540,8 +570,10 @@ async function upgradeReviewToolsNow() {
   await upgradeReviewToolsIfDue();
   let version = null;
   try { version = (await getKlaussyCli()).version; } catch { /* probe failed */ }
-  const ok = version ? !versionBelow(version, KLAUSSY_AGENTS_MIN_VERSION) : false;
-  return { version, min: KLAUSSY_AGENTS_MIN_VERSION, ok };
+  const latest = await latestKlaussyVersion();
+  // Unreachable PyPI can't convict a version that is installed and running.
+  const ok = version ? (!latest || !versionBelow(version, latest)) : false;
+  return { version, min: latest, ok };
 }
 
 // Resolve a worktree (or repo) path to its primary checkout — intel belongs
@@ -1285,4 +1317,4 @@ module.exports = { ensureRepoIntel, getRepoIntelBlock, syncIntelIntoWorktree, en
   // Exported for unit testing of the prompt-minimization logic (Item 4).
   loadStructuredIntel, ruleMatchesTouchedPaths, filterGraphSummary, assembleBlock,
   // Exported for unit testing of the version-floor comparison.
-  versionBelow, KLAUSSY_AGENTS_MIN_VERSION };
+  versionBelow, latestKlaussyVersion, _resetLatestCache };

--- a/main/state/repo-intel.js
+++ b/main/state/repo-intel.js
@@ -292,8 +292,9 @@ let toolsPromise = null;
 // same 1.4.x), so an existing `conventions` already satisfies it; we only
 // install the new dist on machines that lack the command, since reinstalling
 // over it would just collide on the pipx symlink for no behavior change.
+const CONVENTIONS_PKG = 'klaussy-repo-conventions';
 const TOOLS = [
-  { cmd: 'conventions', pkg: 'klaussy-repo-conventions' },
+  { cmd: 'conventions', pkg: CONVENTIONS_PKG },
   { cmd: 'klaussy', pkg: 'klaussy-agents' },
 ];
 
@@ -341,6 +342,16 @@ function listHasPkg(stdout, pkg) {
   return String(stdout || '').split('\n').some((line) => line.trim().split(/\s+/)[0] === pkg);
 }
 
+// The version token from the same two listings: `pipx list --short` prints
+// "<pkg> 1.7.0", `uv tool list` prints "<pkg> v1.7.0".
+function listPkgVersion(stdout, pkg) {
+  for (const line of String(stdout || '').split('\n')) {
+    const parts = line.trim().split(/\s+/);
+    if (parts[0] === pkg && parts[1]) return parts[1].replace(/^v/, '');
+  }
+  return '';
+}
+
 // Which isolated manager OWNS an already-installed tool (vs pickInstaller's
 // "what CAN install") — needed because a blind `pipx upgrade` on a uv-installed
 // tool silently no-ops. Returns { kind } or null (no owner); never throws
@@ -354,6 +365,41 @@ async function detectToolOwner(pkg) {
     if (listHasPkg(r.stdout, pkg)) return { kind: 'uv' };
   } catch { /* no uv, or nothing installed via it */ }
   return null;
+}
+
+// The conventions CLI has no --version flag, so its version comes from whichever
+// isolated manager owns it — and from neither on a pip --user install, which
+// answers '' for good.
+let conventionsCli = { version: '', at: 0, promise: null };
+function getConventionsVersion() {
+  if (conventionsCli.promise) return conventionsCli.promise;
+  if (conventionsCli.version) return Promise.resolve(conventionsCli.version);
+  if (Date.now() - conventionsCli.at < KLAUSSY_VERSION_NULL_TTL_MS) return Promise.resolve('');
+  const p = (async () => {
+    let version = '';
+    try {
+      const r = await execFileP('pipx', ['list', '--short'], { timeout: 15000 });
+      version = listPkgVersion(r.stdout, CONVENTIONS_PKG);
+    } catch { /* no pipx, or nothing installed via it */ }
+    if (!version) {
+      try {
+        const r = await execFileP('uv', ['tool', 'list'], { timeout: 15000 });
+        version = listPkgVersion(r.stdout, CONVENTIONS_PKG);
+      } catch { /* no uv either — stamp without it */ }
+    }
+    conventionsCli = { version, at: Date.now(), promise: null };
+    return version;
+  })();
+  conventionsCli.promise = p;
+  return p;
+}
+
+// The regeneration stamp: both CLIs shape the generated intel, so a bump in
+// either has to invalidate it — leaving conventions out held its new detectors
+// back until the weekly staleness window expired.
+function stampFor(cliVersion, conventionsVersion) {
+  if (!cliVersion) return '';
+  return conventionsVersion ? `${cliVersion}+conventions.${conventionsVersion}` : cliVersion;
 }
 
 // Bootstrap pipx itself when the machine has Python but no isolated installer.
@@ -462,6 +508,7 @@ function ensureReviewTools() {
     try { require('../bootstrap/app-events').refreshSpawnPath(); } catch {}
     // Drop the cached "missing" klaussy CLI so the next ensure re-probes.
     klaussyCli = { bin: null, version: null, at: 0, promise: null };
+    conventionsCli = { version: '', at: 0, promise: null };
 
     const ok = (await Promise.all(missing.map((t) => toolPresent(t.cmd)))).every(Boolean);
     if (ok) {
@@ -528,9 +575,10 @@ async function upgradeReviewToolsIfDue() {
       c2.reviewToolsCheckedAt = Date.now();
       saveConfig(c2);
     }
-    // A new CLI version invalidates the cached intel — bust the version cache so
+    // A new CLI version invalidates the cached intel — bust the version caches so
     // the next ensureRepoIntel regenerates skills with the upgraded templates.
     klaussyCli = { bin: null, version: null, at: 0, promise: null };
+    conventionsCli = { version: '', at: 0, promise: null };
     try { require('../bootstrap/app-events').refreshSpawnPath(); } catch {}
     console.log('[repo-intel] checked analysis tools for upgrades');
   } catch (e) {
@@ -1054,6 +1102,9 @@ function ensureRepoIntel(repoOrWorktreePath) {
       const toolsOk = await ensureReviewTools();
       const cli = await getKlaussyCli();
       const currentVersion = cli.version || '';
+      // currentVersion stays klaussy-only — it also guards the klaussy spawn
+      // below, which must not fire on a conventions-only machine.
+      const stamp = stampFor(currentVersion, await getConventionsVersion());
       const a = artifactPaths(base);
       // Heal a stale klausify-era settings.json on the base repo every run
       // (cache hit or full regen) — klaussy init won't, since it skips existing
@@ -1065,13 +1116,13 @@ function ensureRepoIntel(repoOrWorktreePath) {
 
       const haveArtifacts = fs.existsSync(a.rawJson);
       const freshEnough = haveArtifacts && (Date.now() - srcMtime < STALE_MS);
-      const sameVersion = stampedVersion !== null && stampedVersion === currentVersion;
+      const sameVersion = stampedVersion !== null && stampedVersion === stamp;
 
       if (freshEnough && sameVersion) {
         // Nothing to regenerate — but keep caches coherent, sync worktrees,
         // and STILL tell the user (silent cache hits read as "nothing ran").
         if (!memCache.has(base) || memCache.get(base).srcMtime < srcMtime) {
-          buildBlock(base, currentVersion);
+          buildBlock(base, stamp);
         }
         syncIntelIntoActiveWorktrees(base);
         // Announce the cache hit once per repo per app run — evidence
@@ -1200,7 +1251,7 @@ function ensureRepoIntel(repoOrWorktreePath) {
 
       // Stamp the version only on a fully completed run — an enrichment
       // failure leaves the '' stamp so the next session retries.
-      buildBlock(base, enrichFailed ? '' : currentVersion);
+      buildBlock(base, enrichFailed ? '' : stamp);
       syncIntelIntoActiveWorktrees(base);
       failedAt.delete(base);
       console.log('[repo-intel] generated for', base,
@@ -1317,4 +1368,6 @@ module.exports = { ensureRepoIntel, getRepoIntelBlock, syncIntelIntoWorktree, en
   // Exported for unit testing of the prompt-minimization logic (Item 4).
   loadStructuredIntel, ruleMatchesTouchedPaths, filterGraphSummary, assembleBlock,
   // Exported for unit testing of the version-floor comparison.
-  versionBelow, latestKlaussyVersion, _resetLatestCache };
+  versionBelow, latestKlaussyVersion, _resetLatestCache,
+  // Exported for unit testing of the regeneration stamp.
+  stampFor, listPkgVersion };

--- a/test/util/repo-intel-stamp.test.js
+++ b/test/util/repo-intel-stamp.test.js
@@ -1,0 +1,69 @@
+require('../setup');
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const { stampFor, listPkgVersion } = require('../../main/state/repo-intel');
+
+// The stamp decides whether ensureRepoIntel regenerates a repo's intel, so a
+// bump in either CLI has to change it — a conventions-only bump used to be
+// invisible until the weekly staleness window expired.
+
+test('a conventions bump alone changes the stamp', () => {
+  const before = stampFor('0.27.0', '1.6.0');
+  const after = stampFor('0.27.0', '1.7.0');
+  assert.notEqual(after, before, 'new detectors reach the repo on the next session');
+});
+
+test('a klaussy bump alone still changes the stamp', () => {
+  assert.notEqual(stampFor('0.28.0', '1.7.0'), stampFor('0.27.0', '1.7.0'));
+});
+
+test('an unchanged pair keeps the stamp stable', () => {
+  assert.equal(stampFor('0.27.0', '1.7.0'), stampFor('0.27.0', '1.7.0'),
+    'a stable stamp is what makes the cache hit');
+});
+
+test('no klaussy version stamps empty, which callers read as "no completed run"', () => {
+  assert.equal(stampFor('', '1.7.0'), '');
+  assert.equal(stampFor(null, '1.7.0'), '');
+});
+
+test('an unknown conventions version degrades to the klaussy-only stamp', () => {
+  // Neither manager lists a pip --user install, and falling back to the old
+  // stamp keeps those machines from regenerating forever.
+  assert.equal(stampFor('0.27.0', ''), '0.27.0');
+});
+
+test('the stamp survives the cache-comment round trip', () => {
+  // readDiskCache parses the stamp back with `cli:([^>]*)`, so one containing
+  // '>' would not survive; real stamps carry a space ("klaussy 0.27.0").
+  const stamp = stampFor('klaussy 0.27.0', '1.7.0');
+  const line = '<!-- src-mtime:123 cli:' + stamp + ' -->\nblock';
+  const m = line.match(/^<!-- src-mtime:([\d.]+)(?: cli:([^>]*))? -->\n/);
+  assert.ok(m, 'the comment still parses');
+  assert.equal((m[2] || '').trim(), stamp);
+});
+
+test('an old klaussy-only stamp no longer matches, so upgraded repos regenerate once', () => {
+  // What every existing cache file on disk holds today.
+  assert.notEqual(stampFor('klaussy 0.27.0', '1.7.0'), 'klaussy 0.27.0');
+});
+
+test('listPkgVersion reads the version out of both managers\' listings', () => {
+  assert.equal(listPkgVersion('klaussy-repo-conventions 1.7.0', 'klaussy-repo-conventions'), '1.7.0');
+  // uv prefixes a 'v'; the stamp must not treat "v1.7.0" and "1.7.0" as a bump.
+  assert.equal(listPkgVersion('klaussy-repo-conventions v1.7.0', 'klaussy-repo-conventions'), '1.7.0');
+});
+
+test('listPkgVersion matches the whole package name, not a prefix', () => {
+  const listing = 'klaussy-agents 0.27.0\nklaussy-repo-conventions 1.7.0';
+  assert.equal(listPkgVersion(listing, 'klaussy-repo-conventions'), '1.7.0');
+  assert.equal(listPkgVersion(listing, 'klaussy'), '', 'a prefix is not a match');
+});
+
+test('listPkgVersion yields nothing when the package is absent or unversioned', () => {
+  assert.equal(listPkgVersion('klaussy-agents 0.27.0', 'klaussy-repo-conventions'), '');
+  assert.equal(listPkgVersion('', 'klaussy-repo-conventions'), '');
+  assert.equal(listPkgVersion(null, 'klaussy-repo-conventions'), '');
+  assert.equal(listPkgVersion('klaussy-repo-conventions', 'klaussy-repo-conventions'), '');
+});

--- a/test/util/repo-intel-version-floor.test.js
+++ b/test/util/repo-intel-version-floor.test.js
@@ -2,7 +2,18 @@ require('../setup');
 
 const test = require('node:test');
 const assert = require('node:assert/strict');
-const { versionBelow, KLAUSSY_AGENTS_MIN_VERSION } = require('../../main/state/repo-intel');
+const {
+  versionBelow, latestKlaussyVersion, _resetLatestCache,
+} = require('../../main/state/repo-intel');
+
+function stubFetch(handler) {
+  const real = global.fetch;
+  const calls = [];
+  global.fetch = async (url, init) => { calls.push(String(url)); return handler(String(url), init); };
+  return { calls, restore() { global.fetch = real; } };
+}
+
+const okJson = (obj) => ({ ok: true, status: 200, json: async () => obj });
 
 // versionBelow gates the "out of date" prompt: parse a triple from whatever
 // `klaussy --version` prints, compare per-component (not lexically), and stay
@@ -40,6 +51,61 @@ test('versionBelow: unparseable input is never "below" (no false nag)', () => {
   assert.equal(versionBelow('0.15.0', 'not-a-version'), false);
 });
 
-test('KLAUSSY_AGENTS_MIN_VERSION is a parseable semver triple', () => {
-  assert.match(KLAUSSY_AGENTS_MIN_VERSION, /^\d+\.\d+\.\d+$/);
+test('the latest version comes from what PyPI publishes', async () => {
+  _resetLatestCache();
+  const f = stubFetch(() => okJson({ info: { version: '0.27.0' } }));
+  try {
+    assert.equal(await latestKlaussyVersion(), '0.27.0');
+    assert.equal(versionBelow('0.19.2', '0.27.0'), true, 'the old floor is itself behind');
+  } finally {
+    f.restore();
+  }
+});
+
+test('the answer is cached rather than asked on every check', async () => {
+  _resetLatestCache();
+  const f = stubFetch(() => okJson({ info: { version: '0.27.0' } }));
+  try {
+    await latestKlaussyVersion();
+    await latestKlaussyVersion();
+    assert.equal(f.calls.length, 1, 'PyPI is asked once, not once per caller');
+  } finally {
+    f.restore();
+  }
+});
+
+test('an unreachable or unhelpful PyPI yields no version, and no nag', async () => {
+  const cases = [
+    ['network down', () => { throw new Error('getaddrinfo ENOTFOUND pypi.org'); }],
+    ['http error', () => ({ ok: false, status: 503, json: async () => ({}) })],
+    ['no version in payload', () => okJson({ info: {} })],
+    ['malformed body', () => ({ ok: true, status: 200, json: async () => { throw new Error('bad json'); } })],
+  ];
+  for (const [name, handler] of cases) {
+    _resetLatestCache();
+    const f = stubFetch(handler);
+    try {
+      const latest = await latestKlaussyVersion();
+      assert.equal(latest, '', name + ' yields no version');
+      assert.equal(versionBelow('0.1.0', latest), false, name + ' cannot convict an install');
+    } finally {
+      f.restore();
+    }
+  }
+});
+
+test('a failed lookup is not cached as the answer', async () => {
+  _resetLatestCache();
+  const down = stubFetch(() => { throw new Error('offline'); });
+  try {
+    assert.equal(await latestKlaussyVersion(), '');
+  } finally {
+    down.restore();
+  }
+  const back = stubFetch(() => okJson({ info: { version: '0.27.0' } }));
+  try {
+    assert.equal(await latestKlaussyVersion(), '0.27.0', 'the next check asks again');
+  } finally {
+    back.restore();
+  }
 });


### PR DESCRIPTION
Having klaussy tooling current locally is what makes sessions conventions-aware. Three things could leave a machine on stale skills without telling anyone.

## The version we called "current" was a constant

`KLAUSSY_AGENTS_MIN_VERSION` read `0.19.2` while PyPI was on `0.27.0` — eight releases, six of them shipped in the last five days. A constant only moves when the desktop ships, so it drifts by construction.

That gap matters because the floor was the *only* user-visible signal. Anyone between `0.19.2` and `0.27.0` was below latest and above the floor, which is the one state that prompts nothing at all.

It now asks PyPI what the newest release is, cached for six hours.

## A failed upgrade still counted as "checked"

`upgradeReviewToolsIfDue` stamped `reviewToolsCheckedAt` unconditionally, after a loop whose per-tool failures are swallowed with `console.warn`. Offline, no permission, a manager that doesn't own the install — each recorded as done and sat the machine out for another 24h, silently.

Only a run that upgraded everything counts as having checked. A machine that *can't* upgrade now retries next launch, which is exactly when retrying is worth doing.

## A conventions release couldn't invalidate anything

The regeneration stamp carried only the klaussy-agents version. `upgradeReviewToolsIfDue` upgrades **both** CLIs, so a klaussy-repo-conventions release does land on the machine within a day — but `ensureRepoIntel` would keep serving cached intel generated by the older one, because the stamp hadn't changed. Its new detectors reached an already-generated repo only when the 7-day staleness window expired.

This was not hypothetical: `klaussy-repo-conventions` 1.7.0 adds `api_routes` / `db_entities` detection across six language families. Without this, repos users touch regularly are the ones that wait longest for it, since active repos keep their artifacts fresh.

The stamp now carries both versions. Two details worth noting:

- **`currentVersion` stays klaussy-only on purpose.** It also guards the `klaussy init` spawn, so folding conventions into it would make it truthy on a machine that has `conventions` but not `klaussy`, and the spawn would ENOENT. The stamp is a separate value used only for cache comparison.
- **The conventions CLI has no `--version` flag**, so its version is parsed out of the `pipx list --short` / `uv tool list` output that `detectToolOwner` already reads. `uv`'s `v` prefix is stripped so `v1.7.0` and `1.7.0` aren't read as a bump.

Both edges keep their existing behavior: no klaussy version still stamps `''` ("no completed run"), and an unknown conventions version — a `pip --user` install, which neither manager lists — degrades to exactly the old klaussy-only stamp rather than regenerating forever.

## Why this and not just a higher floor

The upgrade path already targets latest — `pipx upgrade` / `uv tool upgrade` / `pip -U`, all unpinned. Users go stale when that silently fails, not because the target is wrong. Raising the constant would have papered over the lockout; these changes make failing to reach latest both visible and retried.

Sessions still install-if-missing (`ensureRepoIntel` → `ensureReviewTools`) and still never upgrade — unchanged here, and fine, since a fresh install is unpinned and lands on latest.

## Offline behavior

`latestKlaussyVersion()` returns `''` when PyPI can't be reached, and every caller reads that as "no reason to think they're behind":

- `warnIfKlaussyOutdated` stays silent rather than nagging about a number it couldn't check
- `upgradeReviewToolsNow` reports `ok` for an install it can't convict

## Tradeoffs worth a look

**Retry cadence.** Not stamping on failure means a persistently broken upgrade retries every launch instead of daily. That's intended — it's the case where retrying is the point — but each attempt carries a 5-minute timeout per tool, so a long-offline machine does that work at every start. Happy to gate it behind a shorter backoff instead if you'd rather.

**One-time regeneration.** Existing cache files hold `cli:klaussy 0.27.0` and won't match the new composite format, so every repo regenerates once on the first session after this lands. That's the mechanism that delivers the 1.7.0 detectors immediately instead of up to a week later, but it is a real one-time cost on the first session per repo.

**Still uncovered.** The currency check itself remains klaussy-agents-only (`PYPI_LATEST_URL`), so a `klaussy-repo-conventions` install that falls behind gets no toast — it relies entirely on the silent daily upgrade. Worth widening separately.

## Testing

`npm test` — 484 pass, 0 fail. `npm run lint` clean.

New coverage for the floor: latest comes from PyPI, the answer is cached rather than re-fetched, a failed lookup isn't cached as the answer, and four flavors of unreachable/unhelpful PyPI each yield no version and no nag. Verified against real PyPI: returns `0.27.0`, matching the installed CLI, so someone already current gets nothing.

New coverage for the stamp (`test/util/repo-intel-stamp.test.js`): a bump in either CLI changes it, an unchanged pair keeps it stable, the `''` and unknown-conventions edges degrade as described, both managers' listing formats parse, a package name matches whole rather than by prefix, and the composite survives the `<!-- src-mtime:N cli:VER -->` round trip that `readDiskCache` parses with `cli:([^>]*)`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
