### PR TITLE
fix(release): create releases as prereleases until every platform lands

### DIFF
--- a/.github/workflows/build-platforms.yml
+++ b/.github/workflows/build-platforms.yml
@@ -139,9 +139,13 @@ jobs:
           # Create-if-missing: a freshly-tagged release often has no GitHub
           # release object yet, and `gh release upload` fails with "release not
           # found" against a non-existent release. Ensure it exists first.
+          # --prerelease on create: this job carries one platform, so publishing
+          # here would make an incomplete release `releases/latest`. Promote once
+          # every platform has landed:
+          #   gh release edit <tag> --repo <repo> --latest --prerelease=false
           gh release view "${{ inputs.release_tag }}" --repo steph-dove/klaussy-desktop >/dev/null 2>&1 \
             || gh release create "${{ inputs.release_tag }}" --repo steph-dove/klaussy-desktop \
-                 --title "${{ inputs.release_tag }}" --generate-notes
+                 --title "${{ inputs.release_tag }}" --generate-notes --prerelease
           gh release upload "${{ inputs.release_tag }}" "${files[@]}" \
             --repo steph-dove/klaussy-desktop \
             --clobber
@@ -172,9 +176,12 @@ jobs:
           # Create-if-missing on the feedback repo too — the mirror release won't
           # exist until we make it, so creating it here is what makes the
           # dual-publish reliable instead of silently failing.
+          # --prerelease matters most here: klaussy.com's download.js reads this
+          # repo's releases/latest to build its per-platform links, so a release
+          # published with only some platforms present 404s the rest.
           gh release view "${{ inputs.release_tag }}" --repo steph-dove/klaussy-desktop-feedback >/dev/null 2>&1 \
             || gh release create "${{ inputs.release_tag }}" --repo steph-dove/klaussy-desktop-feedback \
-                 --title "${{ inputs.release_tag }}" \
+                 --title "${{ inputs.release_tag }}" --prerelease \
                  --notes "Mirror of steph-dove/klaussy-desktop ${{ inputs.release_tag }} for auto-updaters on v0.6.0 and earlier."
           gh release upload "${{ inputs.release_tag }}" "${files[@]}" \
             --repo steph-dove/klaussy-desktop-feedback \

--- a/scripts/release-mac.js
+++ b/scripts/release-mac.js
@@ -69,6 +69,8 @@ try {
   console.log(`[release:mac] could not switch gh account to ${ghUser}; using current active account.`);
 }
 
+const pendingPromotion = [];
+
 for (const repo of repos) {
   // Create-if-missing: a freshly-tagged release may have no GitHub release
   // object yet, and `gh release upload` fails with "release not found"
@@ -77,16 +79,43 @@ for (const repo of repos) {
     gh(['release', 'view', tag, '--repo', repo]);
     console.log(`[release:mac] ${repo}: release ${tag} exists`);
   } catch {
-    console.log(`[release:mac] ${repo}: creating release ${tag}`);
+    console.log(`[release:mac] ${repo}: creating release ${tag} (prerelease)`);
     const notes = repo.endsWith('/klaussy-desktop-feedback')
       ? `Mirror of ${owner}/${canonicalRepo} ${tag} for auto-updaters on v0.6.0 and earlier.`
       : `Release ${tag}.`;
-    gh(['release', 'create', tag, '--repo', repo, '--title', tag, '--notes', notes], { stdio: 'inherit' });
+    // Prerelease on purpose: this script uploads macOS only, and klaussy.com's
+    // download.js builds its per-platform links from releases/latest, so
+    // publishing here would 404 Windows and Linux until CI caught up.
+    gh(['release', 'create', tag, '--repo', repo, '--title', tag, '--notes', notes, '--prerelease'],
+      { stdio: 'inherit' });
   }
 
   console.log(`[release:mac] ${repo}: uploading macOS artifacts…`);
   gh(['release', 'upload', tag, ...files, '--repo', repo, '--clobber'], { stdio: 'inherit' });
   console.log(`[release:mac] ${repo}: done`);
+
+  // Ask the release what it is rather than assuming this run created it: CI may
+  // have made the prerelease, so the create branch above never ran. On an
+  // unreadable state, assume it needs promoting — a stale download page costs
+  // more than a needless promote command.
+  let isPrerelease = true;
+  try {
+    isPrerelease = !!JSON.parse(
+      gh(['release', 'view', tag, '--repo', repo, '--json', 'isPrerelease'])
+    ).isPrerelease;
+  } catch {
+    console.log(`[release:mac] ${repo}: could not read release state; assuming it needs promoting.`);
+  }
+  if (isPrerelease) pendingPromotion.push(repo);
 }
 
 console.log(`[release:mac] ${tag} macOS artifacts published to all ${repos.length} repos.`);
+
+if (pendingPromotion.length) {
+  console.log(
+    `\n[release:mac] ${tag} is still a PRERELEASE on ${pendingPromotion.length} repo(s), so nothing\n` +
+    `[release:mac] downloads it yet — klaussy.com follows releases/latest. Check every platform's\n` +
+    `[release:mac] artifacts are attached, then promote:\n` +
+    pendingPromotion.map((r) => `  gh release edit ${tag} --repo ${r} --latest --prerelease=false`).join('\n')
+  );
+}


### PR DESCRIPTION
## Summary

Publishing 0.17.1 broke every Windows and Linux download on klaussy.com. The artifacts were fine; the release was published before they existed.

## What happened

The mac build runs locally, so `release:mac` reached the feedback repo first and called `gh release create`, which publishes immediately. That made a release holding **only macOS assets** into `releases/latest` on `klaussy-desktop-feedback`.

That repo is not just an auto-updater mirror — it is where the landing page gets its downloads. `download.js` reads `api.github.com/repos/steph-dove/klaussy-desktop-feedback/releases/latest`, takes `tag_name`, and builds a filename per platform:

```js
return `https://github.com/${REPO}/releases/download/v${version}/${filename}`;
```

So the page pointed Windows and Linux visitors at files that were never uploaded:

```
Klaussy-0.17.1-Windows-Setup.exe  -> HTTP 404
Klaussy-0.17.1-Linux.AppImage     -> HTTP 404
Klaussy-0.17.1-macOS-arm64.dmg    -> HTTP 200
```

CI was meant to add the missing artifacts, but its mirror step had been failing on an expired `FEEDBACK_REPO_TOKEN` since at least 0.17.0:

```
HTTP 401: Bad credentials
(https://api.github.com/repos/steph-dove/klaussy-desktop-feedback/releases)
```

The dead token was the trigger. The defect is that a single-platform upload could become `latest` at all — nothing in the flow required a release to be complete before the world saw it, so any failure or slow platform produced a broken download page rather than a delayed one.

## Changes

- Both create-if-missing paths — `scripts/release-mac.js` and the two in `build-platforms.yml` — now pass `--prerelease`. A release stays invisible to `releases/latest` until someone deliberately promotes it, so an incomplete one can't be served.
- `release:mac` closes by naming any release still sitting as a prerelease, with the exact promote command.
- That reminder is driven by asking the release what it is (`gh release view --json isPrerelease`), **not** by whether this run created it. CI now creates the release as a prerelease too, so a "did I create it" check would go silent in precisely the case that leaves one unpromoted. An unreadable state reminds anyway: a redundant promote command is cheap, a stale download page is not.
- Uploads to a release that already exists are unchanged.

Promotion stays manual, since no single job knows every platform has landed — the mac build is local and the two CI jobs don't see each other.

## Test Plan

- [x] `npm test` — 556 passed, 0 failed
- [x] `npm run lint` clean (`scripts/` is outside the project's lint globs; `eslint scripts/release-mac.js` reports the same pre-existing parser error on unmodified `main`)
- [x] `node --check scripts/release-mac.js`
- [x] Verified end to end against the live 0.17.1 release

The 0.17.1 mirror has been repaired by hand and promoted. All six links the landing page builds now resolve:

```
200  Klaussy-0.17.1-Windows-Setup.exe      200  Klaussy-0.17.1-macOS-arm64.dmg
200  Klaussy-0.17.1-Windows-Portable.exe   200  Klaussy-0.17.1-macOS-x64.dmg
200  Klaussy-0.17.1-Linux.AppImage         200  Klaussy-0.17.1-Linux-Debian-Ubuntu.deb
200  latest.yml   200  latest-linux.yml    200  latest-mac.yml
```

Uploaded artifacts were byte-size verified against the canonical `klaussy-desktop` release before promotion.

## Checklist

- [x] Code follows project conventions
- [x] No unrelated changes
- [ ] Tests added/updated for new functionality — release scripts have no test harness; verified against the live release instead
- [ ] Documentation updated if needed

## Still needs doing separately

`FEEDBACK_REPO_TOKEN` is still returning 401. Until it's renewed, CI can't mirror anything and every release needs the manual copy this one got. This PR stops that failure from breaking the download page; it doesn't fix the token.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
