### PR TITLE
fix(resume): give every resumed agent a terminal, not just the first

### DIFF
--- a/renderer/app-functions-1.js
+++ b/renderer/app-functions-1.js
@@ -287,11 +287,23 @@ window.App = window.App || {};
     return !!box.checked;
   };
 
-  // Every agent a saved worktree had, restored one at a time: each spawn
-  // rewrites the saved snapshot, and two landing together lose one of the tabs
-  // they were meant to record.
-  App.resumeAllSavedAgents = async function(wt) {
-    var agents = wt.savedAgents || [];
+  // Two saves of the same tab can both survive a session; the same agent on the
+  // same session id is one tab, not two.
+  App.dedupeSavedAgents = function(list) {
+    var seen = {};
+    return (list || []).filter(function (s) {
+      if (!s) return false;
+      var key = (s.mode || '') + '|' + (s.sessionId || '');
+      if (seen[key]) return false;
+      seen[key] = true;
+      return true;
+    });
+  };
+
+  // One at a time: each spawn rewrites the saved snapshot. Only the first is
+  // returned, so a caller ignoring onExtra leaves the rest with no terminal.
+  App.resumeAllSavedAgents = async function(wt, onExtra) {
+    var agents = App.dedupeSavedAgents(wt.savedAgents);
     var first = null;
     for (var i = 0; i < agents.length; i++) {
       var s = agents[i];
@@ -301,7 +313,8 @@ window.App = window.App || {};
       if (res && res.id && s.subAgents && s.subAgents.length && window.TerminalManager) {
         await TerminalManager.reopenSubAgents(res.id, s.subAgents);
       }
-      if (i === 0) first = res;
+      if (i === 0) { first = res; continue; }
+      if (res && res.id && onExtra) onExtra(res);
     }
     return first;
   };
@@ -608,17 +621,10 @@ window.App = window.App || {};
   // Resume every agent a worktree had open, not just the first one saved: a
   // session is often a Claude tab plus a second agent, and coming back to only
   // one of them loses the other's place.
-  App.resumeSessionWorktree = async function(wt, sessionName, savedList, mode) {
-    var savedForWt = (savedList || []).filter(function (s) { return s && s.worktreePath === wt.path; });
-    // Two saves of the same tab can both survive; the same agent on the same
-    // session id is one tab, not two.
-    var seen = {};
-    savedForWt = savedForWt.filter(function (s) {
-      var key = (s.mode || '') + '|' + (s.sessionId || '');
-      if (seen[key]) return false;
-      seen[key] = true;
-      return true;
-    });
+  App.resumeSessionWorktree = async function(wt, sessionName, savedList, mode, onExtra) {
+    var savedForWt = App.dedupeSavedAgents(
+      (savedList || []).filter(function (s) { return s && s.worktreePath === wt.path; })
+    );
     // Unticking the box, or picking an agent while it is off, is a deliberate
     // choice about this open: one agent, handed off to when it isn't the one
     // that started the session.
@@ -631,7 +637,8 @@ window.App = window.App || {};
       // One at a time: each spawn writes the session snapshot, and two landing
       // together lose one of the tabs they were meant to record.
       var res = await App.resumeSavedAgent(wt, sessionName, savedForWt[i], null, false);
-      if (i === 0) first = res;
+      if (i === 0) { first = res; continue; }
+      if (res && res.id && onExtra) onExtra(res);
     }
     return first;
   };

--- a/renderer/app-functions-2.js
+++ b/renderer/app-functions-2.js
@@ -845,6 +845,8 @@ window.App = window.App || {};
     var fanoutResume = [];
     var fanoutSavedList = [];
     var fanoutSessionName = '';
+    var resumedExtras = [];
+    var collectExtra = function (t) { resumedExtras.push(t); };
     var fanoutName = App.modalInput.value.trim();
     var fanoutBase = App.selectedBaseBranch;
     // Sessions live in the default ~/klaussy/sessions/<session>/<repo> layout
@@ -943,7 +945,7 @@ window.App = window.App || {};
         fanoutSavedList = [];
       }
       fanoutSessionName = sessName;
-      result = await App.resumeSessionWorktree(sessWts[0], sessName, fanoutSavedList, App.selectedMode);
+      result = await App.resumeSessionWorktree(sessWts[0], sessName, fanoutSavedList, App.selectedMode, collectExtra);
       fanoutResume = sessWts.slice(1);
     }
 
@@ -1033,10 +1035,19 @@ window.App = window.App || {};
       App.switchToTask(result.id);
     }
 
+    var flushResumedExtras = function () {
+      var pending = resumedExtras.splice(0, resumedExtras.length);
+      pending.forEach(function (t) {
+        if (newWindowIds) newWindowIds.push(t.id); else App.addTaskToUI(t);
+      });
+      return pending.length;
+    };
+    var extraAgents = flushResumedExtras();
+
     // Multi-repo / session-resume creates open side by side immediately — in
     // single layout the extra tasks would spawn invisibly and look like they
     // failed. Columns for two terminals, grid once there are three or more.
-    var extraCount = fanoutRepos.length + fanoutResume.length;
+    var extraCount = fanoutRepos.length + fanoutResume.length + extraAgents;
     if (!newWindowIds && extraCount > 0 && TerminalManager.currentLayout() === 'single') {
       TerminalManager.setLayout(extraCount >= 2 ? 'grid' : 'columns');
     }
@@ -1111,8 +1122,11 @@ window.App = window.App || {};
       var rsResumed = 0;
       var rsFanout = fanoutResume.reduce(function (chain, wt) {
         return chain.then(function () {
-          return App.resumeSessionWorktree(wt, fanoutSessionName, fanoutSavedList, fanoutMode).then(function (res) {
+          return App.resumeSessionWorktree(wt, fanoutSessionName, fanoutSavedList, fanoutMode, collectExtra).then(function (res) {
             try {
+              // Before the outcome branches: a worktree whose first agent failed
+              // can still have opened the rest.
+              flushResumedExtras();
               if (!res || res.error) {
                 rsFailures.push(wt.repoName + ': ' + ((res && res.error) || 'failed'));
                 return;

--- a/renderer/sidebar-manager.js
+++ b/renderer/sidebar-manager.js
@@ -255,9 +255,12 @@ window.Sidebar = (function () {
         btn.disabled = true;
         btn.textContent = '...';
         var result;
+        var extraTasks = [];
+        var resumedAll = false;
         try {
           if (wt.savedAgents && wt.savedAgents.length > 1) {
-            result = await window.App.resumeAllSavedAgents(wt);
+            resumedAll = true;
+            result = await window.App.resumeAllSavedAgents(wt, function (t) { extraTasks.push(t); });
           } else if (wt.mode === 'shell') {
             result = await window.klaus.task.attachWorktree(wt.path, 'shell', wt.repoPath, wt.branch);
           } else {
@@ -284,10 +287,16 @@ window.Sidebar = (function () {
         window.App.addTaskToUI(result);
         window.App.switchToTask(result.id);
         window.App.restoreUIState(result);
+        extraTasks.forEach(function (t) { window.App.addTaskToUI(t); });
+        // In single layout the extra agents would run with nothing on screen.
+        if (extraTasks.length && window.TerminalManager && TerminalManager.currentLayout() === 'single') {
+          TerminalManager.setLayout(extraTasks.length >= 2 ? 'grid' : 'columns');
+        }
         // The session's other agents were tabs on this task, so they come back
-        // as tabs rather than as sessions of their own.
+        // as tabs rather than as sessions of their own. resumeAllSavedAgents
+        // has already reopened them, so repeating it here would double the tabs.
         var extras = (wt.savedAgents && wt.savedAgents[0] && wt.savedAgents[0].subAgents) || wt.subAgents;
-        if (extras && extras.length && window.TerminalManager) {
+        if (!resumedAll && extras && extras.length && window.TerminalManager) {
           TerminalManager.reopenSubAgents(result.id, extras);
         }
       });
@@ -445,10 +454,19 @@ window.Sidebar = (function () {
         
         for (var i = 0; i < inactiveList.length; i++) {
           var wt = inactiveList[i];
+          var opened = [];
           try {
-            var result = await window.klaus.task.attachWorktree(wt.path, window.App.defaultAgent(), wt.repoPath, wt.branch);
+            var result;
+            if (wt.isSavedSession && wt.savedAgents && wt.savedAgents.length) {
+              // A plain attach would replace every agent the session had with a
+              // single default-agent terminal.
+              result = await window.App.resumeAllSavedAgents(wt, function (t) { opened.push(t); });
+            } else {
+              result = await window.klaus.task.attachWorktree(wt.path, window.App.defaultAgent(), wt.repoPath, wt.branch);
+            }
             if (result && !result.error) {
               window.App.addTaskToUI(result);
+              opened.forEach(function (t) { window.App.addTaskToUI(t); });
               if (i === 0) window.App.switchToTask(result.id);
             }
           } catch (err) {

--- a/test/util/resume-all-agents.test.js
+++ b/test/util/resume-all-agents.test.js
@@ -1,0 +1,101 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+// app-functions-1.js is pure definitions, so a stub `window` is enough to load
+// it (same approach as app-utils.test.js).
+global.window = global.window || {};
+// resumeAllAgentsWanted reads the dialog's checkbox; absent markup means "yes".
+global.document = global.document || { getElementById: () => null };
+require('../../renderer/app-functions-1');
+const App = global.window.App;
+
+function stubKlaus(spawned) {
+  let n = 0;
+  global.window.klaus = {
+    session: {
+      resume(s) {
+        n++;
+        spawned.push({ kind: 'resume', mode: s.mode, sessionId: s.sessionId, worktreePath: s.worktreePath });
+        return Promise.resolve({ id: 't' + n, mode: s.mode, worktreePath: s.worktreePath });
+      },
+    },
+    task: {
+      attachWorktree(worktreePath, mode) {
+        n++;
+        spawned.push({ kind: 'attach', mode, worktreePath });
+        return Promise.resolve({ id: 't' + n, mode, worktreePath });
+      },
+    },
+  };
+}
+
+// Regression: the extra agents were spawned in the main process but never
+// handed to the renderer, so they ran with no terminal on screen.
+test('resumeAllSavedAgents: hands every agent past the first to onExtra', async () => {
+  const spawned = [];
+  stubKlaus(spawned);
+  const extras = [];
+  const first = await App.resumeAllSavedAgents({
+    savedAgents: [
+      { mode: 'claude', sessionId: 'a', worktreePath: '/wt' },
+      { mode: 'codex', sessionId: 'b', worktreePath: '/wt' },
+      { mode: 'shell', sessionId: null, worktreePath: '/wt' },
+    ],
+  }, (t) => extras.push(t));
+
+  assert.equal(spawned.length, 3);
+  assert.equal(first.id, 't1');
+  assert.deepEqual(extras.map((t) => t.id), ['t2', 't3']);
+  assert.equal(spawned[2].kind, 'attach'); // shell entries attach, not resume
+});
+
+test('resumeAllSavedAgents: same agent saved twice on one session id is one tab', async () => {
+  const spawned = [];
+  stubKlaus(spawned);
+  const extras = [];
+  await App.resumeAllSavedAgents({
+    savedAgents: [
+      { mode: 'claude', sessionId: 'a', worktreePath: '/wt' },
+      { mode: 'claude', sessionId: 'a', worktreePath: '/wt' },
+    ],
+  }, (t) => extras.push(t));
+
+  assert.equal(spawned.length, 1);
+  assert.equal(extras.length, 0);
+});
+
+test('resumeSessionWorktree: resumes every saved agent for the worktree', async () => {
+  const spawned = [];
+  stubKlaus(spawned);
+  App.shellUserPicked = false;
+  const extras = [];
+  const saved = [
+    { mode: 'claude', sessionId: 'a', worktreePath: '/wt' },
+    { mode: 'codex', sessionId: 'b', worktreePath: '/wt' },
+    { mode: 'claude', sessionId: 'c', worktreePath: '/other' },
+  ];
+  const first = await App.resumeSessionWorktree({ path: '/wt', branch: 'feat' }, 'feat', saved, 'claude', (t) => extras.push(t));
+
+  assert.deepEqual(spawned.map((s) => s.mode), ['claude', 'codex']);
+  assert.equal(first.id, 't1');
+  assert.deepEqual(extras.map((t) => t.id), ['t2']);
+});
+
+test('resumeSessionWorktree: unticking resume-all opens only the first agent', async () => {
+  const spawned = [];
+  stubKlaus(spawned);
+  const wanted = App.resumeAllAgentsWanted;
+  App.resumeAllAgentsWanted = () => false;
+  const extras = [];
+  try {
+    await App.resumeSessionWorktree({ path: '/wt', branch: 'feat' }, 'feat', [
+      { mode: 'claude', sessionId: 'a', worktreePath: '/wt' },
+      { mode: 'codex', sessionId: 'b', worktreePath: '/wt' },
+    ], 'claude', (t) => extras.push(t));
+  } finally {
+    App.resumeAllAgentsWanted = wanted;
+  }
+
+  assert.equal(spawned.length, 1);
+  assert.equal(extras.length, 0);
+});


### PR DESCRIPTION
## Summary

Resuming a session spawned every saved agent but handed the renderer only the first one, so the rest ran in the main process with no terminal on screen. Coming back to a session that had run Claude alongside a second agent looked like the second had been dropped.

## Changes

- `resumeAllSavedAgents` and `resumeSessionWorktree` take an `onExtra` callback and pass it every agent past the first, instead of discarding them.
- Three call sites render the extras and switch out of `single` layout so they are visible: the sidebar's worktree resume, its resume-all-inactive button, and session fan-out. Fan-out flushes before the outcome branches, so a worktree whose first agent fails still shows the ones that opened.
- Resume-all-inactive previously attached every inactive worktree with the default agent, replacing a saved session's agents with one fresh terminal. It now routes saved sessions through `resumeAllSavedAgents`.
- The sidebar's `reopenSubAgents` call is guarded so it does not double the tabs `resumeAllSavedAgents` has already reopened.
- The duplicate-entry filter both entry points need is shared as `App.dedupeSavedAgents` rather than living inside one of them.

## Test Plan

New `test/util/resume-all-agents.test.js` covers the fixed paths: every agent past the first reaching `onExtra`, shell entries attaching rather than resuming, the same agent saved twice on one session id collapsing to one tab, per-worktree filtering in `resumeSessionWorktree`, and the resume-all checkbox unticked still opening only one agent.

- [x] Tests pass locally (580/580, `npm test`)
- [x] `npm run lint` clean
- [ ] Manually verified

## Checklist

- [x] Code follows project conventions (see CLAUDE.md)
- [x] No unrelated changes
- [x] Tests added/updated for new functionality
- [ ] Documentation updated if needed