### PR TITLE
fix(session-context): write the one field OKF actually requires

### DIFF
--- a/docs/session-context-sharing-plan.md
+++ b/docs/session-context-sharing-plan.md
@@ -15,7 +15,7 @@
 
 ### Key Goals
 - **Session-Scoped & Uncommitted:** Context lives in local app storage outside of Git tracking (`~/.klaussy/sessions/<channel>/notes/`).
-- **Vendor-Neutral Format:** Use the Open Knowledge Format (OKF) standard—YAML frontmatter + Markdown body—as the inter-agent data exchange contract.
+- **Vendor-Neutral Format:** Use [Open Knowledge Format](https://github.com/GoogleCloudPlatform/knowledge-catalog/blob/main/okf/SPEC.md) (OKF) documents—YAML frontmatter + Markdown body—as the inter-agent data exchange contract. OKF requires only `type`; the remaining fields below are our own extensions, which the spec permits (consumers "MUST NOT reject documents with unrecognized fields").
 - **Provider-Agnostic:** Any CLI agent provider spawned by `klaussy-desktop` can easily read and write OKF notes via simple file operations or environment variables.
 
 ---
@@ -62,16 +62,18 @@ meet, which is the one thing this feature exists to prevent.
 `KLAUSSY_SESSION_ID` identifies the writing terminal in note metadata only.
 
 ### 3.2 OKF Note Schema (`<agent-name>_<timestamp>.md`)
-Every session note created by an agent or system service adheres to the following specification:
+Every session note created by an agent or system service carries the following frontmatter. `type` is the OKF-required key; everything else is a klaussy extension.
 
 ```markdown
 ---
+type: session-note
 id: note-1785128240
 session_id: sess_abc123
 agent: claude-code
 provider: anthropic
-worktree: feature/auth-refactor
+worktree: /Users/me/klaussy/sessions/auth-refactor/api
 timestamp: 2026-07-27T10:00:00Z
+stale_after: 2026-07-31
 affected_files:
   - main/ipc/auth.js
   - renderer/components/login.jsx

--- a/main/state/session-context.js
+++ b/main/state/session-context.js
@@ -13,6 +13,10 @@ const notesDirCache = new Map(); // worktreePath -> notes dir
 // gates prompt injection only, where an agent mid-task cannot tell a
 // three-week-old claim from a current one.
 const NOTE_FRESH_MS = 72 * 60 * 60 * 1000;
+// OKF requires `type` and nothing else, so a note carrying just this is
+// already conformant (okf.md).
+const NOTE_TYPE = 'session-note';
+const DAY_MS = 24 * 60 * 60 * 1000;
 // Shares the handoff seed with a transcript and a git brief, so notes take a
 // slice comparable to session-handoff's MAX_TRANSCRIPT_CHARS.
 const MAX_SUMMARY_CHARS = 12000;
@@ -134,6 +138,23 @@ function parseFrontmatter(content) {
   return { metadata, body };
 }
 
+// OKF's expiry is a date and the window it describes is not, so round up: a date
+// rounded down calls a note stale while the window still treats it as live.
+function staleAfter(timestamp) {
+  const at = new Date(timestamp).getTime();
+  if (!at) return '';
+  return new Date(at + NOTE_FRESH_MS + DAY_MS).toISOString().slice(0, 10);
+}
+
+// A note may declare its own expiry, including one written by a tool that is not
+// klaussy; an absent or unparseable date just falls through to the window.
+function declaredStale(metadata, now) {
+  const raw = metadata && metadata.stale_after;
+  if (!raw) return false;
+  const day = new Date(`${String(raw).slice(0, 10)}T00:00:00Z`).getTime();
+  return !!day && now >= day;
+}
+
 function writeSessionNote(worktreePath, noteData) {
   const dir = ensureSessionNotesDir(worktreePath);
   const timestamp = noteData.timestamp || new Date().toISOString();
@@ -142,15 +163,18 @@ function writeSessionNote(worktreePath, noteData) {
   const filePath = path.join(dir, `${id}.md`);
 
   const metadata = {
+    type: noteData.type || NOTE_TYPE,
     id,
     session_id: noteData.session_id || 'default',
     agent: noteData.agent || 'unknown',
     provider: noteData.provider || 'unknown',
     worktree: worktreePath || '',
     timestamp,
+    stale_after: staleAfter(timestamp),
     affected_files: Array.isArray(noteData.affected_files) ? noteData.affected_files : [],
     tags: Array.isArray(noteData.tags) ? noteData.tags : [],
   };
+  if (noteData.title) metadata.title = noteData.title;
 
   const titleHeader = noteData.title ? `# ${noteData.title}\n\n` : '';
   const bodyText = noteData.content || noteData.body || '';
@@ -209,8 +233,10 @@ function formatList(value) {
 function buildSessionContextSummary(worktreePath) {
   // Only the fresh ones: an old note stays readable in the drawer, where its
   // age is on screen, but must not reach an agent's prompt as current fact.
-  const cutoff = Date.now() - NOTE_FRESH_MS;
-  const notes = listSessionNotes(worktreePath).filter((n) => n.writtenAt >= cutoff);
+  const now = Date.now();
+  const cutoff = now - NOTE_FRESH_MS;
+  const notes = listSessionNotes(worktreePath)
+    .filter((n) => n.writtenAt >= cutoff && !declaredStale(n.metadata, now));
   if (!notes.length) return '';
 
   const items = notes.map((n, i) => {

--- a/test/util/session-context.test.js
+++ b/test/util/session-context.test.js
@@ -244,6 +244,42 @@ test('an old note is kept and still listed', () => {
   assert.ok(fs.existsSync(stale), 'notes are never deleted behind your back');
 });
 
+test('every note carries the one field OKF requires', () => {
+  const repo = makeRepo();
+  const note = writeSessionNote(repo, { id: 'typed', content: 'x' });
+
+  assert.equal(note.metadata.type, 'session-note');
+  const onDisk = parseFrontmatter(fs.readFileSync(note.filePath, 'utf8')).metadata;
+  assert.equal(onDisk.type, 'session-note');
+});
+
+test('the published expiry never precedes the freshness window', () => {
+  const repo = makeRepo();
+  const almostStale = new Date(Date.now() - NOTE_FRESH_MS + 3600000).toISOString();
+  const note = writeSessionNote(repo, { id: 'edge', content: 'still live', timestamp: almostStale });
+
+  assert.match(note.metadata.stale_after, /^\d{4}-\d{2}-\d{2}$/);
+  const declared = new Date(`${note.metadata.stale_after}T00:00:00Z`).getTime();
+  assert.ok(declared > Date.now(), 'a live note must not publish a past expiry');
+  assert.match(buildSessionContextSummary(repo), /still live/);
+});
+
+test('a note that declares itself stale is not injected, whatever its age', () => {
+  const repo = makeRepo();
+  const dir = ensureSessionNotesDir(repo);
+  fs.writeFileSync(path.join(dir, 'expired.md'), [
+    '---',
+    'type: session-note',
+    'agent: some-other-tool',
+    'stale_after: 2020-01-01',
+    '---',
+    'this claim expired years ago',
+  ].join('\n'));
+
+  assert.equal(listSessionNotes(repo).length, 1, 'still on disk and in the drawer');
+  assert.equal(buildSessionContextSummary(repo), '', 'but not in an agent prompt');
+});
+
 test('a note past the freshness window is not injected into prompts', () => {
   const repo = makeRepo();
   const old = new Date(Date.now() - NOTE_FRESH_MS - 60000).toISOString();


### PR DESCRIPTION
## Summary

Our session notes have been called Open Knowledge Format documents in `CLAUDE.md`, in the session-context skill, and in `docs/session-context-sharing-plan.md`, which described it as adopting a standard. They were not conformant.

[OKF](https://github.com/GoogleCloudPlatform/knowledge-catalog/blob/main/okf/SPEC.md) names `type` as the only always-required key ("a concept carrying just `type` is fully conformant"). Every note we wrote carried eight fields of our own invention and not that one. Nothing failed, which is why it stood for months: the tests passed and the feature worked. It surfaced only from re-reading the spec while writing a public article about the format.

## Changes

- `writeSessionNote` emits `type: session-note`, plus `title` when one is given (a recommended OKF key we already had in hand).
- `writeSessionNote` emits `stale_after`, the spec's lifecycle field. The spec wants an absolute date and explicitly rejects relative TTLs. The objection that an agent cannot know when its own claim expires is answered by the app computing the date rather than the agent guessing one.
- `buildSessionContextSummary` honours a declared `stale_after`, so expiry is a property of the note rather than of our code, and a note left by a tool that is not klaussy expires on its own terms. A note without one still falls through to the existing freshness window.
- Plan doc no longer claims conformance to a standard it did not meet, and its example matches what the code actually writes (`worktree` held a branch name in the doc and an absolute path in reality).

`stale_after` rounds **up** to the next whole day. A date comparison has day granularity and `NOTE_FRESH_MS` does not, so rounding down would publish an expiry while the window that gates prompt injection still treats the note as live.

Extra keys are legal: OKF requires that consumers "MUST preserve unknown keys when round-tripping and MUST NOT reject documents with unrecognized fields." A missing required key is not.

## Test Plan

- `npm run test` — 538 pass (3 new), `npm run lint` clean.
- New tests: every note carries `type`; the published expiry never precedes the freshness window (the rounding bug, if `staleAfter` is ever "simplified"); a note declaring itself stale is kept on disk and in the drawer but withheld from prompts.
- Existing freshness, retention and channel tests unchanged and passing.

## Checklist

- [x] Tests pass locally
- [x] Lint clean
- [x] No behaviour change for notes already on disk (a note with no `stale_after` uses the window exactly as before)
- [ ] Needs a release: v0.16.0 shipped without this, so installed builds still write notes lacking `type`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
