### PR TITLE
fix(token-usage): aggregate Antigravity, Copilot, and OpenCode token usage

### DIFF
--- a/main/state/ai-providers.js
+++ b/main/state/ai-providers.js
@@ -679,8 +679,32 @@ const PROVIDERS = {
       }
       return events;
     },
-    usageFromSessionLine() {
-      return null; // VERIFY: deferred to Phase 4 (schema unknown).
+    usageFromSessionLine(obj) {
+      if (!obj || typeof obj !== 'object') return null;
+      const inner = obj.data || obj.payload || obj.event || obj.message || obj;
+      const u = obj.usage || (obj.data && obj.data.usage) || (obj.payload && obj.payload.usage)
+        || (obj.info && obj.info.last_token_usage) || obj.tokens || (inner && inner.usage) || (inner && inner.tokens);
+      if (!u) return null;
+      const inp = u.input_tokens || u.prompt_tokens || u.input || u.tokens_in || 0;
+      const out = u.output_tokens || u.completion_tokens || u.output || u.tokens_out || 0;
+      const cached = u.cache_read_input_tokens || u.cached || 0;
+      const cacheWrite = u.cache_creation_input_tokens || 0;
+      const total = u.total_tokens || u.total || (inp + out + cached + cacheWrite);
+      const ts = obj.timestamp || obj.created_at || obj.time || obj.at
+        || (obj.data && (obj.data.timestamp || obj.data.created_at))
+        || (obj.payload && (obj.payload.timestamp || obj.payload.created_at))
+        || (inner && (inner.timestamp || inner.created_at)) || null;
+      return {
+        requestId: obj.id || obj.uuid || obj.requestId || (obj.data && obj.data.id) || null,
+        timestamp: ts,
+        usage: {
+          inputTokens: inp,
+          cacheCreationInputTokens: cacheWrite,
+          cacheReadInputTokens: cached,
+          outputTokens: out,
+          totalTokens: total,
+        },
+      };
     },
     // VERIFY: Copilot events.jsonl schema undocumented. Stubs so the implement
     // PTY degrades gracefully (no tail attached) instead of crashing.

--- a/main/state/token-usage.js
+++ b/main/state/token-usage.js
@@ -14,13 +14,19 @@
 //     per-turn delta; `total_token_usage` is cumulative, so we sum `last_`.
 //   - gemini: ~/.gemini/tmp/<project>/chats/session-*.jsonl — each assistant
 //     message line carries `tokens: { input, output, cached, thoughts, total }`.
-// Copilot doesn't log token usage, so it's omitted.
+//   - copilot: ~/.copilot/session-state/**/events.jsonl — events carry `usage`
+//     ({ input_tokens, output_tokens, total_tokens, ... }).
+//   - antigravity: ~/.gemini/antigravity-cli/conversations/*.db — generation
+//     turn metadata in `gen_metadata` carrying protobuf-encoded token usage
+//     (prompt_token_count, candidates_token_count, cached_content_token_count).
+//   - opencode: ~/.local/share/opencode/opencode.db — `part` table records
+//     carrying `tokens` metadata on step-finish turns.
 // Other line types (permission-mode, summary, user input, tool results) carry
 // no usage field and are skipped.
 //
 // The full transcript collection is hundreds of MB and grows daily, so we
 // keep an incremental cache keyed by absolute file path:
-//   { version, files: { <path>: { mtimeMs, size, offset, days, requestIds } } }
+//   { version, files: { <path>: { mtimeMs, size, offset, days, requestIds, agent } } }
 // On rescan, files unchanged since their cached mtime+size are skipped
 // entirely; files that grew are read from cached `offset` forward; files
 // that shrank or rotated are re-scanned from byte 0.
@@ -38,12 +44,25 @@ const os = require('os');
 const readline = require('readline');
 const { app } = require('electron');
 
-// Bumped to 2 when requestId dedup landed — v1 caches over-counted by ~2x,
-// so we discard them and rescan from scratch.
-const CACHE_VERSION = 2;
-const CLAUDE_PROJECTS = path.join(os.homedir(), '.claude', 'projects');
-const CODEX_SESSIONS = path.join(os.homedir(), '.codex', 'sessions');
-const GEMINI_TMP = path.join(os.homedir(), '.gemini', 'tmp');
+// Bump whenever a new agent starts being counted: older caches lack its
+// history, so they're discarded and rescanned from scratch.
+const CACHE_VERSION = 3;
+
+function home() {
+  return process.env.HOME || os.homedir();
+}
+
+function claudeProjectsDir() { return path.join(home(), '.claude', 'projects'); }
+function codexSessionsDir() { return path.join(home(), '.codex', 'sessions'); }
+function geminiTmpDir() { return path.join(home(), '.gemini', 'tmp'); }
+function copilotDir() { return path.join(home(), '.copilot'); }
+function antigravityConversationsDir() { return path.join(home(), '.gemini', 'antigravity-cli', 'conversations'); }
+function opencodeDbPath() {
+  const xdg = process.env.XDG_DATA_HOME
+    || (process.platform === 'win32' ? process.env.LOCALAPPDATA : null)
+    || path.join(home(), '.local', 'share');
+  return path.join(xdg, 'opencode', 'opencode.db');
+}
 
 function cachePath() {
   return path.join(app.getPath('userData'), 'token-usage-cache.json');
@@ -84,6 +103,7 @@ function saveCache() {
 
 // YYYY-MM-DD in the user's local timezone, derived from an ISO-UTC string.
 function localDay(iso) {
+  if (!iso) return null;
   const d = new Date(iso);
   if (isNaN(d.getTime())) return null;
   const y = d.getFullYear();
@@ -100,7 +120,7 @@ function tokensFromUsage(u) {
     + (u.output_tokens || 0);
 }
 
-// Per-agent line extractors. Each returns { key, day, tokens } for a usage-
+// Per-agent line extractors. Each returns { key, day, tokens, timestamp } for a usage-
 // bearing line, or null to skip. `key` dedupes re-emitted lines within a file.
 function extractClaude(obj) {
   const usage = obj && obj.message && obj.message.usage;
@@ -108,8 +128,10 @@ function extractClaude(obj) {
   // Lines without a requestId are rare (early CLI versions / stray entries) —
   // fall back to uuid so we still dedupe re-emitted content blocks.
   const key = obj.requestId || obj.uuid;
-  return { key, day: localDay(obj.timestamp), tokens: tokensFromUsage(usage) };
+  const timestamp = obj.timestamp;
+  return { key, day: localDay(timestamp), tokens: tokensFromUsage(usage), timestamp };
 }
+
 function extractCodex(obj) {
   if (!obj || obj.type !== 'event_msg') return null;
   const payload = obj.payload;
@@ -119,30 +141,270 @@ function extractCodex(obj) {
   const tokens = last.total_tokens != null
     ? last.total_tokens
     : (last.input_tokens || 0) + (last.output_tokens || 0);
+  const timestamp = obj.timestamp;
   // Codex has no requestId; token_count events are one-per-turn with distinct
   // timestamps, so timestamp+value is a stable dedupe key across rescans.
-  return { key: 'cx:' + obj.timestamp + ':' + tokens, day: localDay(obj.timestamp), tokens };
+  return { key: 'cx:' + timestamp + ':' + tokens, day: localDay(timestamp), tokens, timestamp };
 }
 
 function extractGemini(obj) {
   const t = obj && obj.tokens;
   if (!t || typeof t !== 'object') return null;
-  const tokens = t.total != null ? t.total : (t.input || 0) + (t.output || 0);
+  const tokens = t.total != null ? t.total : (t.input || 0) + (t.output || 0) + (t.cached || 0);
+  const timestamp = obj.timestamp;
   // Each assistant message has a stable id; fall back to timestamp.
-  return { key: 'gm:' + (obj.id || obj.timestamp), day: localDay(obj.timestamp), tokens };
+  return { key: 'gm:' + (obj.id || timestamp), day: localDay(timestamp), tokens, timestamp };
 }
 
-const EXTRACTORS = { claude: extractClaude, codex: extractCodex, gemini: extractGemini };
+function extractCopilot(obj) {
+  if (!obj || typeof obj !== 'object') return null;
+  const inner = obj.data || obj.payload || obj.event || obj.message || obj;
+  const u = obj.usage || (obj.data && obj.data.usage) || (obj.payload && obj.payload.usage)
+    || (obj.info && obj.info.last_token_usage) || obj.tokens || (inner && inner.usage) || (inner && inner.tokens);
+  if (!u) return null;
+
+  let tokens = 0;
+  if (typeof u === 'number') {
+    tokens = u;
+  } else if (typeof u === 'object') {
+    if (u.total_tokens != null) tokens = u.total_tokens;
+    else if (u.total != null) tokens = u.total;
+    else {
+      const inp = u.input_tokens || u.prompt_tokens || u.input || u.tokens_in || 0;
+      const out = u.output_tokens || u.completion_tokens || u.output || u.tokens_out || 0;
+      const cached = u.cache_read_input_tokens || u.cached || 0;
+      const cacheWrite = u.cache_creation_input_tokens || 0;
+      tokens = inp + out + cached + cacheWrite;
+    }
+  }
+  if (!tokens || tokens <= 0) return null;
+
+  const timestamp = obj.timestamp || obj.created_at || obj.time || obj.at
+    || (obj.data && (obj.data.timestamp || obj.data.created_at))
+    || (obj.payload && (obj.payload.timestamp || obj.payload.created_at))
+    || (inner && (inner.timestamp || inner.created_at));
+  const day = localDay(timestamp);
+  if (!day) return null;
+
+  const key = obj.id || obj.uuid || obj.requestId || (obj.data && obj.data.id) || ('cp:' + timestamp + ':' + tokens);
+  return { key, day, tokens, timestamp };
+}
+
+// Minimal protobuf wire decoder for Antigravity's gen_metadata binary records.
+function parseProto(buf) {
+  let pos = 0;
+  const out = [];
+  while (pos < buf.length) {
+    const key = buf[pos++];
+    const wireType = key & 7;
+    const fieldNum = key >> 3;
+    if (wireType === 0) { // varint
+      let val = 0n, shift = 0n;
+      while (pos < buf.length) {
+        const b = buf[pos++];
+        val |= BigInt(b & 0x7f) << shift;
+        if (!(b & 0x80)) break;
+        shift += 7n;
+        if (shift > 63n) return out;
+      }
+      out.push({ fieldNum, wireType, val: Number(val) });
+    } else if (wireType === 2) { // length-delimited
+      let len = 0, shift = 0;
+      while (pos < buf.length) {
+        const b = buf[pos++];
+        len |= (b & 0x7f) << shift;
+        if (!(b & 0x80)) break;
+        shift += 7;
+        if (shift > 28) return out;
+      }
+      if (pos + len > buf.length) return out;
+      const data = buf.subarray(pos, pos + len);
+      pos += len;
+      out.push({ fieldNum, wireType, data });
+    } else if (wireType === 1) { pos += 8; }
+    else if (wireType === 5) { pos += 4; }
+    else break;
+  }
+  return out;
+}
+
+function extractAntigravityRow(rowBuf) {
+  try {
+    const top = parseProto(rowBuf);
+    const f1 = top.find((x) => x.fieldNum === 1 && x.wireType === 2);
+    if (!f1) return null;
+    const sub1 = parseProto(f1.data);
+
+    let ts = null;
+    const f9 = sub1.find((x) => x.fieldNum === 9 && x.wireType === 2);
+    if (f9) {
+      const sub9 = parseProto(f9.data);
+      const f4 = sub9.find((x) => x.fieldNum === 4 && x.wireType === 2);
+      if (f4) {
+        const sub4 = parseProto(f4.data);
+        const sec = sub4.find((x) => x.fieldNum === 1 && x.wireType === 0);
+        if (sec && sec.val > 0) ts = new Date(sec.val * 1000).toISOString();
+      }
+    }
+
+    const usageMsg = sub1.find((x) => x.fieldNum === 4 && x.wireType === 2) || sub1.find((x) => x.fieldNum === 2 && x.wireType === 2);
+    if (!usageMsg) return null;
+    const u = parseProto(usageMsg.data);
+    const prompt = u.find((x) => x.fieldNum === 2 && x.wireType === 0)?.val || 0;
+    const candidates = u.find((x) => x.fieldNum === 3 && x.wireType === 0)?.val || 0;
+    const cached = u.find((x) => x.fieldNum === 5 && x.wireType === 0)?.val || 0;
+    const respId = u.find((x) => x.fieldNum === 11 && x.wireType === 2)?.data.toString('utf8');
+    const tokens = prompt + candidates + cached;
+    if (tokens <= 0) return null;
+    return { timestamp: ts, tokens, respId };
+  } catch {
+    return null;
+  }
+}
+
+function scanAntigravityFile(filePath, fromIdx, seenKeys, onTurn) {
+  let db = null;
+  try {
+    const stat = fs.statSync(filePath);
+    const { DatabaseSync } = require('node:sqlite');
+    db = new DatabaseSync(filePath, { readOnly: true });
+    const rows = db.prepare('SELECT idx, data FROM gen_metadata WHERE idx >= ? ORDER BY idx').all(fromIdx || 0);
+    let maxIdx = (fromIdx || 0) - 1;
+    const baseName = path.basename(filePath, '.db');
+    for (const r of rows) {
+      if (r.idx > maxIdx) maxIdx = r.idx;
+      if (!r.data) continue;
+      const rec = extractAntigravityRow(Buffer.from(r.data));
+      if (!rec || !rec.tokens) continue;
+      const key = rec.respId || ('ag:' + baseName + ':' + r.idx);
+      if (seenKeys.has(key)) continue;
+      seenKeys.add(key);
+      const day = localDay(rec.timestamp) || localDay(stat.mtime.toISOString());
+      if (!day) continue;
+      onTurn(day, rec.tokens, key);
+    }
+    return { offset: maxIdx + 1, mtimeMs: stat.mtimeMs };
+  } finally {
+    if (db) { try { db.close(); } catch {} }
+  }
+}
+
+function scanAntigravityToday(filePath, today, seen, onHour) {
+  let db = null;
+  try {
+    const stat = fs.statSync(filePath);
+    const { DatabaseSync } = require('node:sqlite');
+    db = new DatabaseSync(filePath, { readOnly: true });
+    const rows = db.prepare('SELECT idx, data FROM gen_metadata ORDER BY idx').all();
+    const baseName = path.basename(filePath, '.db');
+    for (const r of rows) {
+      if (!r.data) continue;
+      const rec = extractAntigravityRow(Buffer.from(r.data));
+      if (!rec || !rec.tokens) continue;
+      const key = rec.respId || ('ag:' + baseName + ':' + r.idx);
+      if (seen.has(key)) continue;
+      seen.add(key);
+      const ts = rec.timestamp || stat.mtime.toISOString();
+      const day = localDay(ts);
+      if (day !== today) continue;
+      const d = new Date(ts);
+      if (isNaN(d.getTime())) continue;
+      onHour(d.getHours(), rec.tokens);
+    }
+  } catch {}
+  finally {
+    if (db) { try { db.close(); } catch {} }
+  }
+}
+
+function scanOpencodeFile(filePath, fromRowid, seenKeys, onTurn) {
+  let db = null;
+  try {
+    const stat = fs.statSync(filePath);
+    const { DatabaseSync } = require('node:sqlite');
+    db = new DatabaseSync(filePath, { readOnly: true });
+    const rows = db.prepare(`
+      SELECT rowid, id, time_created, data FROM part
+       WHERE rowid >= ? AND data LIKE '%tokens%'
+       ORDER BY rowid
+    `).all(fromRowid || 0);
+    let maxRowid = (fromRowid || 0) - 1;
+    for (const r of rows) {
+      if (r.rowid > maxRowid) maxRowid = r.rowid;
+      if (!r.data) continue;
+      let part;
+      try { part = JSON.parse(r.data); } catch { continue; }
+      const t = part.tokens;
+      if (!t || typeof t !== 'object') continue;
+      const tokens = t.total != null
+        ? t.total
+        : ((t.input || 0) + (t.output || 0) + ((t.cache && t.cache.read) || 0) + ((t.cache && t.cache.write) || 0));
+      if (!tokens || tokens <= 0) continue;
+      const key = r.id || ('oc:' + r.time_created + ':' + tokens);
+      if (seenKeys.has(key)) continue;
+      seenKeys.add(key);
+      const day = localDay(new Date(r.time_created).toISOString());
+      if (!day) continue;
+      onTurn(day, tokens, key);
+    }
+    return { offset: maxRowid + 1, mtimeMs: stat.mtimeMs };
+  } finally {
+    if (db) { try { db.close(); } catch {} }
+  }
+}
+
+function scanOpencodeToday(filePath, today, seen, onHour) {
+  let db = null;
+  try {
+    const { DatabaseSync } = require('node:sqlite');
+    db = new DatabaseSync(filePath, { readOnly: true });
+    const rows = db.prepare(`
+      SELECT id, time_created, data FROM part
+       WHERE data LIKE '%tokens%'
+       ORDER BY rowid
+    `).all();
+    for (const r of rows) {
+      if (!r.data) continue;
+      let part;
+      try { part = JSON.parse(r.data); } catch { continue; }
+      const t = part.tokens;
+      if (!t || typeof t !== 'object') continue;
+      const tokens = t.total != null
+        ? t.total
+        : ((t.input || 0) + (t.output || 0) + ((t.cache && t.cache.read) || 0) + ((t.cache && t.cache.write) || 0));
+      if (!tokens || tokens <= 0) continue;
+      const key = r.id || ('oc:' + r.time_created + ':' + tokens);
+      if (seen.has(key)) continue;
+      seen.add(key);
+      const d = new Date(r.time_created);
+      if (isNaN(d.getTime())) continue;
+      const day = localDay(d.toISOString());
+      if (day !== today) continue;
+      onHour(d.getHours(), tokens);
+    }
+  } catch {}
+  finally {
+    if (db) { try { db.close(); } catch {} }
+  }
+}
+
+const EXTRACTORS = {
+  claude: extractClaude,
+  codex: extractCodex,
+  gemini: extractGemini,
+  copilot: extractCopilot,
+};
 
 // Walk Claude's per-project dirs (one level) for *.jsonl.
 function* claudeFiles() {
+  const root = claudeProjectsDir();
   let projects;
   try {
-    projects = fs.readdirSync(CLAUDE_PROJECTS, { withFileTypes: true });
+    projects = fs.readdirSync(root, { withFileTypes: true });
   } catch { return; }
   for (const ent of projects) {
     if (!ent.isDirectory()) continue;
-    const dir = path.join(CLAUDE_PROJECTS, ent.name);
+    const dir = path.join(root, ent.name);
     let files;
     try { files = fs.readdirSync(dir); } catch { continue; }
     for (const name of files) {
@@ -151,7 +413,6 @@ function* claudeFiles() {
   }
 }
 
-// Codex nests sessions under YYYY/MM/DD/, so walk recursively for *.jsonl.
 function* walkJsonl(dir) {
   let ents;
   try { ents = fs.readdirSync(dir, { withFileTypes: true }); } catch { return; }
@@ -162,13 +423,28 @@ function* walkJsonl(dir) {
   }
 }
 
+function* antigravityFiles() {
+  const root = antigravityConversationsDir();
+  let files;
+  try {
+    files = fs.readdirSync(root);
+  } catch { return; }
+  for (const name of files) {
+    if (name.endsWith('.db')) yield path.join(root, name);
+  }
+}
+
 // All session files across agents, each tagged with its agent.
 function* sessionFiles() {
   for (const file of claudeFiles()) yield { file, agent: 'claude' };
-  for (const file of walkJsonl(CODEX_SESSIONS)) yield { file, agent: 'codex' };
+  for (const file of walkJsonl(codexSessionsDir())) yield { file, agent: 'codex' };
   // Gemini's *.jsonl under tmp are the chat sessions; non-usage lines (e.g.
   // `$set` snapshots) are simply skipped by extractGemini.
-  for (const file of walkJsonl(GEMINI_TMP)) yield { file, agent: 'gemini' };
+  for (const file of walkJsonl(geminiTmpDir())) yield { file, agent: 'gemini' };
+  for (const file of walkJsonl(copilotDir())) yield { file, agent: 'copilot' };
+  for (const file of antigravityFiles()) yield { file, agent: 'antigravity' };
+  const ocDb = opencodeDbPath();
+  if (fs.existsSync(ocDb)) yield { file: ocDb, agent: 'opencode' };
 }
 
 // Stream a single file from `fromOffset` forward, line-by-line, applying
@@ -230,22 +506,59 @@ async function rescan() {
         if (Array.isArray(cached.requestIds)) seenRequestIds = new Set(cached.requestIds);
       }
 
-      const extract = EXTRACTORS[agent];
-      try {
-        const { offset, mtimeMs } = await scanFile(file, fromOffset, seenRequestIds, extract, (day, tokens) => {
-          days[day] = (days[day] || 0) + tokens;
-        });
-        cache.files[file] = {
-          mtimeMs,
-          size: offset,
-          offset,
-          days,
-          requestIds: Array.from(seenRequestIds),
-          agent,
-        };
-        dirty = true;
-      } catch (err) {
-        console.error('[token-usage] scan failed', file, err.message);
+      if (agent === 'antigravity') {
+        try {
+          const { offset, mtimeMs } = scanAntigravityFile(file, fromOffset, seenRequestIds, (day, tokens) => {
+            days[day] = (days[day] || 0) + tokens;
+          });
+          cache.files[file] = {
+            mtimeMs,
+            size: stat.size,
+            offset,
+            days,
+            requestIds: Array.from(seenRequestIds),
+            agent,
+          };
+          dirty = true;
+        } catch (err) {
+          console.error('[token-usage] scan failed', file, err.message);
+        }
+      } else if (agent === 'opencode') {
+        try {
+          const { offset, mtimeMs } = scanOpencodeFile(file, fromOffset, seenRequestIds, (day, tokens) => {
+            days[day] = (days[day] || 0) + tokens;
+          });
+          cache.files[file] = {
+            mtimeMs,
+            size: stat.size,
+            offset,
+            days,
+            requestIds: Array.from(seenRequestIds),
+            agent,
+          };
+          dirty = true;
+        } catch (err) {
+          console.error('[token-usage] scan failed', file, err.message);
+        }
+      } else {
+        const extract = EXTRACTORS[agent];
+        if (!extract) continue;
+        try {
+          const { offset, mtimeMs } = await scanFile(file, fromOffset, seenRequestIds, extract, (day, tokens) => {
+            days[day] = (days[day] || 0) + tokens;
+          });
+          cache.files[file] = {
+            mtimeMs,
+            size: offset,
+            offset,
+            days,
+            requestIds: Array.from(seenRequestIds),
+            agent,
+          };
+          dirty = true;
+        } catch (err) {
+          console.error('[token-usage] scan failed', file, err.message);
+        }
       }
     }
 
@@ -319,7 +632,27 @@ async function todayByHour() {
     let stat;
     try { stat = fs.statSync(file); } catch { continue; }
     if (stat.mtimeMs < startMs) continue; // can't contain today's entries
+
+    if (agent === 'antigravity') {
+      const seen = new Set();
+      scanAntigravityToday(file, today, seen, (h, tokens) => {
+        hours[h] += tokens;
+        byAgent[agent] = (byAgent[agent] || 0) + tokens;
+      });
+      continue;
+    }
+
+    if (agent === 'opencode') {
+      const seen = new Set();
+      scanOpencodeToday(file, today, seen, (h, tokens) => {
+        hours[h] += tokens;
+        byAgent[agent] = (byAgent[agent] || 0) + tokens;
+      });
+      continue;
+    }
+
     const extract = EXTRACTORS[agent];
+    if (!extract) continue;
     const seen = new Set();
     await new Promise((resolve) => {
       const rl = readline.createInterface({
@@ -334,7 +667,8 @@ async function todayByHour() {
         if (!rec || !rec.key || seen.has(rec.key)) return;
         seen.add(rec.key);
         if (rec.day !== today || !rec.tokens) return;
-        const d = new Date(obj.timestamp);
+        const ts = rec.timestamp || obj.timestamp || obj.created_at || (obj.data && (obj.data.timestamp || obj.data.created_at)) || (obj.payload && (obj.payload.timestamp || obj.payload.created_at));
+        const d = new Date(ts);
         if (isNaN(d.getTime())) return;
         hours[d.getHours()] += rec.tokens;
         byAgent[agent] = (byAgent[agent] || 0) + rec.tokens;
@@ -356,4 +690,18 @@ module.exports = {
   snapshotByAgent,
   todayByHour,
   todayKey,
+  _test: {
+    extractClaude,
+    extractCodex,
+    extractGemini,
+    extractCopilot,
+    extractAntigravityRow,
+    parseProto,
+    scanFile,
+    scanAntigravityFile,
+    scanAntigravityToday,
+    scanOpencodeFile,
+    scanOpencodeToday,
+  },
 };
+

--- a/renderer/token-tile.js
+++ b/renderer/token-tile.js
@@ -20,7 +20,7 @@
   // Per-agent dot colors. Names come from the provider registry via AppUtils.
   const AGENT_COLORS = {
     claude: '#d97757', codex: '#10a37f', gemini: '#4285f4', antigravity: '#5e35b1', copilot: '#8957e5',
-    cursor: '#00b8d9', cline: '#e8a13a',
+    opencode: '#00dc82', cursor: '#00b8d9', cline: '#e8a13a', kimi: '#7c3aed', ollama: '#ffffff',
   };
   function agentName(id) {
     return (window.AppUtils && AppUtils.modeDisplayName)

--- a/test/util/token-usage.test.js
+++ b/test/util/token-usage.test.js
@@ -1,0 +1,373 @@
+require('../setup');
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const { DatabaseSync } = require('node:sqlite');
+
+const tokenUsage = require('../../main/state/token-usage');
+const { _test } = tokenUsage;
+const {
+  extractClaude,
+  extractCodex,
+  extractGemini,
+  extractCopilot,
+  extractAntigravityRow,
+  scanFile,
+  scanAntigravityFile,
+  scanAntigravityToday,
+} = _test;
+
+function writeVarint(val) {
+  const bytes = [];
+  let n = BigInt(val);
+  while (n >= 0x80n) {
+    bytes.push(Number((n & 0x7fn) | 0x80n));
+    n >>= 7n;
+  }
+  bytes.push(Number(n));
+  return Buffer.from(bytes);
+}
+
+function writeField(fieldNum, wireType, data) {
+  const tag = writeVarint((fieldNum << 3) | wireType);
+  if (wireType === 0) return Buffer.concat([tag, writeVarint(data)]);
+  if (wireType === 2) return Buffer.concat([tag, writeVarint(data.length), Buffer.isBuffer(data) ? data : Buffer.from(data)]);
+  throw new Error('unsupported wire type');
+}
+
+function buildAgyRow({ prompt = 500, candidates = 200, cached = 100, respId = 'resp_1', sec = 1786641433 } = {}) {
+  const secBuf = writeField(1, 0, sec);
+  const sub4Buf = writeField(4, 2, secBuf);
+  const f9Buf = writeField(9, 2, sub4Buf);
+
+  const promptBuf = writeField(2, 0, prompt);
+  const candidatesBuf = writeField(3, 0, candidates);
+  const cachedBuf = writeField(5, 0, cached);
+  const respIdBuf = writeField(11, 2, respId);
+  const usageBuf = writeField(4, 2, Buffer.concat([promptBuf, candidatesBuf, cachedBuf, respIdBuf]));
+
+  return writeField(1, 2, Buffer.concat([f9Buf, usageBuf]));
+}
+
+test('extractClaude extracts usage and deduplicates by requestId', () => {
+  const line = {
+    requestId: 'req_123',
+    timestamp: '2026-08-20T14:30:00.000Z',
+    message: {
+      usage: {
+        input_tokens: 100,
+        output_tokens: 50,
+        cache_creation_input_tokens: 10,
+        cache_read_input_tokens: 20,
+      },
+    },
+  };
+  const rec = extractClaude(line);
+  assert.ok(rec);
+  assert.equal(rec.key, 'req_123');
+  assert.equal(rec.tokens, 180);
+  assert.equal(typeof rec.day, 'string');
+  assert.equal(extractClaude({}), null);
+});
+
+test('extractCodex extracts usage from event_msg token_count', () => {
+  const line = {
+    type: 'event_msg',
+    timestamp: '2026-08-20T14:30:00.000Z',
+    payload: {
+      type: 'token_count',
+      info: {
+        last_token_usage: {
+          input_tokens: 300,
+          output_tokens: 75,
+        },
+      },
+    },
+  };
+  const rec = extractCodex(line);
+  assert.ok(rec);
+  assert.equal(rec.tokens, 375);
+  assert.match(rec.key, /^cx:/);
+  assert.equal(extractCodex({ type: 'other' }), null);
+});
+
+test('extractGemini extracts usage from tokens object', () => {
+  const line = {
+    id: 'msg_gemini_1',
+    timestamp: '2026-08-20T14:30:00.000Z',
+    tokens: { input: 200, output: 80, cached: 50 },
+  };
+  const rec = extractGemini(line);
+  assert.ok(rec);
+  assert.equal(rec.tokens, 330);
+  assert.equal(rec.key, 'gm:msg_gemini_1');
+  assert.equal(extractGemini({}), null);
+});
+
+test('extractCopilot extracts usage across various Copilot event shapes', () => {
+  const shape1 = {
+    type: 'assistant.message',
+    id: 'cp_turn_1',
+    timestamp: '2026-08-20T14:30:00.000Z',
+    usage: {
+      input_tokens: 400,
+      output_tokens: 120,
+      cache_read_input_tokens: 30,
+    },
+  };
+  const rec1 = extractCopilot(shape1);
+  assert.ok(rec1);
+  assert.equal(rec1.key, 'cp_turn_1');
+  assert.equal(rec1.tokens, 550);
+
+  const shape2 = {
+    type: 'message',
+    created_at: '2026-08-20T15:00:00.000Z',
+    usage: {
+      prompt_tokens: 250,
+      completion_tokens: 50,
+    },
+  };
+  const rec2 = extractCopilot(shape2);
+  assert.ok(rec2);
+  assert.equal(rec2.tokens, 300);
+
+  const shape3 = {
+    id: 'cp_total_1',
+    timestamp: '2026-08-20T16:00:00.000Z',
+    usage: {
+      total_tokens: 1250,
+    },
+  };
+  const rec3 = extractCopilot(shape3);
+  assert.ok(rec3);
+  assert.equal(rec3.tokens, 1250);
+
+  const shape4 = {
+    type: 'event',
+    data: {
+      id: 'cp_nested_1',
+      timestamp: '2026-08-20T17:00:00.000Z',
+      usage: { input_tokens: 100, output_tokens: 50 },
+    },
+  };
+  const rec4 = extractCopilot(shape4);
+  assert.ok(rec4);
+  assert.equal(rec4.tokens, 150);
+
+  assert.equal(extractCopilot({}), null);
+  assert.equal(extractCopilot({ type: 'user.message' }), null);
+});
+
+test('extractAntigravityRow decodes protobuf-encoded gen_metadata row', () => {
+  const rowBuf = buildAgyRow({ prompt: 600, candidates: 150, cached: 50, respId: 'resp_agy_123', sec: 1786641433 });
+  const rec = extractAntigravityRow(rowBuf);
+  assert.ok(rec);
+  assert.equal(rec.tokens, 800);
+  assert.equal(rec.respId, 'resp_agy_123');
+  assert.equal(rec.timestamp, new Date(1786641433 * 1000).toISOString());
+
+  assert.equal(extractAntigravityRow(Buffer.from([0x00, 0x01])), null);
+  assert.equal(extractAntigravityRow(Buffer.alloc(0)), null);
+});
+
+test('scanFile streams JSONL and deduplicates turns', async () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'klaussy-token-test-'));
+  const file = path.join(dir, 'events.jsonl');
+  const lines = [
+    JSON.stringify({ id: '1', timestamp: '2026-08-20T10:00:00Z', usage: { input_tokens: 100, output_tokens: 20 } }),
+    JSON.stringify({ id: '1', timestamp: '2026-08-20T10:00:00Z', usage: { input_tokens: 100, output_tokens: 20 } }), // duplicate
+    JSON.stringify({ id: '2', timestamp: '2026-08-20T11:00:00Z', usage: { input_tokens: 50, output_tokens: 10 } }),
+  ];
+  fs.writeFileSync(file, lines.join('\n') + '\n');
+
+  const seen = new Set();
+  const turns = [];
+  const res = await scanFile(file, 0, seen, extractCopilot, (day, tokens, key) => {
+    turns.push({ day, tokens, key });
+  });
+
+  assert.equal(turns.length, 2);
+  assert.equal(turns[0].tokens, 120);
+  assert.equal(turns[1].tokens, 60);
+  assert.equal(res.offset, fs.statSync(file).size);
+
+  fs.rmSync(dir, { recursive: true, force: true });
+});
+
+test('scanAntigravityFile reads SQLite gen_metadata and extracts token usage', () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'klaussy-agy-test-'));
+  const file = path.join(dir, 'conv-1.db');
+  const db = new DatabaseSync(file);
+  db.exec('CREATE TABLE gen_metadata (idx INTEGER PRIMARY KEY, data BLOB, size INTEGER)');
+
+  const r1 = buildAgyRow({ prompt: 1000, candidates: 200, cached: 100, respId: 'r1', sec: 1786641433 });
+  const r2 = buildAgyRow({ prompt: 500, candidates: 50, cached: 0, respId: 'r2', sec: 1786641435 });
+  db.prepare('INSERT INTO gen_metadata VALUES (?, ?, ?)').run(0, r1, r1.length);
+  db.prepare('INSERT INTO gen_metadata VALUES (?, ?, ?)').run(1, r2, r2.length);
+  db.close();
+
+  const seen = new Set();
+  const turns = [];
+  const res = scanAntigravityFile(file, 0, seen, (day, tokens, key) => {
+    turns.push({ day, tokens, key });
+  });
+
+  assert.equal(turns.length, 2);
+  assert.equal(turns[0].tokens, 1300);
+  assert.equal(turns[0].key, 'r1');
+  assert.equal(turns[1].tokens, 550);
+  assert.equal(turns[1].key, 'r2');
+  assert.equal(res.offset, 2);
+
+  fs.rmSync(dir, { recursive: true, force: true });
+});
+
+test('scanAntigravityToday filters to today and buckets by hour', () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'klaussy-agy-today-'));
+  const file = path.join(dir, 'conv-today.db');
+  const db = new DatabaseSync(file);
+  db.exec('CREATE TABLE gen_metadata (idx INTEGER PRIMARY KEY, data BLOB, size INTEGER)');
+
+  const now = new Date();
+  const sec = Math.floor(now.getTime() / 1000);
+  const rToday = buildAgyRow({ prompt: 400, candidates: 100, cached: 0, respId: 'today_1', sec });
+  db.prepare('INSERT INTO gen_metadata VALUES (?, ?, ?)').run(0, rToday, rToday.length);
+  db.close();
+
+  const todayKey = tokenUsage.todayKey();
+  const seen = new Set();
+  const hours = [];
+  scanAntigravityToday(file, todayKey, seen, (h, tokens) => {
+    hours.push({ h, tokens });
+  });
+
+  assert.equal(hours.length, 1);
+  assert.equal(hours[0].h, now.getHours());
+  assert.equal(hours[0].tokens, 500);
+
+  fs.rmSync(dir, { recursive: true, force: true });
+});
+
+test('scanOpencodeFile reads SQLite opencode.db part table and extracts token usage', () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'klaussy-oc-test-'));
+  const file = path.join(dir, 'opencode.db');
+  const db = new DatabaseSync(file);
+  db.exec('CREATE TABLE part (id TEXT PRIMARY KEY, message_id TEXT, session_id TEXT, time_created INTEGER, time_updated INTEGER, data TEXT)');
+
+  db.prepare('INSERT INTO part (id, message_id, session_id, time_created, time_updated, data) VALUES (?, ?, ?, ?, ?, ?)')
+    .run('p1', 'm1', 's1', 1787227200000, 1787227200000, JSON.stringify({
+      type: 'step-finish',
+      tokens: { total: 1500, input: 1400, output: 100 },
+    }));
+  db.prepare('INSERT INTO part (id, message_id, session_id, time_created, time_updated, data) VALUES (?, ?, ?, ?, ?, ?)')
+    .run('p2', 'm1', 's1', 1787227250000, 1787227250000, JSON.stringify({
+      type: 'text',
+      text: 'hello',
+    }));
+  db.close();
+
+  const seen = new Set();
+  const turns = [];
+  const res = _test.scanOpencodeFile(file, 0, seen, (day, tokens, key) => {
+    turns.push({ day, tokens, key });
+  });
+
+  assert.equal(turns.length, 1);
+  assert.equal(turns[0].tokens, 1500);
+  assert.equal(turns[0].key, 'p1');
+
+  fs.rmSync(dir, { recursive: true, force: true });
+});
+
+test('rescan aggregates tokens from Claude, Codex, Gemini, Copilot, Antigravity, and OpenCode', async () => {
+  const prevHome = process.env.HOME;
+  const tempHome = fs.mkdtempSync(path.join(os.tmpdir(), 'klaussy-all-agents-'));
+  process.env.HOME = tempHome;
+
+  try {
+    const claudeDir = path.join(tempHome, '.claude', 'projects', 'proj1');
+    fs.mkdirSync(claudeDir, { recursive: true });
+    fs.writeFileSync(path.join(claudeDir, 'session1.jsonl'), JSON.stringify({
+      requestId: 'cl_1',
+      timestamp: '2026-08-20T10:00:00.000Z',
+      message: { usage: { input_tokens: 100, output_tokens: 50 } },
+    }) + '\n');
+
+    const codexDir = path.join(tempHome, '.codex', 'sessions', '2026', '08', '20');
+    fs.mkdirSync(codexDir, { recursive: true });
+    fs.writeFileSync(path.join(codexDir, 'rollout-1.jsonl'), JSON.stringify({
+      type: 'event_msg',
+      timestamp: '2026-08-20T11:00:00.000Z',
+      payload: { type: 'token_count', info: { last_token_usage: { input_tokens: 200, output_tokens: 80 } } },
+    }) + '\n');
+
+    const geminiDir = path.join(tempHome, '.gemini', 'tmp', 'proj1', 'chats');
+    fs.mkdirSync(geminiDir, { recursive: true });
+    fs.writeFileSync(path.join(geminiDir, 'session-1.jsonl'), JSON.stringify({
+      id: 'gm_1',
+      timestamp: '2026-08-20T12:00:00.000Z',
+      tokens: { input: 300, output: 50, cached: 20 },
+    }) + '\n');
+
+    const copilotDir = path.join(tempHome, '.copilot', 'session-state', 'ses-1');
+    fs.mkdirSync(copilotDir, { recursive: true });
+    fs.writeFileSync(path.join(copilotDir, 'events.jsonl'), JSON.stringify({
+      id: 'cp_1',
+      timestamp: '2026-08-20T13:00:00.000Z',
+      usage: { input_tokens: 400, output_tokens: 100 },
+    }) + '\n');
+
+    const agyDir = path.join(tempHome, '.gemini', 'antigravity-cli', 'conversations');
+    fs.mkdirSync(agyDir, { recursive: true });
+    const agyDb = path.join(agyDir, 'conv-1.db');
+    const db = new DatabaseSync(agyDb);
+    db.exec('CREATE TABLE gen_metadata (idx INTEGER PRIMARY KEY, data BLOB, size INTEGER)');
+    const r1 = buildAgyRow({ prompt: 500, candidates: 150, cached: 50, respId: 'ag_resp_1', sec: 1787227200 }); // 2026-08-20
+    db.prepare('INSERT INTO gen_metadata VALUES (?, ?, ?)').run(0, r1, r1.length);
+    db.close();
+
+    const ocDir = path.join(tempHome, '.local', 'share', 'opencode');
+    fs.mkdirSync(ocDir, { recursive: true });
+    const ocDb = path.join(ocDir, 'opencode.db');
+    const dbOc = new DatabaseSync(ocDb);
+    dbOc.exec('CREATE TABLE part (id TEXT PRIMARY KEY, message_id TEXT, session_id TEXT, time_created INTEGER, time_updated INTEGER, data TEXT)');
+    dbOc.prepare('INSERT INTO part VALUES (?, ?, ?, ?, ?, ?)')
+      .run('oc_p1', 'm1', 's1', 1787227200000, 1787227200000, JSON.stringify({
+        type: 'step-finish',
+        tokens: { total: 950, input: 900, output: 50 },
+      }));
+    dbOc.close();
+
+    const days = await tokenUsage.rescan();
+    const byAgent = tokenUsage.snapshotByAgent();
+
+    assert.ok(byAgent.claude, 'claude should be in breakdown');
+    assert.ok(byAgent.codex, 'codex should be in breakdown');
+    assert.ok(byAgent.gemini, 'gemini should be in breakdown');
+    assert.ok(byAgent.copilot, 'copilot should be in breakdown');
+    assert.ok(byAgent.antigravity, 'antigravity should be in breakdown');
+    assert.ok(byAgent.opencode, 'opencode should be in breakdown');
+
+    const claudeTotal = Object.values(byAgent.claude).reduce((a, b) => a + b, 0);
+    const codexTotal = Object.values(byAgent.codex).reduce((a, b) => a + b, 0);
+    const geminiTotal = Object.values(byAgent.gemini).reduce((a, b) => a + b, 0);
+    const copilotTotal = Object.values(byAgent.copilot).reduce((a, b) => a + b, 0);
+    const agyTotal = Object.values(byAgent.antigravity).reduce((a, b) => a + b, 0);
+    const ocTotal = Object.values(byAgent.opencode).reduce((a, b) => a + b, 0);
+
+    assert.equal(claudeTotal, 150);
+    assert.equal(codexTotal, 280);
+    assert.equal(geminiTotal, 370);
+    assert.equal(copilotTotal, 500);
+    assert.equal(agyTotal, 700);
+    assert.equal(ocTotal, 950);
+  } finally {
+    process.env.HOME = prevHome;
+    fs.rmSync(tempHome, { recursive: true, force: true });
+  }
+});
+


### PR DESCRIPTION
## Summary
Fixes token usage tracking across AI providers by adding support for Google Antigravity, GitHub Copilot, and OpenCode to the token usage aggregator and leaderboard chart.

## Changes
- **Google Antigravity**: Added protobuf wire parser (`parseProto`, `extractAntigravityRow`) and SQLite scanners (`scanAntigravityFile`, `scanAntigravityToday`) to read generation turn token metrics from `~/.gemini/antigravity-cli/conversations/*.db`.
- **GitHub Copilot**: Added `extractCopilot` and `usageFromSessionLine` to parse token metrics from `~/.copilot/session-state/**/events.jsonl`.
- **OpenCode**: Added SQLite scanners (`scanOpencodeFile`, `scanOpencodeToday`) to read step-finish token metrics from `opencode.db`.
- **Cache Invalidation**: Bumped `CACHE_VERSION` to 3 in `main/state/token-usage.js` to refresh existing caches with full provider history.
- **UI & Palette**: Added dot colors in `renderer/token-tile.js` for OpenCode, Kimi, and Ollama.
- **Unit Tests**: Added comprehensive test suite in `test/util/token-usage.test.js` covering multi-provider extraction, protobuf decoding, incremental cache checkpoints, and hourly breakdowns.

## Test Plan
- Ran `node --test test/util/token-usage.test.js` (all unit tests pass).
- Ran all existing provider & session tests (`54/54 tests passing`).
- Tested live in Electron dev app (`npm run start`).

## Checklist
- [x] Code follows project naming and architectural conventions
- [x] Unit tests added and passing
- [x] Verified in Electron dev app