### PR TITLE
fix(resume): bring a session's other agents back where they left off

### DIFF
--- a/main/bootstrap/app-events.js
+++ b/main/bootstrap/app-events.js
@@ -12,6 +12,7 @@ const { execToolSync } = require('../util/exec');
 const { app, ipcMain, dialog, BrowserWindow } = require('electron');
 const lspManager = require('../../lsp-manager');
 const { loadConfig, saveConfig, flushSaveConfig, runConfigMigrations } = require('../util/config');
+const { mergeSavedSessions } = require('../util/saved-sessions');
 const {
   allWindows, getMainWindow, createWindow, setWindowCloseHook,
 } = require('../state/windows');
@@ -212,6 +213,21 @@ function checkExternalCLIs() {
   agents.forEach((a) => binPresent(a.bin, (ok) => { if (ok) anyAgent = true; finish(); }));
 }
 
+// A fresh tab has no id until its agent writes the transcript, so it resolves on
+// a later save; `claimed` stops two tabs on one worktree adopting the same id.
+function resolveSubSessionId(inst, sub, claimed) {
+  if (sub.sessionId) return sub.sessionId;
+  const provider = getProvider(sub.mode);
+  if (!provider || typeof provider.findNewSession !== 'function') return null;
+  let found = null;
+  try {
+    found = provider.findNewSession(inst.worktreePath, sub.preSpawnSessions || new Set());
+  } catch { return null; } // a session store we cannot read is not worth failing the save
+  if (!found || !found.sessionId || claimed.has(found.sessionId)) return null;
+  sub.sessionId = found.sessionId;
+  return sub.sessionId;
+}
+
 function saveSessions() {
   // Only overwrite savedSessions if there are active instances;
   // otherwise keep whatever was previously saved
@@ -247,6 +263,7 @@ function saveSessions() {
   }
 
   const sessions = [];
+  const claimedSubSessions = new Set();
   for (const [, inst] of instances) {
     const saveMode = inst.originalMode || inst.mode;
     const provider = getProvider(saveMode);
@@ -269,13 +286,17 @@ function saveSessions() {
       // belonging to the agent that started the session.
       subAgents: (inst.subTerminals || [])
         .filter((s) => s && s.alive && isAgentMode(s.mode))
-        .map((s) => ({ mode: s.mode, label: s.label || null })),
+        .map((s) => {
+          const subSessionId = resolveSubSessionId(inst, s, claimedSubSessions);
+          if (subSessionId) claimedSubSessions.add(subSessionId);
+          return { mode: s.mode, label: s.label || null, sessionId: subSessionId };
+        }),
       savedAt: new Date().toISOString(),
     });
   }
   // saveConfig's write is queued, so passing a whole snapshot would revert
   // anything saved between this function starting and landing.
-  saveConfig({ savedSessions: sessions });
+  saveConfig({ savedSessions: mergeSavedSessions(sessions, loadConfig().savedSessions) });
 }
 
 function shutdownAndSave() {

--- a/main/ipc/tasks.js
+++ b/main/ipc/tasks.js
@@ -1102,7 +1102,7 @@ ipcMain.on('resize-terminal', (_event, { id, cols, rows, subId }) => {
   }
 });
 
-ipcMain.handle('add-sub-terminal', (_event, { taskId, label, mode, initialPrompt }) => {
+ipcMain.handle('add-sub-terminal', (_event, { taskId, label, mode, initialPrompt, resumeSessionId }) => {
   const inst = instances.get(taskId);
   if (!inst) return { error: 'Instance not found' };
 
@@ -1117,6 +1117,7 @@ ipcMain.handle('add-sub-terminal', (_event, { taskId, label, mode, initialPrompt
   let needsEnter = false;    // codex-style TUIs pre-fill but wait for Enter
   let pasteText = null;      // kimi-style TUIs take no spawn-time prompt at all
   let ptyProc;
+  let preSpawnSessions = new Set();
   {
     if (isAgentMode(mode)) {
       const config = loadConfig();
@@ -1131,7 +1132,13 @@ ipcMain.handle('add-sub-terminal', (_event, { taskId, label, mode, initialPrompt
       if (!session.ok) return { cancelled: true };
       const model = nemProfile ? (nemProfile.model || '') : ((config.agentModel || {})[provider.id] || '');
       const sessionDirs = sessionSiblingWorktrees(inst.worktreePath);
-      let agentCmd = provider.buildInteractiveCmd(bin, { trust: consent.trust, model, sessionDirs, profile: nemProfile });
+      // Deliberately not resumeLatest: that adopts whatever ran last in this
+      // worktree, which is another tab as often as this one.
+      preSpawnSessions = provider.snapshotSessions ? provider.snapshotSessions() : new Set();
+      let agentCmd = provider.buildInteractiveCmd(bin, {
+        trust: consent.trust, model, sessionDirs, profile: nemProfile,
+        resumeSessionId: resumeSessionId || null,
+      });
       // Seed an initial prompt (Plan/Debug/Review) at spawn rather than typing it
       // in after boot — shared staging with the cross-agent session-resume
       // handoff (see util/agent-prompt).
@@ -1160,7 +1167,11 @@ ipcMain.handle('add-sub-terminal', (_event, { taskId, label, mode, initialPrompt
     });
   }
 
-  const sub = { subId, label: label || displayNameFor(mode || 'shell'), pty: ptyProc, alive: true, mode: mode || 'shell' };
+  const sub = {
+    subId, label: label || displayNameFor(mode || 'shell'), pty: ptyProc, alive: true, mode: mode || 'shell',
+    preSpawnSessions,
+    sessionId: resumeSessionId || null,
+  };
   inst.subTerminals.push(sub);
 
   // codex pre-fills its positional prompt but waits for an Enter to submit

--- a/main/state/ai-providers.js
+++ b/main/state/ai-providers.js
@@ -5,6 +5,7 @@
 const path = require('path');
 const os = require('os');
 const fs = require('fs');
+const { fileURLToPath } = require('url');
 const { claudeProjectDir } = require('../util/claude-paths');
 const { loadConfig } = require('../util/config');
 
@@ -12,10 +13,8 @@ function home() {
   return process.env.HOME || os.homedir();
 }
 
-// List *.jsonl files under `dir` (recursively if `recursive`), each with
-// nanosecond ctime + mtime for stable ordering. Used by the implement-PTY
-// session detection. Missing dirs yield [].
-function listJsonlFiles(dir, recursive) {
+// Nanosecond ctime + mtime give callers stable ordering; missing dirs yield [].
+function listFilesByExt(dir, ext, recursive) {
   if (!dir) return [];
   const out = [];
   const walk = (d) => {
@@ -24,7 +23,7 @@ function listJsonlFiles(dir, recursive) {
     for (const e of ents) {
       const full = path.join(d, e.name);
       if (e.isDirectory()) { if (recursive) walk(full); }
-      else if (e.name.endsWith('.jsonl')) {
+      else if (e.name.endsWith(ext)) {
         try {
           const st = fs.statSync(full, { bigint: true });
           out.push({ path: full, mtimeMs: Number(st.mtimeMs), ctimeNs: st.ctimeNs });
@@ -34,6 +33,10 @@ function listJsonlFiles(dir, recursive) {
   };
   walk(dir);
   return out;
+}
+
+function listJsonlFiles(dir, recursive) {
+  return listFilesByExt(dir, '.jsonl', recursive);
 }
 
 // Resolve a path through symlinks for comparison (macOS /tmp → /private/tmp).
@@ -560,9 +563,48 @@ const PROVIDERS = {
     },
     sessionDir() {
       // CONFIRMED on a real install: agy's home is ~/.gemini/antigravity-cli/.
-      // Resumable transcripts live in its conversations/ subdir, but the file
-      // format isn't verified yet, so no tail is wired (see snapshotSessions).
       return path.join(home(), '.gemini', 'antigravity-cli');
+    },
+    // conversations/<conversation-id>.db, and that filename is the id
+    // `--conversation` takes (verified against the trajectory_meta row inside).
+    conversationsDir() {
+      return path.join(this.sessionDir(), 'conversations');
+    },
+    snapshotSessions() {
+      return new Set(listFilesByExt(this.conversationsDir(), '.db').map(f => f.path));
+    },
+    // agy reattaches to the workspace's existing conversation rather than
+    // starting one per launch, so there is no new file to spot; the snapshot is
+    // unused and the workspace recorded in conversation_summaries.db is the key.
+    findNewSession(worktreePath) {
+      const target = realPath(worktreePath);
+      let db = null;
+      try {
+        const { DatabaseSync } = require('node:sqlite');
+        db = new DatabaseSync(path.join(this.sessionDir(), 'conversation_summaries.db'), { readOnly: true });
+        const rows = db.prepare(
+          'select conversation_id, workspace_uris from conversation_summaries order by last_modified_time desc'
+        ).all();
+        for (const row of rows) {
+          if (!row.conversation_id) continue;
+          let uris = [];
+          try { uris = JSON.parse(row.workspace_uris || '[]'); } catch { continue; }
+          const match = uris.some((u) => {
+            try { return realPath(fileURLToPath(u)) === target; } catch { return false; }
+          });
+          if (match) {
+            return {
+              filePath: path.join(this.conversationsDir(), row.conversation_id + '.db'),
+              sessionId: row.conversation_id,
+            };
+          }
+        }
+        return null;
+      } catch {
+        return null; // agy not installed, or its summary db is locked mid-write
+      } finally {
+        if (db) { try { db.close(); } catch { /* already gone */ } }
+      }
     },
     // agy emits plain text (no JSON lines), so there is nothing to parse for the
     // stream/usage surfaces. No-ops keep the provider contract intact and let
@@ -570,8 +612,6 @@ const PROVIDERS = {
     parseStreamLine() { return []; },
     usageFromSessionLine() { return null; },
     sessionLineToEvents() { return []; },
-    snapshotSessions() { return new Set(); },
-    findNewSession() { return null; },
   },
 
   copilot: {

--- a/main/util/saved-sessions.js
+++ b/main/util/saved-sessions.js
@@ -1,0 +1,10 @@
+// The saver only describes worktrees open right now, so overwriting the stored
+// list with that snapshot drops closed sessions and their agent — which is what
+// made a closed Copilot session come back as Claude.
+function mergeSavedSessions(described, previous) {
+  const describedPaths = new Set((described || []).map((s) => s && s.worktreePath));
+  const untouched = (previous || []).filter((s) => s && !describedPaths.has(s.worktreePath));
+  return (described || []).concat(untouched);
+}
+
+module.exports = { mergeSavedSessions };

--- a/preload.js
+++ b/preload.js
@@ -170,7 +170,7 @@ contextBridge.exposeInMainWorld('klaus', {
         ipcRenderer.send('unsubscribe-terminal', channel);
       };
     },
-    addSub: (taskId, label, mode, initialPrompt) => ipcRenderer.invoke('add-sub-terminal', { taskId, label, mode, initialPrompt }),
+    addSub: (taskId, label, mode, initialPrompt, resumeSessionId) => ipcRenderer.invoke('add-sub-terminal', { taskId, label, mode, initialPrompt, resumeSessionId }),
     killSub: (taskId, subId) => ipcRenderer.invoke('kill-sub-terminal', { taskId, subId }),
     onSubData: (taskId, subId, callback) => {
       const channel = `terminal-data-${taskId}-${subId}`;

--- a/renderer/terminal-manager.js
+++ b/renderer/terminal-manager.js
@@ -787,7 +787,7 @@ window.TerminalManager = (function () {
       if (!agent || !agent.mode) continue;
       var label = agent.label || (window.AppUtils ? AppUtils.modeDisplayName(agent.mode) : agent.mode);
       try {
-        var result = await window.klaus.terminal.addSub(taskId, label, agent.mode);
+        var result = await window.klaus.terminal.addSub(taskId, label, agent.mode, null, agent.sessionId || null);
         if (!result || result.error || result.cancelled) continue;
         addSubTerminalTab(taskEntry, result.subId, result.label, agent.mode, true);
       } catch (err) {

--- a/test/util/antigravity-sessions.test.js
+++ b/test/util/antigravity-sessions.test.js
@@ -1,0 +1,84 @@
+require('../setup');
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const { DatabaseSync } = require('node:sqlite');
+
+const providers = require('../../main/state/ai-providers');
+const agy = providers.getProvider('antigravity');
+
+// The provider resolves its store under $HOME, so a temp home gives each test a
+// conversation store of its own.
+function withStore(rows, fn) {
+  const prev = process.env.HOME;
+  const home = fs.mkdtempSync(path.join(os.tmpdir(), 'agy-home-'));
+  const dir = path.join(home, '.gemini', 'antigravity-cli');
+  fs.mkdirSync(path.join(dir, 'conversations'), { recursive: true });
+  if (rows) {
+    const db = new DatabaseSync(path.join(dir, 'conversation_summaries.db'));
+    db.exec('create table conversation_summaries (conversation_id text, workspace_uris text, last_modified_time text)');
+    const insert = db.prepare('insert into conversation_summaries values (?, ?, ?)');
+    for (const r of rows) insert.run(r.id, JSON.stringify(r.workspaces), r.at);
+    db.close();
+  }
+  process.env.HOME = home;
+  try {
+    return fn(home);
+  } finally {
+    process.env.HOME = prev;
+    fs.rmSync(home, { recursive: true, force: true });
+  }
+}
+
+// agy reattaches to a workspace's existing conversation, so the id cannot be
+// spotted as a file that appeared after spawn — it comes from the workspace.
+test('the conversation is the one recorded against this worktree', () => {
+  withStore([
+    { id: 'other-conv', workspaces: ['file:///wt/b'], at: '2026-08-24 10:00:00+00:00' },
+    { id: 'mine-conv', workspaces: ['file:///wt/a'], at: '2026-08-24 09:00:00+00:00' },
+  ], () => {
+    const found = agy.findNewSession('/wt/a', new Set());
+    assert.equal(found.sessionId, 'mine-conv');
+    assert.match(found.filePath, /conversations\/mine-conv\.db$/);
+  });
+});
+
+test('the most recent conversation wins when a worktree has several', () => {
+  withStore([
+    { id: 'stale', workspaces: ['file:///wt/a'], at: '2026-08-20 10:00:00+00:00' },
+    { id: 'current', workspaces: ['file:///wt/a'], at: '2026-08-24 10:00:00+00:00' },
+  ], () => {
+    assert.equal(agy.findNewSession('/wt/a', new Set()).sessionId, 'current');
+  });
+});
+
+test('a worktree agy has never run in has no conversation', () => {
+  withStore([{ id: 'c', workspaces: ['file:///wt/b'], at: '2026-08-24 10:00:00+00:00' }], () => {
+    assert.equal(agy.findNewSession('/wt/a', new Set()), null);
+  });
+});
+
+// agy may not be installed at all, and its store is written while it runs.
+test('an absent or unreadable store yields no session rather than throwing', () => {
+  withStore(null, () => {
+    assert.equal(agy.findNewSession('/wt/a', new Set()), null);
+  });
+});
+
+test('a multi-workspace conversation matches on any of its roots', () => {
+  withStore([
+    { id: 'multi', workspaces: ['file:///wt/b', 'file:///wt/a'], at: '2026-08-24 10:00:00+00:00' },
+  ], () => {
+    assert.equal(agy.findNewSession('/wt/a', new Set()).sessionId, 'multi');
+  });
+});
+
+test('--conversation resumes an exact id, --continue is the fallback', () => {
+  assert.match(agy.buildInteractiveCmd('agy', { resumeSessionId: 'abc' }), /--conversation abc/);
+  assert.match(agy.buildInteractiveCmd('agy', { resumeLatest: true }), /--continue/);
+  const fresh = agy.buildInteractiveCmd('agy', {});
+  assert.doesNotMatch(fresh, /--conversation|--continue/);
+});

--- a/test/util/saved-sessions.test.js
+++ b/test/util/saved-sessions.test.js
@@ -1,0 +1,40 @@
+require('../setup');
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const { mergeSavedSessions } = require('../../main/util/saved-sessions');
+
+const copilot = { worktreePath: '/wt/a', mode: 'copilot', sessionId: 'c1' };
+const claude = { worktreePath: '/wt/b', mode: 'claude', sessionId: 'k1' };
+
+// Regression: closing the Copilot session while another stayed open wiped its
+// entry, so the sidebar rediscovered the worktree from disk as a Claude session.
+test('a session that is no longer open keeps its entry', () => {
+  const merged = mergeSavedSessions([claude], [copilot, claude]);
+  const kept = merged.find((s) => s.worktreePath === '/wt/a');
+  assert.equal(kept.mode, 'copilot');
+  assert.equal(kept.sessionId, 'c1');
+});
+
+test('a worktree that is open is described by the live snapshot, not the old entry', () => {
+  const resumed = { worktreePath: '/wt/a', mode: 'copilot', sessionId: 'c2' };
+  const merged = mergeSavedSessions([resumed], [copilot]);
+  assert.deepEqual(merged, [resumed]);
+});
+
+test('every stored entry for a live worktree is replaced together', () => {
+  const second = { worktreePath: '/wt/a', mode: 'antigravity', sessionId: 'a1' };
+  const merged = mergeSavedSessions([copilot], [copilot, second]);
+  assert.deepEqual(merged, [copilot]);
+});
+
+test('a dismissed session stays gone', () => {
+  assert.deepEqual(mergeSavedSessions([claude], []), [claude]);
+});
+
+test('empty and missing inputs do not throw', () => {
+  assert.deepEqual(mergeSavedSessions([], []), []);
+  assert.deepEqual(mergeSavedSessions(undefined, undefined), []);
+  assert.deepEqual(mergeSavedSessions([claude], [null]), [claude]);
+});


### PR DESCRIPTION
## Summary

Follow-up to #61. Two separate reasons a resumed session came back wrong: a saved session was only as durable as the next save, and a session's second agent came back as a blank agent instead of its conversation.

## Changes

**Saved sessions survive until they are deleted.** `saveSessions()` replaced the whole stored array with the instances open at that moment, so closing one session dropped its entry while any other stayed open. The sidebar then rediscovered the worktree from disk, and `discoverDiskSessions()` has no record of which agent ran there — it labels every row `claude`. That is why a closed Copilot session resumed as Claude. Entries for worktrees that are not currently open are now preserved as-is (`mergeSavedSessions`, extracted so the rule is testable — `app-events.js` does too much at import to load under `node --test`). Dismiss and the sessions modal still remove entries, since both write config directly.

**A reopened agent tab resumes its conversation.** A second agent is saved as a `subAgents` entry, but that entry carried only `mode` and `label`, and `add-sub-terminal` passed no resume argument at all — so reopening a tab always started a fresh conversation. Sub-agents now carry a session id, threaded through save → `reopenSubAgents` → spawn. Deliberately not `resumeLatest`: on a worktree with two agent tabs that adopts the wrong conversation as often as the right one.

**Antigravity can report a conversation id.** It reattaches to whatever conversation a workspace already had rather than writing a file per launch, so the snapshot-and-diff approach the other providers use never sees a new file (this is why a first attempt at `findNewSession` returned `null` every time). Its `conversation_summaries.db` records the workspace each conversation ran in, which names it outright. Read via `node:sqlite` — Electron 41 ships Node 24, so **no new dependency** — opened read-only, with a missing or mid-write store resolving to no id rather than failing the save.

A fresh tab has no conversation until its agent writes one, so the id is resolved on a later save and cached; a `claimed` set stops two tabs on one worktree adopting the same conversation.

## Test Plan

Verified against a real Antigravity install, not just fixtures:

- `conversation_summaries.db` maps `ff345a8d-…` to the exact worktree agy was running in; an unknown path resolves to `null`.
- With the app running, the id is captured into `savedSessions` while the session is live, and survives a quit.
- The conversation count stayed flat at 108 across resumes — agy grows one conversation per workspace rather than forking, so caching the id is safe.

Unit tests: `antigravity-sessions.test.js` (workspace match, newest-wins, multi-root workspaces, unknown worktree, absent store, resume flag shapes) and `saved-sessions.test.js` (the Copilot regression directly, multi-agent worktrees, dismissed entries, empty/missing input).

- [x] Tests pass locally (591/591, `npm test`)
- [x] `npm run lint` clean
- [x] Manually verified in the dev app

## Checklist

- [x] Code follows project conventions (see CLAUDE.md)
- [x] No unrelated changes
- [x] Tests added/updated for new functionality
- [ ] Documentation updated if needed
