### PR TITLE
feat(session-context): use OKF's provenance, trust and lifecycle keys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,35 @@
 
 All notable changes to Klaussy Desktop are documented here.
 
+## 0.17.0
+
+### 🔏 Notes say who wrote them and whether anyone checked
+
+Session notes carried `type` from 0.16.1 but kept hand-rolled versions of three
+things OKF already defines, so a tool that wasn't ours could read the envelope
+and still miss who wrote a note or whether anyone had confirmed it.
+
+- `agent` and `provider` are now one `generated: { by, at }` key, using OKF's
+  actor convention. Klaussy writes `klaussy/gemini`, the harness and the agent
+  it was driving.
+- Trust comes from `verified` alone. A note with no `verified` key is
+  unverified, which is the right state for one an agent just wrote, and a
+  `human:<id>` actor means a person checked it. Only the exception is labelled
+  in the injected block, since stamping "unverified" on every note is noise an
+  agent learns to skip.
+- `status: deprecated` behaves like an expired note, kept in the drawer and
+  withheld from prompts, so a superseded note can say so instead of waiting out
+  `stale_after`.
+- The frontmatter parser reads flow mappings, since OKF writes provenance as
+  `{ by: x, at: y }` and an agent quotes that into valid JSON roughly never.
+  Splitting each pair on its first colon leaves actors like `human:sdover`
+  intact.
+- The older `agent` and `provider` keys are still read, so notes already on
+  disk stay valid.
+
+Needs `klaussy-agents` 0.29.0 and `klaussy-repo-conventions` 1.9.0, which teach
+the same keys to the agents writing notes by hand.
+
 ## 0.16.1
 
 ### 📎 Session notes are real OKF documents now

--- a/main/state/session-context.js
+++ b/main/state/session-context.js
@@ -91,15 +91,30 @@ function serializeFrontmatter(meta) {
   return lines.join('\n');
 }
 
+const unquote = (s) => s.trim().replace(/^['"]|['"]$/g, '');
+
+// A flow mapping is only JSON when an agent quotes it, so split each pair on the
+// FIRST colon — an actor is itself colon-shaped (`human:sdover`).
+function parseFlowMap(body) {
+  const out = {};
+  for (const pair of body.split(',')) {
+    const idx = pair.indexOf(':');
+    if (idx === -1) continue;
+    const key = unquote(pair.slice(0, idx));
+    if (key) out[key] = unquote(pair.slice(idx + 1));
+  }
+  return Object.keys(out).length ? out : body.trim();
+}
+
 // Notes are hand-written by agents, so a flow sequence arrives as often
 // unquoted (`tags: [ports]`) as valid JSON (`tags: ["ports"]`).
 function parseScalar(raw) {
   try { return JSON.parse(raw); } catch { /* not JSON — keep reading */ }
+  const map = raw.match(/^\{(.*)\}$/s);
+  if (map) return parseFlowMap(map[1]);
   const flow = raw.match(/^\[(.*)\]$/s);
   if (!flow) return raw;
-  return flow[1].split(',')
-    .map((item) => item.trim().replace(/^['"]|['"]$/g, ''))
-    .filter(Boolean);
+  return flow[1].split(',').map(unquote).filter(Boolean);
 }
 
 function parseFrontmatter(content) {
@@ -162,12 +177,14 @@ function writeSessionNote(worktreePath, noteData) {
   const id = sanitizeSegment(noteData.id || generatedId, generatedId);
   const filePath = path.join(dir, `${id}.md`);
 
+  const agent = noteData.agent || 'unknown';
+  const provider = noteData.provider || 'unknown';
   const metadata = {
     type: noteData.type || NOTE_TYPE,
     id,
     session_id: noteData.session_id || 'default',
-    agent: noteData.agent || 'unknown',
-    provider: noteData.provider || 'unknown',
+    // OKF's actor convention: one string, `<provider>/<agent>`.
+    generated: { by: `${provider}/${agent}`, at: timestamp },
     worktree: worktreePath || '',
     timestamp,
     stale_after: staleAfter(timestamp),
@@ -175,6 +192,8 @@ function writeSessionNote(worktreePath, noteData) {
     tags: Array.isArray(noteData.tags) ? noteData.tags : [],
   };
   if (noteData.title) metadata.title = noteData.title;
+  if (noteData.status) metadata.status = noteData.status;
+  if (noteData.verified) metadata.verified = noteData.verified;
 
   const titleHeader = noteData.title ? `# ${noteData.title}\n\n` : '';
   const bodyText = noteData.content || noteData.body || '';
@@ -191,6 +210,25 @@ function writeSessionNote(worktreePath, noteData) {
   };
 }
 
+// Back-fill the agent/provider spelling readers still use, leaving a legacy
+// note's own keys intact.
+function normalizeActor(metadata) {
+  const by = metadata.generated && metadata.generated.by;
+  if (!by || metadata.agent) return;
+  const slash = String(by).indexOf('/');
+  metadata.provider = slash === -1 ? '' : by.slice(0, slash);
+  metadata.agent = slash === -1 ? by : by.slice(slash + 1);
+}
+
+// OKF derives trust from `verified` alone: absent means nobody has confirmed it.
+function trustOf(metadata) {
+  const raw = metadata && metadata.verified;
+  const entries = Array.isArray(raw) ? raw : (raw ? [raw] : []);
+  if (!entries.length) return 'unverified';
+  const human = entries.some((e) => /^human:/.test(String((e && e.by) || '')));
+  return human ? 'human-reviewed' : 'machine-confirmed';
+}
+
 function listSessionNotes(worktreePath) {
   const dir = ensureSessionNotesDir(worktreePath);
   const files = fs.readdirSync(dir).filter((f) => f.endsWith('.md'));
@@ -201,9 +239,11 @@ function listSessionNotes(worktreePath) {
       const filePath = path.join(dir, file);
       const content = fs.readFileSync(filePath, 'utf8');
       const { metadata, body } = parseFrontmatter(content);
+      normalizeActor(metadata);
       // The documented frontmatter carries no timestamp, so mtime is what keeps
       // newest-first ordering meaningful.
-      const stamped = new Date(metadata.timestamp || 0).getTime();
+      const generatedAt = metadata.generated && metadata.generated.at;
+      const stamped = new Date(metadata.timestamp || generatedAt || 0).getTime();
       const writtenAt = stamped || fs.statSync(filePath).mtimeMs;
 
       notes.push({
@@ -212,6 +252,7 @@ function listSessionNotes(worktreePath) {
         metadata,
         body,
         writtenAt,
+        trust: trustOf(metadata),
       });
     } catch {
       // skip unparseable / already-removed files
@@ -236,18 +277,23 @@ function buildSessionContextSummary(worktreePath) {
   const now = Date.now();
   const cutoff = now - NOTE_FRESH_MS;
   const notes = listSessionNotes(worktreePath)
-    .filter((n) => n.writtenAt >= cutoff && !declaredStale(n.metadata, now));
+    .filter((n) => n.writtenAt >= cutoff
+      && !declaredStale(n.metadata, now)
+      // A note whose author marked it superseded is history, not current state.
+      && (n.metadata || {}).status !== 'deprecated');
   if (!notes.length) return '';
 
   const items = notes.map((n, i) => {
     const meta = n.metadata || {};
     const agentInfo = meta.agent ? `[Agent: ${meta.agent}${meta.provider ? ` (${meta.provider})` : ''}]` : '';
+    // Unverified is the norm, so labelling it on every note would be noise.
+    const trustInfo = n.trust && n.trust !== 'unverified' ? ` [${n.trust}]` : '';
     const files = formatList(meta.affected_files);
     const tags = formatList(meta.tags);
     const filesInfo = files ? `\nAffected files: ${files}` : '';
     const tagsInfo = tags ? `\nTags: ${tags}` : '';
     const when = meta.timestamp || new Date(n.writtenAt).toISOString();
-    return `--- Note ${i + 1} (${when}) ${agentInfo} ---${filesInfo}${tagsInfo}\n${n.body}`;
+    return `--- Note ${i + 1} (${when}) ${agentInfo}${trustInfo} ---${filesInfo}${tagsInfo}\n${n.body}`;
   });
 
   // Drop whole notes from the oldest end rather than truncating mid-note, which

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "klaussy-desktop",
   "productName": "Klaussy",
-  "version": "0.16.1",
+  "version": "0.17.0",
   "description": "Multi-terminal Claude Code worktree manager + GitHub PR reviewer for macOS, Windows, and Linux",
   "main": "main.js",
   "author": {

--- a/test/util/session-context.test.js
+++ b/test/util/session-context.test.js
@@ -244,6 +244,81 @@ test('an old note is kept and still listed', () => {
   assert.ok(fs.existsSync(stale), 'notes are never deleted behind your back');
 });
 
+test('provenance is written in the OKF actor convention', () => {
+  const repo = makeRepo();
+  const note = writeSessionNote(repo, { id: 'prov', agent: 'gemini', provider: 'klaussy', content: 'x' });
+
+  assert.equal(note.metadata.generated.by, 'klaussy/gemini');
+  assert.equal(note.metadata.generated.at, note.metadata.timestamp);
+
+  const [read] = listSessionNotes(repo);
+  assert.equal(read.metadata.generated.by, 'klaussy/gemini');
+  assert.equal(read.metadata.agent, 'gemini', 'the drawer still gets an agent');
+  assert.equal(read.metadata.provider, 'klaussy');
+});
+
+test('a note using the legacy agent and provider keys still reads', () => {
+  const repo = makeRepo();
+  const dir = ensureSessionNotesDir(repo);
+  fs.writeFileSync(path.join(dir, 'legacy.md'), [
+    '---', 'agent: claude-code', 'provider: anthropic', '---', 'port moved',
+  ].join('\n'));
+
+  const [note] = listSessionNotes(repo);
+  assert.equal(note.metadata.agent, 'claude-code');
+  assert.equal(note.trust, 'unverified');
+  assert.match(buildSessionContextSummary(repo), /\[Agent: claude-code \(anthropic\)\]/);
+});
+
+// OKF writes provenance as a flow mapping, which an agent will rarely quote.
+test('an unquoted flow mapping parses', () => {
+  const repo = makeRepo();
+  const dir = ensureSessionNotesDir(repo);
+  fs.writeFileSync(path.join(dir, 'flow.md'), [
+    '---',
+    'type: session-note',
+    'generated: { by: reference_agent/gemini-2.5-pro, at: 2026-06-20T22:53:05Z }',
+    '---',
+    'written by another tool',
+  ].join('\n'));
+
+  const [note] = listSessionNotes(repo);
+  assert.equal(note.metadata.generated.by, 'reference_agent/gemini-2.5-pro');
+  assert.equal(note.metadata.generated.at, '2026-06-20T22:53:05Z');
+  assert.equal(note.metadata.agent, 'gemini-2.5-pro', 'actor splits into a display name');
+});
+
+test('trust tiers follow the spec', () => {
+  const repo = makeRepo();
+  const dir = ensureSessionNotesDir(repo);
+  const write = (name, verified) => fs.writeFileSync(path.join(dir, name),
+    `---\ntype: session-note\nagent: a\n${verified}---\nclaim\n`);
+
+  write('none.md', '');
+  write('machine.md', 'verified: { by: process:nightly, at: 2026-08-17T09:00:00Z }\n');
+  write('human.md', 'verified: { by: human:sdover, at: 2026-08-17T09:00:00Z }\n');
+
+  const byId = Object.fromEntries(listSessionNotes(repo).map((n) => [n.id, n.trust]));
+  assert.equal(byId.none, 'unverified');
+  assert.equal(byId.machine, 'machine-confirmed');
+  assert.equal(byId.human, 'human-reviewed');
+
+  const summary = buildSessionContextSummary(repo);
+  assert.match(summary, /\[human-reviewed\]/);
+  assert.ok(!summary.includes('[unverified]'), 'the norm is not worth labelling');
+});
+
+test('a note marked deprecated is kept but withheld from prompts', () => {
+  const repo = makeRepo();
+  writeSessionNote(repo, { id: 'old-plan', content: 'we are going with option A', status: 'deprecated' });
+  writeSessionNote(repo, { id: 'new-plan', content: 'option B in the end' });
+
+  assert.equal(listSessionNotes(repo).length, 2, 'still on disk and in the drawer');
+  const summary = buildSessionContextSummary(repo);
+  assert.match(summary, /option B in the end/);
+  assert.ok(!summary.includes('option A'), 'superseded notes do not reach a prompt');
+});
+
 test('every note carries the one field OKF requires', () => {
   const repo = makeRepo();
   const note = writeSessionNote(repo, { id: 'typed', content: 'x' });


### PR DESCRIPTION
Session notes carried `type` after 0.16.1 but kept hand-rolled versions of three things the spec already defines.

- `agent` and `provider` become `generated: { by, at }`, using OKF's actor convention (`klaussy/gemini`, the harness and the agent it was driving).
- Trust tiers derive from `verified` alone. No key means nobody confirmed it, which is the honest state for a note an agent just wrote, and a `human:<id>` actor means a person checked it. Only the exception gets labelled in the injected block, since stamping "unverified" on every note is noise an agent learns to skip.
- `status: deprecated` now behaves like an expired note, kept in the drawer and withheld from prompts, so a superseded note can say so instead of waiting out `stale_after`.

The parser needed flow mappings for this. OKF writes provenance as `{ by: x, at: y }`, and an agent quotes that into valid JSON roughly never, so each pair splits on its first colon. That leaves actors like `human:sdover` intact.

The older `agent` and `provider` keys are still read, so notes already on disk stay valid.

543 tests pass and lint is clean. The commit adds 75 lines of tests covering the flow-mapping parser, the trust tiers and the deprecated handling.

Still needed before release: a CHANGELOG entry and a `package.json` bump to 0.17.0.

Pairs with the `feat/okf-provenance-trust` branches in klaussy-agents and klaussy-repo-conventions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
