### PR TITLE
fix(session-notes): capture every agent in the session, not just the first

### DIFF
--- a/main.js
+++ b/main.js
@@ -59,7 +59,7 @@ require('./main/ipc/session-context');
 
 // Wired here so session-activity never imports the instances map back and closes a cycle.
 require('./main/state/session-activity').start(
-  () => [...require('./main/state/instances').instances.values()],
+  () => require('./main/state/instances').liveAgentInstances(),
 );
 
 require('./main/bootstrap/error-reporter').install();

--- a/main/ipc/session-context.js
+++ b/main/ipc/session-context.js
@@ -40,9 +40,9 @@ ipcMain.handle('session-context:get-summary', async (_event, { worktreePath } = 
 // another channel, so their notes would never show up here.
 ipcMain.handle('session-context:capture-now', async (_event, { worktreePath } = {}) => {
   try {
-    const { instances } = require('../state/instances');
+    const { liveAgentInstances } = require('../state/instances');
     const activity = require('../state/session-activity');
-    const agents = [...instances.values()];
+    const agents = liveAgentInstances();
     const byChannel = activity.liveAgentsByChannel(agents);
     const here = worktreePath ? activity.channelFor(worktreePath) : null;
     const inSession = (here && byChannel.get(here)) ? byChannel.get(here).length : 0;

--- a/main/ipc/tasks.js
+++ b/main/ipc/tasks.js
@@ -1233,6 +1233,7 @@ ipcMain.handle('add-sub-terminal', (_event, { taskId, label, mode, initialPrompt
     // This tab had its own thread in chat; nothing typed there reaches it now.
     if (sub.mirror) {
       try { require('../util/notification-gateway').forgetTask(sub.mirror.id); } catch { /* non-fatal */ }
+      try { require('../state/session-activity').forgetInstance(sub.mirror.id); } catch { /* non-fatal */ }
     }
     session.release(); // free the concurrency slot (Codex token-rotation guard)
     if (promptFile) { try { fs.unlinkSync(promptFile); } catch {} }
@@ -1325,6 +1326,7 @@ ipcMain.handle('kill-task', (_event, { id }) => {
     if (!sub.mirror) continue;
     try { require('../util/notification-gateway').forgetTask(sub.mirror.id); } catch { /* non-fatal */ }
     try { require('../util/session-transcript').forgetTask(sub.mirror.id); } catch { /* non-fatal */ }
+    try { require('../state/session-activity').forgetInstance(sub.mirror.id); } catch { /* non-fatal */ }
   }
 
   // Never delete worktrees or branches — only kill the process

--- a/main/state/instances.js
+++ b/main/state/instances.js
@@ -1044,6 +1044,19 @@ function isAgentInstance(inst) {
   return Boolean(inst && inst.alive && isAgentMode(inst.mode));
 }
 
+// A task's extra agent tabs are sub-terminals, so they have no `instances` entry
+// of their own and the map alone is never the whole session.
+function liveAgentInstances() {
+  const out = [];
+  for (const [, inst] of instances) {
+    out.push(inst);
+    for (const sub of (inst.subTerminals || [])) {
+      if (sub.alive && isAgentMode(sub.mode) && sub.mirror) out.push(sub.mirror);
+    }
+  }
+  return out;
+}
+
 function notifyingAgentInstances() {
   const out = [];
   for (const [, inst] of instances) {
@@ -1063,6 +1076,7 @@ module.exports = {
   instances,
   isAgentInstance,
   notifyingAgentInstances,
+  liveAgentInstances,
   stripAnsi,
   APPROVAL_PROMPT_PATTERNS,
   ROLLING_BUFFER_SIZE,

--- a/test/util/session-activity.test.js
+++ b/test/util/session-activity.test.js
@@ -296,3 +296,36 @@ test('a handoff with no brief writes nothing', async () => {
     fs.rmSync(path.dirname(dir), { recursive: true, force: true });
   }
 });
+
+test('the extra agent tabs in a task are captured too, not just the first agent', async () => {
+  const { instances, liveAgentInstances } = require('../../main/state/instances');
+  const wt = workspace('subs');
+  const dir = ensureSessionNotesDir(wt);
+  instances.set(4201, {
+    id: 4201, name: 'auth', worktreePath: wt, mode: 'agy', alive: true, recentOutput: LOTS,
+    subTerminals: [
+      {
+        subId: 1, mode: 'claude', alive: true,
+        mirror: {
+          id: '4201:1', name: 'auth · Claude Code', mode: 'claude',
+          worktreePath: wt, alive: true, recentOutput: LOTS,
+        },
+      },
+      { subId: 2, mode: 'codex', alive: false, mirror: { id: '4201:2', name: 'gone', mode: 'codex', worktreePath: wt, alive: true, recentOutput: LOTS } },
+    ],
+  });
+  try {
+    const agents = liveAgentInstances();
+    assert.deepEqual(agents.map((a) => a.id), [4201, '4201:1']);
+
+    const written = await activity.captureActivity(agents);
+    assert.equal(written.length, 2, 'both live agents in the task should get a note');
+    const notes = listSessionNotes(wt);
+    assert.deepEqual(notes.map((n) => n.metadata.agent).sort(), ['agy', 'claude']);
+  } finally {
+    instances.delete(4201);
+    activity.forgetInstance(4201);
+    activity.forgetInstance('4201:1');
+    fs.rmSync(path.dirname(dir), { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
## Summary

Session notes only ever captured the first agent in a session. A task's second (and third) agent is a sub-terminal, not an entry in the `instances` map, and both capture paths built their agent list from `instances.values()` alone, so an extra agent tab could do a session's worth of work and the channel would never hear about it.

## Changes

- `main/state/instances.js`, add `liveAgentInstances()`, which walks the map and its live sub-terminal mirrors. It follows `notifyingAgentInstances()`, which already does this expansion for the notification path.
- `main.js` and `main/ipc/session-context.js`, the activity timer and the "Capture now" button both use it instead of `instances.values()`.
- `main/ipc/tasks.js`, the sub-terminal exit and kill-task paths now forget the mirror's `lastSeen` cursor, alongside the notification and transcript entries they already forget.
- Regression test in `test/util/session-activity.test.js`.

Two symptoms came from the one cause. "Capture now" saw no output for the second tab and reported "nothing new to capture". The background timer needs two live agents on a channel before it writes anything at all, so counting one where there were two meant it never ran for that channel either.

## Test Plan

- [x] Tests pass locally, `npm test`, 669 passing
- [x] Manually verified

New test builds a task with its own agent plus one live and one exited agent tab, and asserts both live agents get a note. It fails against the old code: a lone parent agent is filtered out by the two-agent rule, so zero notes are written.

## Checklist

- [x] Code follows project conventions (see CLAUDE.md)
- [x] No unrelated changes
- [x] Tests added/updated for new functionality
- [ ] Documentation updated if needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V56b7phEAsXXrDDF3xZ3sM