### PR TITLE
fix(gh-error, pr-review): stop misreporting two GitHub failures

### DIFF
--- a/main/ipc/pr-review-comments.js
+++ b/main/ipc/pr-review-comments.js
@@ -9,6 +9,7 @@ const { execFile, execFileSync, spawn } = require('child_process');
 const { ghExec, ghExecP, resolveGhEnv, appendStderr, execFileP } = require('../util/exec');
 const { ghJson, ghText } = require('../util/gh-json');
 const { humanizeComment } = require('../util/humanize-comment');
+const { isEmptyReview, ghApiErrorMessage } = require('../util/review-payload');
 const {
   prReview, currentRepoPath, sanitizePrReview, broadcastPrReview, fetchThreadsForActive,
 } = require('../state/pr-review');
@@ -263,6 +264,13 @@ ipcMain.handle('pr-submit-review', async (_event, { event, body, comments }) => 
     }),
   };
 
+  // Every draft may have fallen through to an issue comment, leaving an empty
+  // COMMENT review that 422s and drops the issue comments with it.
+  const skipReview = isEmptyReview(payload);
+  if (skipReview && !issueCommentDrafts.some((d) => d.body && d.body.trim())) {
+    return { error: 'Nothing to submit — add a summary or a comment first.' };
+  }
+
   const cwd = currentRepoPath() || require('os').homedir();
   const endpoint = `repos/${baseOwner}/${baseRepo}/pulls/${number}/reviews`;
   // `spawn` is imported at the top of the file.
@@ -274,7 +282,7 @@ ipcMain.handle('pr-submit-review', async (_event, { event, body, comments }) => 
       path: c.path, line: c.line, start_line: c.start_line, side: c.side,
     }))));
 
-  const reviewResult = await new Promise((resolve) => {
+  const reviewResult = skipReview ? { ok: true } : await new Promise((resolve) => {
     const proc = spawn('gh', ['api', endpoint, '--method', 'POST', '--input', '-'], {
       cwd,
       env: reviewGhEnv(cwd),
@@ -287,13 +295,7 @@ ipcMain.handle('pr-submit-review', async (_event, { event, body, comments }) => 
     proc.on('exit', (code) => {
       if (code !== 0) {
         // gh often writes JSON errors to stdout on non-zero exit.
-        let msg = stderrBuf.trim();
-        if (stdoutBuf) {
-          try {
-            const parsed = JSON.parse(stdoutBuf);
-            if (parsed.message) msg = parsed.message + (parsed.errors ? ': ' + JSON.stringify(parsed.errors) : '');
-          } catch (_) {}
-        }
+        let msg = ghApiErrorMessage(stdoutBuf, stderrBuf);
         log.warn('[pr-submit-review] failed code=' + code,
           'stderr=' + stderrBuf.trim(), 'stdout=' + stdoutBuf.trim());
         // GitHub blocks approve / request-changes on your own PR. Surface the
@@ -324,6 +326,7 @@ ipcMain.handle('pr-submit-review', async (_event, { event, body, comments }) => 
   // can retry manually.
   const issueEndpoint = `repos/${baseOwner}/${baseRepo}/issues/${number}/comments`;
   const issueCommentFailures = [];
+  let issueCommentsPosted = 0;
   for (const draft of issueCommentDrafts) {
     if (!draft.body || !draft.body.trim()) continue;
     const res = await new Promise((resolve) => {
@@ -354,12 +357,19 @@ ipcMain.handle('pr-submit-review', async (_event, { event, body, comments }) => 
       proc.stdin.end();
     });
     if (res.error) issueCommentFailures.push(res.error);
+    else issueCommentsPosted += 1;
   }
 
   if (issueCommentFailures.length) {
+    // With the review skipped, the comments were the whole submission — if none
+    // landed, nothing reached the PR and this is a failure, not a warning.
+    if (skipReview && issueCommentsPosted === 0) {
+      return { error: `Nothing was posted: ${issueCommentFailures.join('; ')}` };
+    }
+    const led = skipReview ? '' : 'Review posted, but ';
     return {
       ok: true,
-      warning: `Review posted, but ${issueCommentFailures.length} follow-up comment(s) failed: ${issueCommentFailures.join('; ')}`,
+      warning: `${led}${issueCommentFailures.length} follow-up comment(s) failed: ${issueCommentFailures.join('; ')}`,
     };
   }
   return { ok: true };

--- a/main/util/gh-error.js
+++ b/main/util/gh-error.js
@@ -35,6 +35,22 @@ function parseGhAccount(text) {
   return m ? m[1] : null;
 }
 
+// gh prefers a token in the environment over every account it has stored, so
+// while one of these is set, `gh auth switch` cannot change which credential
+// is used. Returns the variable name in force, or null.
+function envTokenVar() {
+  if (process.env.GH_TOKEN) return 'GH_TOKEN';
+  if (process.env.GITHUB_TOKEN) return 'GITHUB_TOKEN';
+  return null;
+}
+
+// A repo outside a fine-grained PAT's allow-list answers with a plain 404, the
+// same response GitHub gives for a repo that doesn't exist — which is why the
+// account gets blamed for a token's limits.
+function isFineGrainedPat(value) {
+  return /^github_pat_/.test(String(value == null ? '' : value));
+}
+
 // Classify a raw error message. `ctx` may carry { target: 'owner/repo' } for a
 // more specific summary. Returns { kind, summary, fix, retryable }.
 function classifyGhError(raw, ctx = {}) {
@@ -85,9 +101,25 @@ function classifyGhError(raw, ctx = {}) {
     };
   }
   if (has(/could not resolve to a|http 404|not found|resource not accessible|http 403/i)) {
+    const what = ctx.target || 'this repo';
+    const envVar = envTokenVar();
+    if (envVar) {
+      const fine = isFineGrainedPat(process.env[envVar]);
+      return {
+        kind: 'not-found',
+        summary: `GitHub can't see ${what} with the token in $${envVar}.`
+          + (fine ? ' That is a fine-grained PAT, which only reaches repositories it was granted.' : '')
+          + ` gh uses that token instead of any signed-in account, so switching accounts won't help.`,
+        fix: `unset ${envVar}   # gh falls back to the signed-in account\n`
+          + (fine
+            ? `# or grant ${what} to the token at github.com/settings/personal-access-tokens`
+            : `# or reissue the token with access to ${what}`),
+        retryable: false,
+      };
+    }
     return {
       kind: 'not-found',
-      summary: `GitHub can't see ${ctx.target || 'this repo'} for the signed-in account.${acctNote} Likely the wrong gh account is active, or it lacks access.`,
+      summary: `GitHub can't see ${what} for the signed-in account.${acctNote} Likely the wrong gh account is active, or it lacks access.`,
       fix: acct
         ? `gh auth status            # confirm the account\ngh auth switch            # switch to the account with access`
         : 'gh auth login            # sign in with the account that has access',
@@ -118,4 +150,4 @@ function classifyGhError(raw, ctx = {}) {
   };
 }
 
-module.exports = { classifyGhError, activeGhAccount };
+module.exports = { classifyGhError, activeGhAccount, envTokenVar };

--- a/main/util/review-payload.js
+++ b/main/util/review-payload.js
@@ -1,0 +1,34 @@
+// Helpers for the "submit review" payload. Kept out of the IPC handler so they
+// can be unit-tested without stubbing electron.
+
+// A COMMENT review with no inline comments and no summary is one GitHub refuses
+// with an opaque 422. APPROVE and REQUEST_CHANGES carry a verdict, so an empty
+// body there is still a real review.
+function isEmptyReview({ event, comments, body }) {
+  return event === 'COMMENT'
+    && (!comments || comments.length === 0)
+    && !String(body == null ? '' : body).trim();
+}
+
+// gh writes its JSON error to stdout on a non-zero exit. Turn that into a
+// message worth reading: GitHub's validation errors are often an array of empty
+// strings, and appending `: [""]` to the summary only adds noise.
+function ghApiErrorMessage(stdout, stderr) {
+  const fallback = String(stderr == null ? '' : stderr).trim();
+  const raw = String(stdout == null ? '' : stdout).trim();
+  if (!raw) return fallback;
+  let parsed;
+  try {
+    parsed = JSON.parse(raw);
+  } catch (_) {
+    return fallback;
+  }
+  if (!parsed || !parsed.message) return fallback;
+  const errors = Array.isArray(parsed.errors)
+    ? parsed.errors.filter((e) => (typeof e === 'string' ? e.trim() : e != null))
+    : parsed.errors;
+  const hasDetail = Array.isArray(errors) ? errors.length > 0 : !!errors;
+  return parsed.message + (hasDetail ? ': ' + JSON.stringify(errors) : '');
+}
+
+module.exports = { isEmptyReview, ghApiErrorMessage };

--- a/test/util/gh-error.test.js
+++ b/test/util/gh-error.test.js
@@ -61,3 +61,70 @@ test('SSO and scope errors are unaffected by the outage branch', () => {
   assert.equal(classifyGhError('SAML enforcement').kind, 'sso');
   assert.equal(classifyGhError('missing required scopes').kind, 'scope');
 });
+
+// --- an env token overrides the signed-in account -------------------------
+
+function withEnv(vars, fn) {
+  const saved = {};
+  for (const k of ['GH_TOKEN', 'GITHUB_TOKEN']) {
+    saved[k] = process.env[k];
+    delete process.env[k];
+  }
+  Object.assign(process.env, vars);
+  try {
+    return fn();
+  } finally {
+    for (const k of ['GH_TOKEN', 'GITHUB_TOKEN']) {
+      if (saved[k] === undefined) delete process.env[k];
+      else process.env[k] = saved[k];
+    }
+  }
+}
+
+// The reported bug: a PAT's 404 was blamed on the account, advising `gh auth
+// switch`, which gh ignores while GH_TOKEN is set.
+test('a 404 under GH_TOKEN blames the token, not the account', () => {
+  const cls = withEnv({ GH_TOKEN: 'github_pat_11ABCDEF' }, () => classifyGhError(
+    "GraphQL: Could not resolve to a Repository with the name 'steph-dove/interview-train'. (repository)",
+    { target: 'steph-dove/interview-train' },
+  ));
+
+  assert.strictEqual(cls.kind, 'not-found');
+  assert.match(cls.summary, /\$GH_TOKEN/);
+  assert.match(cls.summary, /fine-grained PAT/);
+  assert.match(cls.summary, /switching accounts won't help/);
+  assert.match(cls.fix, /unset GH_TOKEN/);
+  // The advice that cannot work must not be offered.
+  assert.doesNotMatch(cls.fix, /gh auth switch/);
+  assert.doesNotMatch(cls.summary, /wrong gh account/);
+});
+
+test("a 403 naming the PAT is classified the same way", () => {
+  const cls = withEnv({ GH_TOKEN: 'github_pat_11ABCDEF' }, () => classifyGhError(
+    'GraphQL: Resource not accessible by personal access token (createPullRequest)',
+    { target: 'steph-dove/klaussy-agents' },
+  ));
+
+  assert.strictEqual(cls.kind, 'not-found');
+  assert.match(cls.fix, /unset GH_TOKEN/);
+});
+
+test('GITHUB_TOKEN is honoured the same as GH_TOKEN', () => {
+  const cls = withEnv({ GITHUB_TOKEN: 'ghp_classic' }, () => classifyGhError(
+    'gh: HTTP 404', { target: 'o/r' },
+  ));
+
+  assert.match(cls.summary, /\$GITHUB_TOKEN/);
+  assert.match(cls.fix, /unset GITHUB_TOKEN/);
+  // A classic token has no repository allow-list, so don't claim it does.
+  assert.doesNotMatch(cls.summary, /fine-grained/);
+  assert.match(cls.fix, /reissue the token/);
+});
+
+test('with no env token the account advice is unchanged', () => {
+  const cls = withEnv({}, () => classifyGhError('gh: HTTP 404', { target: 'o/r' }));
+
+  assert.strictEqual(cls.kind, 'not-found');
+  assert.match(cls.summary, /for the signed-in account/);
+  assert.doesNotMatch(cls.summary, /GH_TOKEN/);
+});

--- a/test/util/review-payload.test.js
+++ b/test/util/review-payload.test.js
@@ -1,0 +1,45 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const { isEmptyReview, ghApiErrorMessage } = require('../../main/util/review-payload');
+
+// The reported failure: every draft fell through to an issue comment and the
+// summary was blank, so the 422 on the empty review dropped all three.
+test('a COMMENT review with no comments and no body is empty', () => {
+  assert.equal(isEmptyReview({ event: 'COMMENT', comments: [], body: '' }), true);
+  assert.equal(isEmptyReview({ event: 'COMMENT', comments: [], body: '   \n' }), true);
+  assert.equal(isEmptyReview({ event: 'COMMENT', comments: undefined, body: null }), true);
+});
+
+test('a COMMENT review with either half is not empty', () => {
+  assert.equal(isEmptyReview({ event: 'COMMENT', comments: [{ path: 'a' }], body: '' }), false);
+  assert.equal(isEmptyReview({ event: 'COMMENT', comments: [], body: 'looks good' }), false);
+});
+
+test('approve and request-changes are never treated as empty', () => {
+  // An approval with an empty body is a perfectly good review; skipping it
+  // would silently swallow the approval.
+  assert.equal(isEmptyReview({ event: 'APPROVE', comments: [], body: '' }), false);
+  assert.equal(isEmptyReview({ event: 'REQUEST_CHANGES', comments: [], body: '' }), false);
+});
+
+test('an all-empty errors array is not appended to the message', () => {
+  const stdout = JSON.stringify({ message: 'Unprocessable Entity', errors: [''], status: '422' });
+  assert.equal(ghApiErrorMessage(stdout, 'gh: Unprocessable Entity (HTTP 422)'), 'Unprocessable Entity');
+});
+
+test('errors with real content are still surfaced', () => {
+  const stdout = JSON.stringify({
+    message: 'Validation Failed',
+    errors: [{ resource: 'PullRequestReviewComment', field: 'line' }],
+  });
+  const msg = ghApiErrorMessage(stdout, '');
+  assert.match(msg, /^Validation Failed: /);
+  assert.match(msg, /PullRequestReviewComment/);
+});
+
+test('falls back to stderr when stdout is absent or unparseable', () => {
+  assert.equal(ghApiErrorMessage('', 'gh: HTTP 500'), 'gh: HTTP 500');
+  assert.equal(ghApiErrorMessage('not json', 'gh: HTTP 500'), 'gh: HTTP 500');
+  assert.equal(ghApiErrorMessage('{"no":"message"}', 'gh: HTTP 500'), 'gh: HTTP 500');
+});


### PR DESCRIPTION
## Summary

Two GitHub failures that told the user the wrong thing. One blamed the account for a token's limits; the other reported a validation error so opaque it read as an auth problem, while silently dropping the review it was meant to post.

---

## 1. A 404 blamed the account, not the env token

Pasting a PR URL for a repo the `GH_TOKEN` PAT can't reach produced: *"GitHub can't see steph-dove/interview-train for the signed-in account. You're signed in to gh as steph-dove. Likely the wrong gh account is active, or it lacks access."*

The account was correct, and the suggested fix could not work.

A fine-grained PAT only reaches repositories it was explicitly granted. For anything else GitHub answers with a plain 404 — the same response it gives for a repo that doesn't exist. Reproduced on the reported repo, same machine, same login:

| | `gh api user` | `gh repo view steph-dove/interview-train` |
|---|---|---|
| with `GH_TOKEN` | `steph-dove` | ✗ "Could not resolve to a Repository" |
| without `GH_TOKEN` | `steph-dove` | ✓ resolves |

- **The diagnosis was wrong.** Same login either way, so the active account was never the variable.
- **The fix was worse.** `gh` prefers an env token over every stored account, so `gh auth switch` changes nothing while `GH_TOKEN` is set. The user follows the advice, nothing improves, and the message still says the same thing.

`main/util/gh-error.js` now checks for an env token before blaming the account on a 404/403. `envTokenVar()` reports which of `GH_TOKEN` / `GITHUB_TOKEN` is in force; `isFineGrainedPat()` recognises the `github_pat_` prefix. What the reported failure now says:

```
GitHub can't see steph-dove/interview-train with the token in $GH_TOKEN. That is a
fine-grained PAT, which only reaches repositories it was granted. gh uses that token
instead of any signed-in account, so switching accounts won't help.

unset GH_TOKEN   # gh falls back to the signed-in account
# or grant steph-dove/interview-train to the token at github.com/settings/personal-access-tokens
```

A classic token gets "reissue the token" instead, since it has no allow-list to grant against. With no env token set, the account advice is unchanged byte-for-byte.

---

## 2. An empty review 422'd, and took the comments down with it

Submitting a review showed *"Unprocessable Entity: [""]"*. From the log:

```
POST repos/steph-dove/klaussy-desktop/pulls/1/reviews  event=COMMENT  anchors=[]
→ 422 {"message":"Unprocessable Entity","errors":[""],"status":"422"}
```

All three drafts had fallen through to issue comments because their lines weren't in the diff, so `inlineComments` filtered out every one. With a blank summary the payload became `{ event: 'COMMENT', body: '', comments: [] }` — an empty review, which GitHub rejects with an errors array holding a single empty string. That is where `[""]` came from.

The 422 was the visible half. The costly half was the early return on a failed review:

```js
if (reviewResult.error) return reviewResult;
// ...the loop that posts the issue-comment drafts never runs
```

All three comments were **dropped, not delayed**, with nothing on the PR to show for the review.

- A COMMENT review with no inline comments and no summary is now recognised as having nothing to create, and the drafts post on their own.
- `APPROVE` and `REQUEST_CHANGES` are untouched — an approval with an empty body is a real review, and skipping it would swallow the approval.
- With no drafts either, the user gets "Nothing to submit" rather than a 422 from GitHub.
- If the review was skipped and every comment then fails, that returns an error. Previously it would have reported `ok: true` with "Review posted, but…" when nothing was posted at all.
- `ghApiErrorMessage()` stops appending an all-empty errors array to the summary, which is what made the original message unreadable.

Both helpers live in `main/util/review-payload.js` so they can be tested without stubbing electron.

---

## Test Plan

- [x] Tests pass locally — 553 passed, 0 failed; eslint clean across the linted globs
- [x] Verified against the real error strings from both reported failures

`test/util/gh-error.test.js`:

- a 404 under `GH_TOKEN` blames the token, not the account, and never suggests `gh auth switch`
- a 403 naming the PAT classifies the same way
- `GITHUB_TOKEN` is honoured like `GH_TOKEN`, and a classic token isn't described as fine-grained
- with no env token the account advice is unchanged

Each of those saves and restores both env vars, so they don't leak into the rest of the suite.

`test/util/review-payload.test.js`:

- a COMMENT review with no comments and no body is empty; with either half present it isn't
- approve and request-changes are never treated as empty
- an all-empty errors array is not appended to the message; real errors still are
- falls back to stderr when stdout is absent or unparseable

## Checklist

- [x] Code follows project conventions
- [x] No unrelated changes
- [x] Tests added/updated for new functionality
- [ ] Documentation updated if needed

## Notes for review

- The first fix corrects the diagnosis; it doesn't change which credential the app uses. If the app should prefer a keyring account when the env token can't see the target, that's a behavioral change worth deciding separately.
- The second fix stops the empty review from being sent. It doesn't address *why* all three findings failed line verification on that PR, which is a separate question about the anchoring path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
